### PR TITLE
refactor(playground): integrate playground with client js sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 # production
 /packages/*/dist
 /packages/*/lib
+/packages/*/build
 
 # logs
 logs

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -9,6 +9,7 @@ Create `.env` file with the following content:
 ```env
 RAZZLE_OIDC_BASE_URL=https://logto.dev/oidc
 ```
+
 Then
 
 ```bash

--- a/packages/playground/jest.setup.js
+++ b/packages/playground/jest.setup.js
@@ -1,0 +1,12 @@
+// Need to disable following rulus to mock text-decode/text-encoder and crypto for jsdom
+// https://github.com/jsdom/jsdom/issues/1612
+/* eslint-disable @silverhand/fp/no-mutation */
+/* eslint-disable unicorn/prefer-module */
+const { Crypto } = require('@peculiar/webcrypto');
+const fetch = require('node-fetch');
+const { TextDecoder, TextEncoder } = require('text-encoder');
+
+global.crypto = new Crypto();
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+global.fetch = fetch;

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@silverhand/playground",
+  "name": "@logto/playground",
   "version": "0.1.0",
   "license": "UNLICENSED",
   "private": true,
@@ -14,6 +14,7 @@
     "test": "razzle test --env=jsdom"
   },
   "dependencies": {
+    "@logto/client": "^0.0.1",
     "@silverhand/essentials": "^1.1.0-rc.1",
     "js-base64": "^3.6.1",
     "ky": "^0.28.5",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",
+    "@peculiar/webcrypto": "^1.1.7",
     "@silverhand/eslint-config": "^0.2.2",
     "@silverhand/eslint-config-react": "^0.2.2",
     "@silverhand/ts-config": "^0.2.2",
@@ -41,12 +43,14 @@
     "html-webpack-plugin": "^4.5.2",
     "lint-staged": ">=10",
     "mini-css-extract-plugin": "^0.9.0",
+    "node-fetch": "2.6.6",
     "postcss": "^8.3.6",
     "prettier": "^2.3.2",
     "razzle": "^4.2.6",
     "razzle-dev-utils": "^4.2.6",
     "razzle-plugin-scss": "^4.2.6",
     "stylelint": "^13.13.1",
+    "text-encoder": "^0.0.4",
     "typescript": "^4.3.5",
     "webpack": "^4.44.1",
     "webpack-dev-server": "^3.11.2"

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -15,6 +15,13 @@ module.exports = {
       '@': path.resolve('src/'),
     };
 
+    // Playground exceed the 244kb limitation after import client
+    // create a issue to optimize client js SDK package size
+    // https://linear.app/silverhand/issue/LOG-236/need-to-reduce-the-client-package-size
+    config.performance = {
+      hints: 'warning'
+    };
+
     return config;
   },
   modifyJestConfig: ({ jestConfig }) => {

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -19,7 +19,8 @@ module.exports = {
     // create a issue to optimize client js SDK package size
     // https://linear.app/silverhand/issue/LOG-236/need-to-reduce-the-client-package-size
     config.performance = {
-      hints: 'warning'
+      maxEntrypointSize: 512000,
+      maxAssetSize: 512000,
     };
 
     return config;

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -32,6 +32,8 @@ module.exports = {
       '@/(.*)': '<rootDir>/src/$1',
     };
 
+    config.setupFilesAfterEnv =['./jest.setup.js'];
+
     return config;
   },
 };

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,15 +1,39 @@
-import React from 'react';
+import LogtoClient from '@logto/client';
+import React, { useState, useEffect } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { oidcDomain } from '@/consts/url';
+
+import LogtoClientContext from './LogtoClientContext';
 import Callback from './pages/Callback';
 import Home from './pages/Home';
 import './scss/normalized.scss';
 
-const App = () => (
-  <Switch>
-    <Route exact path="/" component={Home} />
-    <Route exact path="/callback" component={Callback} />
-  </Switch>
-);
+const App = () => {
+  const [logtoClient, setLogtoClient] = useState<LogtoClient | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const client = await LogtoClient.create({
+        domain: oidcDomain,
+        clientId: 'foo',
+      });
+      setLogtoClient(client);
+      setLoading(false);
+    })();
+  }, []);
+
+  return (
+    <Switch>
+      {!loading && (
+        <LogtoClientContext.Provider value={logtoClient}>
+          <Route exact path="/" component={Home} />
+          <Route exact path="/callback" component={Callback} />
+        </LogtoClientContext.Provider>
+      )}
+    </Switch>
+  );
+};
 
 export default App;

