### PR TITLE
chore(client): bump node-fetch to 2.6.6

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
     "jest": "^27.0.6",
     "lint-staged": "^11.1.2",
     "nock": "^13.1.3",
-    "node-fetch": "2",
+    "node-fetch": "2.6.6",
     "prettier": "^2.3.2",
     "text-encoder": "^0.0.4",
     "ts-jest": "^27.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       lint-staged: ^11.1.2
       nanoid: ^3.1.30
       nock: ^13.1.3
-      node-fetch: '2'
+      node-fetch: 2.6.6
       prettier: ^2.3.2
       query-string: ^7.0.1
       text-encoder: ^0.0.4
@@ -60,7 +60,7 @@ importers:
       jest: 27.0.6
       lint-staged: 11.1.2
       nock: 13.1.3
-      node-fetch: 2.6.1
+      node-fetch: 2.6.6
       prettier: 2.3.2
       text-encoder: 0.0.4
       ts-jest: 27.0.4_52cc4273aa16028085013af47e479e10
@@ -11295,6 +11295,13 @@ packages:
     engines: {node: 4.x || >=6.0.0}
     dev: true
 
+  /node-fetch/2.6.6:
+    resolution: {integrity: sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==}
+    engines: {node: 4.x || >=6.0.0}
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
     engines: {node: '>= 6.0.0'}
@@ -15151,6 +15158,10 @@ packages:
       universalify: 0.1.2
     dev: true
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    dev: true
+
   /tr46/2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
     engines: {node: '>=8'}
@@ -15804,6 +15815,10 @@ packages:
       tslib: 2.3.1
     dev: true
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    dev: true
+
   /webidl-conversions/5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -16075,6 +16090,13 @@ packages:
 
   /whatwg-mimetype/2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+    dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: true
 
   /whatwg-url/8.7.0:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

https://github.com/logto-io/js/security/dependabot/packages/client/package.json/node-fetch/open
