### PR TITLE
refactor(js): move generateScope to generators.ts

### DIFF
--- a/packages/client/src/generators.test.ts
+++ b/packages/client/src/generators.test.ts
@@ -1,34 +1,114 @@
-import { CODE_VERIFIER_MAX_LENGTH } from './constants';
-import { generateCodeVerifier, generateCodeChallenge } from './generators';
+import {
+  CODE_VERIFIER_MAX_LENGTH,
+  DEFAULT_SCOPE_STRING,
+  EMAIL,
+  NAME,
+  OFFLINE_ACCESS,
+  OPENID,
+} from './constants';
+import { generateCodeChallenge, generateCodeVerifier, generateScope } from './generators';
 
-test('generate codeVerifier with fixed length', () => {
-  const verifier = generateCodeVerifier();
-  expect(verifier.length).toEqual(CODE_VERIFIER_MAX_LENGTH);
+describe('generateCodeVerifier', () => {
+  test('with fixed length', () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier.length).toEqual(CODE_VERIFIER_MAX_LENGTH);
+  });
+
+  test('with random value', () => {
+    const verifier1 = generateCodeVerifier();
+    const verifier2 = generateCodeVerifier();
+    expect(verifier1).not.toEqual(verifier2);
+  });
 });
 
-test('generate codeVerifier with random value', () => {
-  const verifier1 = generateCodeVerifier();
-  const verifier2 = generateCodeVerifier();
-  expect(verifier1 === verifier2).toBeFalsy();
+describe('generateCodeChallenge', () => {
+  test('with fixed length', async () => {
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    expect(challenge.length).toEqual(Math.ceil(32 * 1.34));
+  });
+
+  test('with different codeVerifier', async () => {
+    const verifier1 = generateCodeVerifier();
+    const challenge1 = await generateCodeChallenge(verifier1);
+    const verifier2 = generateCodeVerifier();
+    const challenge2 = await generateCodeChallenge(verifier2);
+    expect(challenge1).not.toEqual(challenge2);
+  });
+
+  test('with same codeVerifier', async () => {
+    const verifier = generateCodeVerifier();
+    const challenge1 = await generateCodeChallenge(verifier);
+    const challenge2 = await generateCodeChallenge(verifier);
+    expect(challenge1).toEqual(challenge2);
+  });
 });
 
-test('generate codeChallenge with fixed length', async () => {
-  const verifier = generateCodeVerifier();
-  const challenge = await generateCodeChallenge(verifier);
-  expect(challenge.length).toEqual(Math.ceil(32 * 1.34));
-});
+describe('generateScope', () => {
+  describe('Expect generateScope method to append default scope values to the head of scope string', () => {
+    describe('undefined param', () => {
+      test('should generate DEFAULT_SCOPE_STRING if calling without parameters', () => {
+        expect(generateScope()).toEqual(DEFAULT_SCOPE_STRING);
+      });
+    });
 
-test('generate codeChallenge with different codeVerifier', async () => {
-  const verifier1 = generateCodeVerifier();
-  const challenge1 = await generateCodeChallenge(verifier1);
-  const verifier2 = generateCodeVerifier();
-  const challenge2 = await generateCodeChallenge(verifier2);
-  expect(challenge1 === challenge2).toBeFalsy();
-});
+    describe('string param', () => {
+      test('empty', () => {
+        expect(generateScope('')).toEqual(DEFAULT_SCOPE_STRING);
+      });
 
-test('generate codeChallenge with same codeVerifier', async () => {
-  const verifier = generateCodeVerifier();
-  const challenge1 = await generateCodeChallenge(verifier);
-  const challenge2 = await generateCodeChallenge(verifier);
-  expect(challenge1 === challenge2).toBeTruthy();
+      test('with blank characters', () => {
+        expect(generateScope(' \t')).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid offline_access', () => {
+        expect(generateScope(DEFAULT_SCOPE_STRING)).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid (without default scope value offline_access)', () => {
+        expect(generateScope(OPENID)).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid name (without default scope value offline_access)', () => {
+        expect(generateScope(`${NAME} ${OPENID}`)).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME}`);
+      });
+
+      test('with offline_access email (without default scope value openid)', () => {
+        expect(generateScope(`${EMAIL} ${OFFLINE_ACCESS}`)).toEqual(
+          `${DEFAULT_SCOPE_STRING} ${EMAIL}`
+        );
+      });
+
+      test('with name email (without all default scope values)', () => {
+        const originalScope = `${NAME} ${EMAIL}`;
+        expect(generateScope(originalScope)).toEqual(`${DEFAULT_SCOPE_STRING} ${originalScope}`);
+      });
+    });
+
+    describe('string array param', () => {
+      test('empty', () => {
+        expect(generateScope([])).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid offline_access', () => {
+        expect(generateScope([OPENID, OFFLINE_ACCESS])).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid (without default scope value offline_access)', () => {
+        expect(generateScope([OPENID])).toEqual(DEFAULT_SCOPE_STRING);
+      });
+
+      test('with openid name (without default scope value offline_access)', () => {
+        expect(generateScope([NAME, OPENID])).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME}`);
+      });
+
+      test('with offline_access email (without default scope value openid)', () => {
+        expect(generateScope([EMAIL, OFFLINE_ACCESS])).toEqual(`${DEFAULT_SCOPE_STRING} ${EMAIL}`);
+      });
+
+      test('with name email (without all default scope values)', () => {
+        expect(generateScope([NAME, EMAIL])).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME} ${EMAIL}`);
+      });
+    });
+  });
 });

--- a/packages/client/src/generators.ts
+++ b/packages/client/src/generators.ts
@@ -6,6 +6,7 @@ import { customAlphabet } from 'nanoid';
 import {
   CODE_VERIFIER_ALPHABET,
   CODE_VERIFIER_MAX_LENGTH,
+  DEFAULT_SCOPE_VALUES,
   RANDOM_STRING_MAX_LENGTH,
 } from './constants';
 import { encodeBase64 } from './utils';
@@ -50,4 +51,20 @@ export const generateCodeChallenge = async (codeVerifier: string): Promise<strin
   const encoded = new TextEncoder().encode(codeVerifier);
   const challenge = new Uint8Array(await crypto.subtle.digest('SHA-256', encoded));
   return fromUint8Array(challenge).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+};
+
+/**
+ * @param originalScope
+ * @return customScope including all default scope values ( Logto requires `openid` and `offline_access` )
+ */
+export const generateScope = (originalScope?: string | string[]): string => {
+  const originalScopeValues =
+    originalScope === undefined
+      ? []
+      : Array.isArray(originalScope)
+      ? originalScope
+      : originalScope.split(' ');
+  const nonEmptyScopeValues = originalScopeValues.map((s) => s.trim()).filter((s) => s.length > 0);
+  const uniqueScopeValues = new Set([...DEFAULT_SCOPE_VALUES, ...nonEmptyScopeValues]);
+  return Array.from(uniqueScopeValues).join(' ');
 };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@ import { Optional } from '@silverhand/essentials';
 
 import { TOKEN_SET_CACHE_KEY } from './constants';
 import discover, { OIDCConfiguration } from './discover';
+import { generateScope } from './generators';
 import {
   grantTokenByAuthorizationCode,
   grantTokenByRefreshToken,
@@ -13,7 +14,6 @@ import { getLogoutUrl } from './request-logout';
 import SessionManager from './session-manager';
 import { ClientStorage, LocalStorage } from './storage';
 import TokenSet from './token-set';
-import { generateScope } from './utils';
 import { createJWKS, verifyIdToken } from './verify-id-token';
 
 export * from './storage';

--- a/packages/client/src/utils.test.ts
+++ b/packages/client/src/utils.test.ts
@@ -1,8 +1,7 @@
 import { generateKeyPair, SignJWT } from 'jose';
 import { ZodError } from 'zod';
 
-import { DEFAULT_SCOPE_STRING, EMAIL, NAME, OFFLINE_ACCESS, OPENID } from './constants';
-import { decodeToken, generateScope } from './utils';
+import { decodeToken } from './utils';
 
 describe('decodeToken', () => {
   test('decode token and get claims', async () => {
@@ -31,65 +30,5 @@ describe('decodeToken', () => {
       .setExpirationTime('2h')
       .sign((await generateKeyPair('RS256')).privateKey);
     expect(() => decodeToken(JWT)).toThrowError(ZodError);
-  });
-});
-
-describe('generateScope', () => {
-  test('no argument', () => {
-    expect(generateScope()).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('empty string', () => {
-    expect(generateScope('')).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string with blank characters', () => {
-    expect(generateScope(' \t')).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string with openid offline_access', () => {
-    const originalScope = DEFAULT_SCOPE_STRING;
-    expect(generateScope(originalScope)).toEqual(originalScope);
-  });
-
-  test('string with openid (without default scope value offline_access)', () => {
-    expect(generateScope(OPENID)).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string with openid name (without default scope value offline_access)', () => {
-    expect(generateScope(`${NAME} ${OPENID}`)).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME}`);
-  });
-
-  test('string with offline_access email (without default scope value openid)', () => {
-    expect(generateScope(`${EMAIL} ${OFFLINE_ACCESS}`)).toEqual(`${DEFAULT_SCOPE_STRING} ${EMAIL}`);
-  });
-
-  test('string with name email (without all default scope values)', () => {
-    const originalScope = `${NAME} ${EMAIL}`;
-    expect(generateScope(originalScope)).toEqual(`${DEFAULT_SCOPE_STRING} ${originalScope}`);
-  });
-
-  test('empty string array', () => {
-    expect(generateScope([])).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string array with openid offline_access', () => {
-    expect(generateScope([OPENID, OFFLINE_ACCESS])).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string array with openid (without default scope value offline_access)', () => {
-    expect(generateScope([OPENID])).toEqual(DEFAULT_SCOPE_STRING);
-  });
-
-  test('string array with openid name (without default scope value offline_access)', () => {
-    expect(generateScope([NAME, OPENID])).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME}`);
-  });
-
-  test('string array with offline_access email (without default scope value openid)', () => {
-    expect(generateScope([EMAIL, OFFLINE_ACCESS])).toEqual(`${DEFAULT_SCOPE_STRING} ${EMAIL}`);
-  });
-
-  test('string array with name email (without all default scope values)', () => {
-    expect(generateScope([NAME, EMAIL])).toEqual(`${DEFAULT_SCOPE_STRING} ${NAME} ${EMAIL}`);
   });
 });

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -1,7 +1,5 @@
 import { z, ZodError } from 'zod';
 
-import { DEFAULT_SCOPE_VALUES } from './constants';
-
 const fullfillBase64 = (input: string) => {
   if (input.length === 2) {
     return `${input}==`;
@@ -59,19 +57,3 @@ export const nowRoundToSec = () => Math.floor(Date.now() / 1000);
 
 export const encodeBase64 = (input: string) => btoa(input);
 export const decodeBase64 = (input: string) => atob(input);
-
-/**
- * @param originalScope
- * @return customScope including all default scope values ( Logto requires `openid` and `offline_access` )
- */
-export const generateScope = (originalScope?: string | string[]): string => {
-  const originalScopeValues =
-    originalScope === undefined
-      ? []
-      : Array.isArray(originalScope)
-      ? originalScope
-      : originalScope.split(' ');
-  const nonEmptyScopeValues = originalScopeValues.map((s) => s.trim()).filter((s) => s.length > 0);
-  const uniqueScopeValues = new Set([...DEFAULT_SCOPE_VALUES, ...nonEmptyScopeValues]);
-  return Array.from(uniqueScopeValues).join(' ');
-};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Move method `generateScope` from `util.ts` to `generators.ts`

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing unit tests.