--- a/packages/playground/src/LogtoClientContext.ts
+++ b/packages/playground/src/LogtoClientContext.ts
@@ -1,0 +1,6 @@
+import LogtoClient from '@logto/client';
+import React from 'react';
+
+const LogtoClientContext = React.createContext<LogtoClient | null>(null);
+
+export default LogtoClientContext;

--- a/packages/playground/src/consts/url.ts
+++ b/packages/playground/src/consts/url.ts
@@ -1,5 +1,2 @@
 export const baseUrl = `http://${String(process.env.HOST)}:${String(process.env.PORT)}`;
 export const oidcDomain = process.env.RAZZLE_OIDC_BASE_DOMAIN ?? 'N/A';
-export const oidcUrl = process.env.RAZZLE_OIDC_BASE_DOMAIN
-  ? `http://${process.env.RAZZLE_OIDC_BASE_DOMAIN}/oidc`
-  : 'N/A';

--- a/packages/playground/src/consts/url.ts
+++ b/packages/playground/src/consts/url.ts
@@ -1,2 +1,5 @@
 export const baseUrl = `http://${String(process.env.HOST)}:${String(process.env.PORT)}`;
-export const oidcUrl = process.env.RAZZLE_OIDC_BASE_URL ?? 'N/A';
+export const oidcDomain = process.env.RAZZLE_OIDC_BASE_DOMAIN ?? 'N/A';
+export const oidcUrl = process.env.RAZZLE_OIDC_BASE_DOMAIN
+  ? `http://${process.env.RAZZLE_OIDC_BASE_DOMAIN}/oidc`
+  : 'N/A';

--- a/packages/playground/src/pages/Home/index.tsx
+++ b/packages/playground/src/pages/Home/index.tsx
@@ -1,82 +1,27 @@
-import { conditional } from '@silverhand/essentials/lib/utilities/conditional.js';
-import { fromUint8Array } from 'js-base64';
-import ky from 'ky';
-import qs from 'query-string';
-import React, { useCallback } from 'react';
-import { number, object, string } from 'zod';
+import React, { useCallback, useMemo, useContext } from 'react';
 
-import { baseUrl, oidcUrl } from '@/consts/url';
+import LogtoClientContext from '@/LogtoClientContext';
+import { baseUrl } from '@/consts/url';
 
 import styles from './index.module.scss';
 
