### PR TITLE
chore: upgrade jose to 4.x

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -6,8 +6,5 @@ module.exports = {
   testPathIgnorePatterns: ['lib'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
-  moduleNameMapper: {
-    '^jose/(.*)$': '<rootDir>/node_modules/jose/dist/node/cjs/$1',
-  },
   setupFilesAfterEnv: ['./jest.setup.js'],
 };

--- a/packages/client/jest.setup.js
+++ b/packages/client/jest.setup.js
@@ -1,13 +1,10 @@
 // Need to disable following rulus to mock text-decode/text-encoder and crypto for jsdom
 // https://github.com/jsdom/jsdom/issues/1612
-/* eslint-disable node/prefer-global/text-decoder */
-/* eslint-disable node/prefer-global/text-encoder */
 /* eslint-disable @silverhand/fp/no-mutation */
 /* eslint-disable unicorn/prefer-module */
-const { TextEncoder, TextDecoder } = require('util');
-
 const { Crypto } = require('@peculiar/webcrypto');
 const fetch = require('node-fetch');
+const { TextDecoder, TextEncoder } = require('text-encoder');
 
 global.crypto = new Crypto();
 global.TextEncoder = TextEncoder;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
     "prepublish": "npm run build && npm run package"
   },
   "dependencies": {
-    "jose": "^3.14.3",
+    "jose": "^4.1.4",
     "js-base64": "^3.7.2",
     "nanoid": "^3.1.30",
     "query-string": "^7.0.1",
@@ -32,8 +32,9 @@
     "nock": "^13.1.3",
     "node-fetch": "2",
     "prettier": "^2.3.2",
-    "ts-loader": "^9.2.6",
+    "text-encoder": "^0.0.4",
     "ts-jest": "^27.0.4",
+    "ts-loader": "^9.2.6",
     "typescript": "^4.3.5",
     "webpack": "^5.58.2",
     "webpack-cli": "^4.9.1"

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3,8 +3,7 @@
 /* eslint-disable @silverhand/fp/no-mutation */
 import { KeyObject } from 'crypto';
 
-import { SignJWT } from 'jose/jwt/sign';
-import { generateKeyPair } from 'jose/util/generate_key_pair';
+import { SignJWT, generateKeyPair } from 'jose';
 import nock from 'nock';
 
 import LogtoClient from '.';

--- a/packages/client/src/token-set.test.ts
+++ b/packages/client/src/token-set.test.ts
@@ -1,5 +1,4 @@
-import { SignJWT } from 'jose/jwt/sign';
-import { generateKeyPair } from 'jose/util/generate_key_pair';
+import { SignJWT, generateKeyPair } from 'jose';
 
 import TokenSet from './token-set';
 import { nowRoundToSec } from './utils';

--- a/packages/client/src/utils.test.ts
+++ b/packages/client/src/utils.test.ts
@@ -1,5 +1,4 @@
-import { SignJWT } from 'jose/jwt/sign';
-import { generateKeyPair } from 'jose/util/generate_key_pair';
+import { SignJWT, generateKeyPair } from 'jose';
 import { ZodError } from 'zod';
 
 import { decodeToken } from './utils';

--- a/packages/client/src/verify-id-token.test.ts
+++ b/packages/client/src/verify-id-token.test.ts
@@ -1,7 +1,6 @@
 import { KeyObject } from 'crypto';
 
-import { SignJWT } from 'jose/jwt/sign';
-import { generateKeyPair } from 'jose/util/generate_key_pair';
+import { SignJWT, generateKeyPair } from 'jose';
 import nock from 'nock';
 
 import { createJWKS, verifyIdToken } from './verify-id-token';

--- a/packages/client/src/verify-id-token.ts
+++ b/packages/client/src/verify-id-token.ts
@@ -1,21 +1,14 @@
-import { createRemoteJWKSet } from 'jose/jwks/remote';
-import { jwtVerify } from 'jose/jwt/verify';
-import {
-  FlattenedJWSInput,
-  GetKeyFunction,
-  JWSHeaderParameters,
-  JWTVerifyResult,
-} from 'jose/webcrypto/types';
+import { createRemoteJWKSet, jwtVerify, JWTVerifyResult, JWTVerifyGetKey } from 'jose';
 
 const EXPECTED_ALG = 'RS256';
 const CLOCK_TOLERANCE = 60;
 
-export const createJWKS = (JWKSUri: string) => {
+export const createJWKS = (JWKSUri: string): JWTVerifyGetKey => {
   return createRemoteJWKSet(new URL(JWKSUri));
 };
 
 export const verifyIdToken = async (
-  JWKS: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>,
+  JWKS: JWTVerifyGetKey,
   idToken: string,
   audience: string
 ): Promise<JWTVerifyResult> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
       '@types/webpack': ^5.28.0
       eslint: ^7.32.0
       jest: ^27.0.6
-      jose: ^3.14.3
+      jose: ^4.1.4
       js-base64: ^3.7.2
       lint-staged: ^11.1.2
       nanoid: ^3.1.30
@@ -36,6 +36,7 @@ importers:
       node-fetch: '2'
       prettier: ^2.3.2
       query-string: ^7.0.1
+      text-encoder: ^0.0.4
       ts-jest: ^27.0.4
       ts-loader: ^9.2.6
       typescript: ^4.3.5
@@ -43,7 +44,7 @@ importers:
       webpack-cli: ^4.9.1
       zod: ^3.9.8
     dependencies:
-      jose: 3.14.3
+      jose: 4.1.4
       js-base64: 3.7.2
       nanoid: 3.1.30
       query-string: 7.0.1
@@ -61,6 +62,7 @@ importers:
       nock: 13.1.3
       node-fetch: 2.6.1
       prettier: 2.3.2
+      text-encoder: 0.0.4
       ts-jest: 27.0.4_52cc4273aa16028085013af47e479e10
       ts-loader: 9.2.6_typescript@4.3.5+webpack@5.61.0
       typescript: 4.3.5
@@ -10096,8 +10098,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jose/3.14.3:
-    resolution: {integrity: sha512-j1vO5oWqa6LmdpiZvhkM9NYxN3EuTrmzVIqSGWtJVP6BOByujZdefZZjSFGzxmbf4GLYWaXLZMKTyVPbm00S2Q==}
+  /jose/4.1.4:
+    resolution: {integrity: sha512-iCCOrCZuG+BjP3SsjTmJtgFZey1hwHMUqv9nBqFkdJtJ/jd193QgCl/u339IdyS+2opUklON+9VzGzmKaudsfg==}
     dev: false
 
   /js-base64/3.7.2:
@@ -15005,6 +15007,10 @@ packages:
       '@istanbuljs/schema': 0.1.3
       glob: 7.1.7
       minimatch: 3.0.4
+    dev: true
+
+  /text-encoder/0.0.4:
+    resolution: {integrity: sha512-12gllbNnC0Zdh9r+LCpEwpUdvncaE9hfUmCVm2ryCH1LEVUZbS6NdRq8omEgJI0zKgaGFTjwQVHbglGDCIbmNA==}
     dev: true
 
   /text-extensions/1.9.0:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

in jose 3.x, module can only be imported by subpath, it could cause problems in both jsdom and webpack.

change log from jose 4.x:

> All module named exports have moved from subpaths to just "jose". For example, import { jwtVerify } from 'jose/jwt/verify' is now just import { jwtVerify } from 'jose'.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

old unit tests.