### PR TITLE
chore(analyze): add webpack bundle analyze script

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint --ext .ts src",
     "package": "webpack",
     "test": "jest",
-    "prepublish": "npm run build && npm run package"
+    "prepublish": "npm run build && ",
+    "report": "WITH_REPORT=true npm run package"
   },
   "dependencies": {
     "jose": "^4.1.4",
@@ -37,6 +38,7 @@
     "ts-loader": "^9.2.6",
     "typescript": "^4.3.5",
     "webpack": "^5.58.2",
+    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.1"
   },
   "eslintConfig": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --ext .ts src",
     "package": "webpack",
     "test": "jest",
-    "prepublish": "npm run build && ",
+    "prepublish": "npm run build && npm run package",
     "report": "WITH_REPORT=true npm run package"
   },
   "dependencies": {

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -1,24 +1,31 @@
 const path = require('path');
 
-module.exports = {
-  entry: './src/index.ts',
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
-  output: {
-    filename: 'logto.min.js',
-    path: path.resolve(__dirname, 'dist'),
-    library: 'logto',
-    libraryTarget: 'umd',
-  },
-  mode: 'production',
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+module.exports = () => {
+  const { WITH_REPORT } = process.env;
+
+  return {
+    entry: './src/index.ts',
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    resolve: {
+      extensions: ['.tsx', '.ts', '.js'],
+    },
+    output: {
+      filename: 'logto.min.js',
+      path: path.resolve(__dirname, 'dist'),
+      library: 'logto',
+      libraryTarget: 'umd',
+    },
+    mode: 'production',
+    plugins: WITH_REPORT ? [new BundleAnalyzerPlugin()] : [],
+  };
 };

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -b && razzle build",
     "lint": "eslint --format pretty --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
-    "test": "razzle test --env=jsdom"
+    "test": "razzle test --env=jsdom",
+    "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {
     "@logto/client": "^0.0.1",
@@ -53,6 +54,7 @@
     "text-encoder": "^0.0.4",
     "typescript": "^4.3.5",
     "webpack": "^4.44.1",
+    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-dev-server": "^3.11.2"
   },
   "engines": {

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -2,6 +2,8 @@
 
 const path = require('path');
 
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
 module.exports = {
   options: {
     buildType: 'spa',
@@ -10,6 +12,7 @@ module.exports = {
   modifyWebpackConfig: ({ webpackConfig }) => {
     /** @type {import('webpack').Configuration} **/
     const config = { ...webpackConfig };
+    const { WITH_REPORT } = process.env;
 
     config.resolve.alias = {
       '@': path.resolve('src/'),
@@ -22,6 +25,10 @@ module.exports = {
       maxEntrypointSize: 512000,
       maxAssetSize: 512000,
     };
+
+    if (WITH_REPORT) {
+      config.plugins = [...config.plugins, new BundleAnalyzerPlugin()];
+    }
 
     return config;
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ importers:
       ts-loader: ^9.2.6
       typescript: ^4.3.5
       webpack: ^5.58.2
+      webpack-bundle-analyzer: ^4.5.0
       webpack-cli: ^4.9.1
       zod: ^3.9.8
     dependencies:
@@ -67,7 +68,8 @@ importers:
       ts-loader: 9.2.6_typescript@4.3.5+webpack@5.61.0
       typescript: 4.3.5
       webpack: 5.61.0_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_webpack@5.61.0
+      webpack-bundle-analyzer: 4.5.0
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
 
   packages/playground:
     specifiers:
@@ -107,6 +109,7 @@ importers:
       text-encoder: ^0.0.4
       typescript: ^4.3.5
       webpack: ^4.44.1
+      webpack-bundle-analyzer: ^4.5.0
       webpack-dev-server: ^3.11.2
       zod: ^3.5.1
     dependencies:
@@ -148,6 +151,7 @@ importers:
       text-encoder: 0.0.4
       typescript: 4.4.4
       webpack: 4.46.0
+      webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 3.11.2_webpack@4.46.0
 
 packages:
@@ -3145,6 +3149,10 @@ packages:
       webpack-dev-server: 3.11.2_webpack@4.46.0
     dev: true
 
+  /@polka/url/1.0.0-next.21:
+    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
   /@silverhand/eslint-config-react/0.2.2_4c20fd9f9f0b69dac15e87486719255f:
     resolution: {integrity: sha512-rYjOM3DktpATV8On+1+YzBqCnnfVz/4ByDK58QELCm0jvLzkl1e5IbpqM5Ay1KIPDLYo6we6EB7IJeEiRJJG8Q==}
     peerDependencies:
@@ -3999,7 +4007,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.61.0_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_webpack@5.61.0
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
     dev: true
 
   /@webpack-cli/info/1.4.0_webpack-cli@4.9.1:
@@ -4008,7 +4016,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.1_webpack@5.61.0
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
     dev: true
 
   /@webpack-cli/serve/1.6.0_webpack-cli@4.9.1:
@@ -4020,7 +4028,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.9.1_webpack@5.61.0
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
     dev: true
 
   /@xtuc/ieee754/1.2.0:
@@ -4080,6 +4088,11 @@ packages:
 
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -11775,6 +11788,11 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
+  /opener/1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
+    dev: true
+
   /opn/5.5.0:
     resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
     engines: {node: '>=4'}
@@ -14101,6 +14119,15 @@ packages:
       is-arrayish: 0.3.2
     dev: true
 
+  /sirv/1.0.18:
+    resolution: {integrity: sha512-f2AOPogZmXgJ9Ma2M22ZEhc1dNtRIzcEkiflMFeVTRq+OViOZMvH1IPMVOwrKaxpSaHioBJiDR0SluRqGa7atA==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mime: 2.5.2
+      totalist: 1.1.0
+    dev: true
+
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -15149,6 +15176,11 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
+  /totalist/1.1.0:
+    resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
+    engines: {node: '>=6'}
+    dev: true
+
   /tough-cookie/2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
@@ -15837,7 +15869,26 @@ packages:
     engines: {node: '>=10.4'}
     dev: true
 
-  /webpack-cli/4.9.1_webpack@5.61.0:
+  /webpack-bundle-analyzer/4.5.0:
+    resolution: {integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+    dependencies:
+      acorn: 8.4.1
+      acorn-walk: 8.2.0
+      chalk: 4.1.2
+      commander: 7.2.0
+      gzip-size: 6.0.0
+      lodash: 4.17.21
+      opener: 1.5.2
+      sirv: 1.0.18
+      ws: 7.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /webpack-cli/4.9.1_51b97b2ad784f46f7873debea239ad34:
     resolution: {integrity: sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -15869,6 +15920,7 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.1
       webpack: 5.61.0_webpack-cli@4.9.1
+      webpack-bundle-analyzer: 4.5.0
       webpack-merge: 5.8.0
     dev: true
 
@@ -16051,7 +16103,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.2.4_webpack@5.61.0
       watchpack: 2.2.0
-      webpack-cli: 4.9.1_webpack@5.61.0
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
       webpack-sources: 3.2.1
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
add webpack bundle analyze script

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

As we have observed the package oversize issue on clientjs and playground, to better analyze the bundle size and optimize it, add the `webpack-bundle-analyzer`

with script `pnpm report`


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing

![image](https://user-images.githubusercontent.com/36393111/140494814-7c2ac17c-bd91-4496-b12d-af6f3d24546e.png)

<!-- How did you test this PR? -->