-function base64URLEncode(array: Uint8Array) {
-  return fromUint8Array(array).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-const Auth = object({
-  access_token: string(),
-  refresh_token: string(),
-  id_token: string(),
-  expires_in: number(),
-  scope: string(),
-  token_type: string(),
-});
-
 const Home = () => {
-  const auth = localStorage.getItem('auth');
-  const parsed = conditional(auth && Auth.parse(JSON.parse(auth)));
-  const isAuthed = Boolean(auth);
+  const logtoClient = useContext(LogtoClientContext);
 
-  const signIn = useCallback(async () => {
-    const verifier = base64URLEncode(crypto.getRandomValues(new Uint8Array(32)));
-    const encoded = new TextEncoder().encode(verifier);
-    const challenge = base64URLEncode(
-      new Uint8Array(await crypto.subtle.digest('SHA-256', encoded))
-    );
+  if (!logtoClient) {
+    throw new Error('no logto client found');
+  }
 
-    localStorage.setItem('verifier', verifier);
-    console.log(challenge, verifier);
+  const isAuthed = useMemo(() => logtoClient.isAuthenticated(), [logtoClient]);
+  const claims = isAuthed && logtoClient.getClaims();
 
-    const parameters = qs.stringify(
-      {
-        response_type: 'code',
-        redirect_uri: `${baseUrl}/callback`,
-        client_id: 'foo',
-        scope: 'openid%20offline_access',
-        prompt: 'consent',
-        code_challenge: challenge,
-        code_challenge_method: 'S256',
-        resource: 'https://api.logto.io',
-      },
-      { encode: false }
-    );
+  const signIn = useCallback(() => {
+    void logtoClient.loginWithRedirect(`${baseUrl}/callback`);
+  }, [logtoClient]);
 
-    window.location.assign(`${oidcUrl}/auth?${parameters}`);
-  }, []);
-
-  const signOut = useCallback(async () => {
-    if (parsed?.access_token) {
-      const body = new URLSearchParams();
-      body.set('token', String(parsed.access_token));
-      body.set('client_id', 'foo');
-      await ky.post(`${oidcUrl}/token/revocation`, { body });
-    }
-
-    if (parsed?.refresh_token) {
-      const body = new URLSearchParams();
-      body.set('token', String(parsed.refresh_token));
-      body.set('client_id', 'foo');
-      await ky.post(`${oidcUrl}/token/revocation`, { body });
-    }
-
-    localStorage.removeItem('auth');
-    const parameters = qs.stringify(
-      { id_token_hint: parsed?.id_token, post_logout_redirect_uri: baseUrl },
-      { encode: false }
-    );
-
-    window.location.assign(`${oidcUrl}/session/end?${parameters}`);
-  }, [parsed?.access_token, parsed?.id_token, parsed?.refresh_token]);
+  const signOut = useCallback(() => {
+    logtoClient.logout(baseUrl);
+  }, [logtoClient]);
 
   return (
     <div className={styles.wrapper}>
@@ -91,7 +36,7 @@ const Home = () => {
           Sign Out
         </button>
       )}
-      {isAuthed && parsed && (
+      {claims && (
         <table className={styles.table}>
           <thead>
             <tr>
@@ -100,19 +45,10 @@ const Home = () => {
             </tr>
           </thead>
           <tbody>
-            {(
-              [
-                'access_token',
-                'expires_in',
-                'refresh_token',
-                'id_token',
-                'scope',
-                'token_type',
-              ] as const
-            ).map((key) => (
+            {Object.keys(claims).map((key) => (
               <tr key={key}>
                 <td>{key}</td>
-                <td>{parsed[key]}</td>
+                <td>{claims[key as keyof typeof claims]}</td>
               </tr>
             ))}
           </tbody>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,8 @@ importers:
   packages/playground:
     specifiers:
       '@babel/core': ^7.14.6
+      '@logto/client': ^0.0.1
+      '@peculiar/webcrypto': ^1.1.7
       '@silverhand/eslint-config': ^0.2.2
       '@silverhand/eslint-config-react': ^0.2.2
       '@silverhand/essentials': ^1.1.0-rc.1
@@ -91,6 +93,7 @@ importers:
       ky: ^0.28.5
       lint-staged: '>=10'
       mini-css-extract-plugin: ^0.9.0
+      node-fetch: 2.6.6
       postcss: ^8.3.6
       prettier: ^2.3.2
       query-string: ^7.0.1
@@ -101,11 +104,13 @@ importers:
       react-dom: ^17.0.2
       react-router-dom: ^5.2.0
       stylelint: ^13.13.1
+      text-encoder: ^0.0.4
       typescript: ^4.3.5
       webpack: ^4.44.1
       webpack-dev-server: ^3.11.2
       zod: ^3.5.1
     dependencies:
+      '@logto/client': link:../client
       '@silverhand/essentials': 1.1.0
       js-base64: 3.7.2
       ky: 0.28.6
@@ -116,6 +121,7 @@ importers:
       zod: 3.9.8
     devDependencies:
       '@babel/core': 7.15.0
+      '@peculiar/webcrypto': 1.1.7
       '@silverhand/eslint-config': 0.2.2_d0e06193b104cab3f9ceaef77640598a
       '@silverhand/eslint-config-react': 0.2.2_4c20fd9f9f0b69dac15e87486719255f
       '@silverhand/ts-config': 0.2.2_typescript@4.4.4
@@ -132,12 +138,14 @@ importers:
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       lint-staged: 11.1.2
       mini-css-extract-plugin: 0.9.0_webpack@4.46.0
+      node-fetch: 2.6.6
       postcss: 8.3.11
       prettier: 2.3.2
       razzle: 4.2.6_e4684ab490cb0dcc31add400d8065769
       razzle-dev-utils: 4.2.6_25582cf9a45d8a495d3f9acca3867c25
       razzle-plugin-scss: 4.2.6_041d2e272707d6b253e23199b16beaed
       stylelint: 13.13.1
+      text-encoder: 0.0.4
       typescript: 4.4.4
       webpack: 4.46.0
       webpack-dev-server: 3.11.2_webpack@4.46.0
@@ -6818,7 +6826,7 @@ packages:
       '@typescript-eslint/eslint-plugin': '>=4.28.1'
       eslint: '>=7.30.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_1ff229bad5b3f782209b865beb048324
+      '@typescript-eslint/eslint-plugin': 4.31.2_8f0416aa8ec58a469909c5c0f73069bc
       eslint: 7.32.0
       typescript: 4.3.5
     dev: true


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Integrate playground with client js sdk

- Create a logtoClient instance and put is in as a context
- replace original login/logout logic using logtoClient api
- add `jest-setup` file to bypass the `jose` jest env issue
- As `token_set` storage is hidden to the client, display IDToken claims instead of original token_set details  after success login

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
Test locally successfully sign-in and out

![image](https://user-images.githubusercontent.com/36393111/140025952-6505a929-c3a8-4d5e-aec9-6ed5d4181895.png)

<!-- How did you test this PR? -->

@wangsijie @xiaoyijun cc: @IceHe @gao-sun 