### PR TITLE
feat: show logto api response error

### DIFF
--- a/packages/client/src/op-request.ts
+++ b/packages/client/src/op-request.ts
@@ -16,11 +16,17 @@ axiosInstance.interceptors.request.use(
   }
 );
 
+declare interface LogtoErrorResponse {
+  error_description?: string;
+}
+
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
     const opError = new OPError({
-      message: `request error with OP (${error.message})`,
+      message: `request error with OP (${
+        (error.response?.data as LogtoErrorResponse)?.error_description ?? error.message
+      })`,
       originalError: error,
     });
     return Promise.reject(opError);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

When API request failed with non-2xx status code, attach response `error_description` to the Error instance if possible.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

send request to grantToken endpoint with fake refresh_token and get error description. (`opps! some...`)

![image](https://user-images.githubusercontent.com/5717882/137659915-e7035e2b-498a-432f-aa09-54e0d6f69710.png)
