### PR TITLE
refactor(client): burn zod dependency

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
     "js-base64": "^3.7.2",
     "nanoid": "^3.1.30",
     "query-string": "^7.0.1",
-    "zod": "^3.9.8"
+    "superstruct": "^0.15.3"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.7",

--- a/packages/client/src/discover.ts
+++ b/packages/client/src/discover.ts
@@ -1,18 +1,18 @@
-import { z } from 'zod';
+import * as s from 'superstruct';
 
 import { requestWithFetch } from './api';
 import { LogtoError } from './errors';
 
-const OIDCConfigurationSchema = z.object({
-  authorization_endpoint: z.string(),
-  jwks_uri: z.string(),
-  token_endpoint: z.string(),
-  issuer: z.string(),
-  revocation_endpoint: z.string(),
-  end_session_endpoint: z.string(),
+const OIDCConfigurationSchema = s.object({
+  authorization_endpoint: s.string(),
+  jwks_uri: s.string(),
+  token_endpoint: s.string(),
+  issuer: s.string(),
+  revocation_endpoint: s.string(),
+  end_session_endpoint: s.string(),
 });
 
-export type OIDCConfiguration = z.infer<typeof OIDCConfigurationSchema>;
+export type OIDCConfiguration = s.Infer<typeof OIDCConfigurationSchema>;
 
 const appendSlashIfNeeded = (url: string): string => {
   if (url.endsWith('/')) {
@@ -26,11 +26,15 @@ export default async function discover(url: string): Promise<OIDCConfiguration> 
   const response = await requestWithFetch<OIDCConfiguration>(
     `${appendSlashIfNeeded(url)}oidc/.well-known/openid-configuration`
   );
-  const result = OIDCConfigurationSchema.safeParse(response);
 
-  if (!result.success) {
-    throw new LogtoError({ cause: result.error });
+  try {
+    s.assert(response, OIDCConfigurationSchema);
+    return response;
+  } catch (error: unknown) {
+    if (error instanceof s.StructError) {
+      throw new LogtoError({ cause: error });
+    }
+
+    throw error;
   }
-
-  return result.data;
 }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,4 +1,4 @@
-import { ZodError } from 'zod';
+import { StructError } from 'superstruct';
 
 interface LogtoErrorParameters {
   message?: string;
@@ -9,10 +9,10 @@ interface LogtoErrorParameters {
 export class LogtoError extends Error {
   public uri?: string;
   public response?: Response;
-  public cause?: Error | ZodError;
+  public cause?: Error | StructError;
 
   constructor({ message, cause, response }: LogtoErrorParameters) {
-    if (cause instanceof ZodError) {
+    if (cause instanceof StructError) {
       super(`Remote response format error: ${cause.message}`);
     } else {
       super(message);

--- a/packages/client/src/grant-token.ts
+++ b/packages/client/src/grant-token.ts
@@ -1,16 +1,16 @@
-import { z } from 'zod';
+import * as s from 'superstruct';
 
 import { requestWithFetch } from './api';
 import { LogtoError } from './errors';
 
-const TokenSetParametersSchema = z.object({
-  access_token: z.string(),
-  expires_in: z.number(),
-  id_token: z.string(),
-  refresh_token: z.string(),
+const TokenSetParametersSchema = s.object({
+  access_token: s.string(),
+  expires_in: s.number(),
+  id_token: s.string(),
+  refresh_token: s.string(),
 });
 
-export type TokenSetParameters = z.infer<typeof TokenSetParametersSchema>;
+export type TokenSetParameters = s.Infer<typeof TokenSetParametersSchema>;
 
 type GrantTokenPayload = {
   endpoint: string;
@@ -41,13 +41,17 @@ export const grantTokenByAuthorizationCode = async ({
     },
     body: parameters,
   });
-  const result = TokenSetParametersSchema.safeParse(response);
 
-  if (!result.success) {
-    throw new LogtoError({ cause: result.error });
+  try {
+    s.assert(response, TokenSetParametersSchema);
+    return response;
+  } catch (error: unknown) {
+    if (error instanceof s.StructError) {
+      throw new LogtoError({ cause: error });
+    }
+
+    throw error;
   }
-
-  return result.data;
 };
 
 export const grantTokenByRefreshToken = async (
@@ -67,11 +71,15 @@ export const grantTokenByRefreshToken = async (
     },
     body: parameters,
   });
-  const result = TokenSetParametersSchema.safeParse(response);
 
-  if (!result.success) {
-    throw new LogtoError({ cause: result.error });
+  try {
+    s.assert(response, TokenSetParametersSchema);
+    return response;
+  } catch (error: unknown) {
+    if (error instanceof s.StructError) {
+      throw new LogtoError({ cause: error });
+    }
+
+    throw error;
   }
-
-  return result.data;
 };

--- a/packages/client/src/utils.test.ts
+++ b/packages/client/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPair, SignJWT } from 'jose';
-import { ZodError } from 'zod';
+import { StructError } from 'superstruct';
 
 import { decodeToken } from './utils';
 
@@ -29,6 +29,6 @@ describe('decodeToken', () => {
       .setIssuedAt()
       .setExpirationTime('2h')
       .sign((await generateKeyPair('RS256')).privateKey);
-    expect(() => decodeToken(JWT)).toThrowError(ZodError);
+    expect(() => decodeToken(JWT)).toThrowError(StructError);
   });
 });

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -43,7 +43,7 @@ export const decodeToken = (token: string): IDToken => {
   );
 
   try {
-    // using SuperStruct to validate the json type
+    // Using SuperStruct to validate the json type
     const data = JSON.parse(json) as IDToken;
     s.assert(data, IDTokenSchema);
     return data;

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -1,4 +1,4 @@
-import { z, ZodError } from 'zod';
+import * as s from 'superstruct';
 
 const fullfillBase64 = (input: string) => {
   if (input.length === 2) {
@@ -12,16 +12,16 @@ const fullfillBase64 = (input: string) => {
   return input;
 };
 
-const IDTokenSchema = z.object({
-  iss: z.string(),
-  sub: z.string(),
-  aud: z.string(),
-  exp: z.number(),
-  iat: z.number(),
-  at_hash: z.optional(z.string()),
+const IDTokenSchema = s.object({
+  iss: s.string(),
+  sub: s.string(),
+  aud: s.string(),
+  exp: s.number(),
+  iat: s.number(),
+  at_hash: s.optional(s.string()),
 });
 
-export type IDToken = z.infer<typeof IDTokenSchema>;
+export type IDToken = s.Infer<typeof IDTokenSchema>;
 
 /**
  * Decode IDToken from JWT, without verifying.
@@ -43,9 +43,12 @@ export const decodeToken = (token: string): IDToken => {
   );
 
   try {
-    return IDTokenSchema.parse(JSON.parse(json));
+    // using SuperStruct to validate the json type
+    const data = JSON.parse(json) as IDToken;
+    s.assert(data, IDTokenSchema);
+    return data;
   } catch (error: unknown) {
-    if (error instanceof ZodError) {
+    if (error instanceof s.StructError) {
       throw error;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ importers:
       node-fetch: 2.6.6
       prettier: ^2.3.2
       query-string: ^7.0.1
+      superstruct: ^0.15.3
       text-encoder: ^0.0.4
       ts-jest: ^27.0.4
       ts-loader: ^9.2.6
@@ -43,13 +44,12 @@ importers:
       webpack: ^5.58.2
       webpack-bundle-analyzer: ^4.5.0
       webpack-cli: ^4.9.1
-      zod: ^3.9.8
     dependencies:
       jose: 4.1.4
       js-base64: 3.7.2
       nanoid: 3.1.30
       query-string: 7.0.1
-      zod: 3.9.8
+      superstruct: 0.15.3
     devDependencies:
       '@peculiar/webcrypto': 1.1.7
       '@silverhand/eslint-config': 0.2.2_aff669e8eb0d21fc4e2068e6112ef4d0
@@ -14916,6 +14916,10 @@ packages:
     dependencies:
       postcss: 7.0.39
     dev: true
+
+  /superstruct/0.15.3:
+    resolution: {integrity: sha512-wilec1Rg3FtKuRjRyCt70g5W29YUEuaLnybdVQUI+VQ7m0bw8k7TzrRv5iYmo6IpjLVrwxP5t3RgjAVqhYh4Fg==}
+    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}


### PR DESCRIPTION
as zod package size exceed our limit. replace zod with superstruct

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

We have observed that `zod` dependency cost lot in terms of the client package's bundle size.  So find an alteration [superstruct](https://github.com/ianstormtaylor/superstruct) to replace the `zod`. Both shares a similar api. Easy to shift. 

Before:
<img width="1126" alt="Screen Shot 2021-11-08 at 11 38 18 AM" src="https://user-images.githubusercontent.com/36393111/140691641-308eaab8-fd93-4f48-b397-c4fdd4c16b34.png">

After:
<img width="715" alt="Screen Shot 2021-11-08 at 11 35 14 AM" src="https://user-images.githubusercontent.com/36393111/140691658-dc1d39f0-3ede-4dde-8321-55ccaf8cb1f4.png">

For More details:

https://www.npmtrends.com/yup-vs-zod-vs-superstruct
https://bundlephobia.com/package/superstruct@0.15.3


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case updated. Test locally on playground 

## Reviewers
@wangsijie @gao-sun cc: @IceHe @xiaoyijun
