### PR TITLE
refactor(react): use reducer

### DIFF
--- a/packages/react/src/auth-state.ts
+++ b/packages/react/src/auth-state.ts
@@ -1,12 +1,12 @@
 export interface AuthState {
   isLoading: boolean;
-  initialized: boolean;
+  isInitialized: boolean;
   isAuthenticated: boolean;
   error?: Error;
 }
 
-export const initialAuthState: AuthState = {
+export const defaultAuthState: AuthState = {
   isLoading: false,
-  initialized: false,
+  isInitialized: false,
   isAuthenticated: false,
 };

--- a/packages/react/src/auth-state.ts
+++ b/packages/react/src/auth-state.ts
@@ -1,0 +1,12 @@
+export interface AuthState {
+  isLoading: boolean;
+  initialized: boolean;
+  isAuthenticated: boolean;
+  error?: Error;
+}
+
+export const initialAuthState: AuthState = {
+  isLoading: false,
+  initialized: false,
+  isAuthenticated: false,
+};

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,7 +1,7 @@
 import LogtoClient from '@logto/client';
 import { createContext } from 'react';
 
-import { AuthState, initialAuthState } from './auth-state';
+import { AuthState, defaultAuthState } from './auth-state';
 
 const notInProvider = (): never => {
   throw new Error('Must be used inside <LogtoProvider>');
@@ -15,7 +15,7 @@ export interface LogtoContextProperties extends AuthState {
 }
 
 export const LogtoContext = createContext<LogtoContextProperties>({
-  ...initialAuthState,
+  ...defaultAuthState,
   loginWithRedirect: notInProvider,
   handleCallback: notInProvider,
   logout: notInProvider,

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,9 +1,22 @@
 import LogtoClient from '@logto/client';
 import { createContext } from 'react';
 
-export interface LogtoContextProperties {
+import { AuthState, initialAuthState } from './auth-state';
+
+const notInProvider = (): never => {
+  throw new Error('Must be used inside <LogtoProvider>');
+};
+
+export interface LogtoContextProperties extends AuthState {
   logtoClient?: LogtoClient;
-  isAuthenticated: boolean;
+  loginWithRedirect: (redirectUri: string) => Promise<void>;
+  handleCallback: (url: string) => Promise<void>;
+  logout: (redirectUri: string) => void;
 }
 
-export const LogtoContext = createContext<LogtoContextProperties>({ isAuthenticated: false });
+export const LogtoContext = createContext<LogtoContextProperties>({
+  ...initialAuthState,
+  loginWithRedirect: notInProvider,
+  handleCallback: notInProvider,
+  logout: notInProvider,
+});

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,7 +1,9 @@
 import LogtoClient, { ConfigParameters } from '@logto/client';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
 
+import { initialAuthState } from './auth-state';
 import { LogtoContext } from './context';
+import { reducer } from './reducer';
 
 export interface LogtoProviderProperties {
   logtoConfig: ConfigParameters;
@@ -10,24 +12,67 @@ export interface LogtoProviderProperties {
 
 export const LogtoProvider = ({ logtoConfig, children }: LogtoProviderProperties) => {
   const [logtoClient, setLogtoClient] = useState<LogtoClient>();
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialAuthState);
 
   useEffect(() => {
     const createClient = async () => {
-      const client = await LogtoClient.create({
-        ...logtoConfig,
-        onAuthStateChange: () => {
-          setIsAuthenticated(client.isAuthenticated());
-        },
-      });
+      const client = await LogtoClient.create(logtoConfig);
+      dispatch({ type: 'INITIALIZE', isAuthenticated: client.isAuthenticated() });
       setLogtoClient(client);
     };
 
     void createClient();
   }, [logtoConfig]);
 
+  const loginWithRedirect = useCallback(
+    async (redirectUri: string) => {
+      if (!logtoClient) {
+        return;
+      }
+
+      dispatch({ type: 'LOGIN_WITH_REDIRECT' });
+      try {
+        await logtoClient.loginWithRedirect(redirectUri);
+      } catch (error: unknown) {
+        dispatch({ type: 'ERROR', error });
+      }
+    },
+    [logtoClient]
+  );
+
+  const handleCallback = useCallback(
+    async (uri: string) => {
+      if (!logtoClient) {
+        return;
+      }
+
+      dispatch({ type: 'HANDLE_CALLBACK_REQUEST' });
+      try {
+        await logtoClient.handleCallback(uri);
+        dispatch({ type: 'HANDLE_CALLBACK_SUCCESS' });
+      } catch (error: unknown) {
+        dispatch({ type: 'ERROR', error });
+      }
+    },
+    [logtoClient]
+  );
+
+  const logout = useCallback(
+    (redirectUri: string) => {
+      if (!logtoClient) {
+        return;
+      }
+
+      dispatch({ type: 'LOGOUT' });
+      logtoClient.logout(redirectUri);
+    },
+    [logtoClient]
+  );
+
   return (
-    <LogtoContext.Provider value={{ logtoClient, isAuthenticated }}>
+    <LogtoContext.Provider
+      value={{ ...state, logtoClient, loginWithRedirect, handleCallback, logout }}
+    >
       {children}
     </LogtoContext.Provider>
   );

--- a/packages/react/src/reducer.ts
+++ b/packages/react/src/reducer.ts
@@ -1,0 +1,42 @@
+import { AuthState } from './auth-state';
+
+type Action =
+  | { type: 'INITIALIZE'; isAuthenticated: boolean }
+  | { type: 'LOGIN_WITH_REDIRECT' }
+  | { type: 'HANDLE_CALLBACK_REQUEST' }
+  | { type: 'HANDLE_CALLBACK_SUCCESS' }
+  | { type: 'LOGOUT' }
+  | { type: 'ERROR'; error: unknown };
+
+export const reducer = (state: AuthState, action: Action): AuthState => {
+  if (action.type === 'INITIALIZE') {
+    return { ...state, initialized: true, isAuthenticated: action.isAuthenticated };
+  }
+
+  if (action.type === 'LOGIN_WITH_REDIRECT') {
+    return { ...state, isLoading: true };
+  }
+
+  if (action.type === 'HANDLE_CALLBACK_REQUEST') {
+    return { ...state, isLoading: true, isAuthenticated: false };
+  }
+
+  if (action.type === 'HANDLE_CALLBACK_SUCCESS') {
+    return { ...state, isLoading: false, isAuthenticated: true };
+  }
+
+  if (action.type === 'LOGOUT') {
+    return { ...state, isAuthenticated: false };
+  }
+
+  if (action.type === 'ERROR') {
+    const { error } = action;
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    return { ...state, error, isLoading: false };
+  }
+
+  return state;
+};

--- a/packages/react/src/reducer.ts
+++ b/packages/react/src/reducer.ts
@@ -10,7 +10,7 @@ type Action =
 
 export const reducer = (state: AuthState, action: Action): AuthState => {
   if (action.type === 'INITIALIZE') {
-    return { ...state, initialized: true, isAuthenticated: action.isAuthenticated };
+    return { ...state, isInitialized: true, isAuthenticated: action.isAuthenticated };
   }
 
   if (action.type === 'LOGIN_WITH_REDIRECT') {
@@ -18,7 +18,7 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
   }
 
   if (action.type === 'HANDLE_CALLBACK_REQUEST') {
-    return { ...state, isLoading: true, isAuthenticated: false };
+    return { ...state, isLoading: true };
   }
 
   if (action.type === 'HANDLE_CALLBACK_SUCCESS') {

--- a/packages/react/src/use-logto.spec.tsx
+++ b/packages/react/src/use-logto.spec.tsx
@@ -51,11 +51,11 @@ describe('useLogto', () => {
     const { result, waitFor } = renderHook(() => useLogto(), {
       wrapper: createHookWrapper(),
     });
-    const { isAuthenticated, initialized } = result.current;
-    expect(initialized).toBeFalsy();
+    const { isAuthenticated, isInitialized } = result.current;
+    expect(isInitialized).toBeFalsy();
     await waitFor(() => {
-      const { initialized } = result.current;
-      expect(initialized).toBeTruthy();
+      const { isInitialized } = result.current;
+      expect(isInitialized).toBeTruthy();
     });
     expect(isAuthenticated).toBeFalsy();
   });
@@ -65,8 +65,8 @@ describe('useLogto', () => {
       wrapper: createHookWrapper(),
     });
     await waitFor(() => {
-      const { initialized } = result.current;
-      expect(initialized).toBeTruthy();
+      const { isInitialized } = result.current;
+      expect(isInitialized).toBeTruthy();
     });
     expect(result.current.isAuthenticated).toBeFalsy();
     await act(async () => result.current.handleCallback('url'));
@@ -82,8 +82,8 @@ describe('useLogto', () => {
       wrapper: createHookWrapper(),
     });
     await waitFor(() => {
-      const { initialized } = result.current;
-      expect(initialized).toBeTruthy();
+      const { isInitialized } = result.current;
+      expect(isInitialized).toBeTruthy();
     });
     expect(result.current.isAuthenticated).toBeFalsy();
     await act(async () => result.current.handleCallback('url'));

--- a/packages/react/src/use-logto.spec.tsx
+++ b/packages/react/src/use-logto.spec.tsx
@@ -7,23 +7,16 @@ import useLogto from './use-logto';
 const isAuthenticated = jest.fn();
 
 jest.mock('@logto/client', () => {
-  const Mocked = jest.fn(({ onAuthStateChange }: { onAuthStateChange: () => void }) => {
+  const Mocked = jest.fn(() => {
     return {
       isAuthenticated,
-      handleCallback: jest.fn(() => {
-        onAuthStateChange();
-      }),
-      logout: jest.fn(() => {
-        onAuthStateChange();
-      }),
+      handleCallback: jest.fn(),
+      logout: jest.fn(),
     };
   });
   return {
     default: Mocked,
-    create: jest.fn(
-      ({ onAuthStateChange }: { onAuthStateChange: () => void }) =>
-        new Mocked({ onAuthStateChange })
-    ),
+    create: jest.fn(() => new Mocked()),
   };
 });
 
@@ -58,51 +51,49 @@ describe('useLogto', () => {
     const { result, waitFor } = renderHook(() => useLogto(), {
       wrapper: createHookWrapper(),
     });
-    const { isAuthenticated, isLoading } = result.current;
-    expect(isLoading).toBeTruthy();
+    const { isAuthenticated, initialized } = result.current;
+    expect(initialized).toBeFalsy();
     await waitFor(() => {
-      const { isLoading } = result.current;
-      expect(isLoading).toBeFalsy();
+      const { initialized } = result.current;
+      expect(initialized).toBeTruthy();
     });
     expect(isAuthenticated).toBeFalsy();
   });
 
   test('change from not authenticated to authenticated', async () => {
-    isAuthenticated.mockImplementationOnce(() => true);
     const { result, waitFor } = renderHook(() => useLogto(), {
       wrapper: createHookWrapper(),
     });
-    const { isLoading } = result.current;
-    expect(isLoading).toBeTruthy();
+    await waitFor(() => {
+      const { initialized } = result.current;
+      expect(initialized).toBeTruthy();
+    });
+    expect(result.current.isAuthenticated).toBeFalsy();
+    await act(async () => result.current.handleCallback('url'));
     await waitFor(() => {
       const { isLoading } = result.current;
       expect(isLoading).toBeFalsy();
-    });
-    expect(result.current.isAuthenticated).toBeFalsy();
-    act(() => {
-      result.current.logtoClient?.handleCallback('url');
     });
     expect(result.current.isAuthenticated).toBeTruthy();
   });
 
   test('change from authenticated to not authenticated', async () => {
-    isAuthenticated.mockImplementationOnce(() => true).mockImplementationOnce(() => false);
     const { result, waitFor } = renderHook(() => useLogto(), {
       wrapper: createHookWrapper(),
     });
-    const { isLoading } = result.current;
-    expect(isLoading).toBeTruthy();
+    await waitFor(() => {
+      const { initialized } = result.current;
+      expect(initialized).toBeTruthy();
+    });
+    expect(result.current.isAuthenticated).toBeFalsy();
+    await act(async () => result.current.handleCallback('url'));
     await waitFor(() => {
       const { isLoading } = result.current;
       expect(isLoading).toBeFalsy();
     });
-    expect(result.current.isAuthenticated).toBeFalsy();
-    act(() => {
-      result.current.logtoClient?.handleCallback('url');
-    });
     expect(result.current.isAuthenticated).toBeTruthy();
     act(() => {
-      result.current.logtoClient?.logout('url');
+      result.current.logout('url');
     });
     expect(result.current.isAuthenticated).toBeFalsy();
   });

--- a/packages/react/src/use-logto.ts
+++ b/packages/react/src/use-logto.ts
@@ -9,13 +9,5 @@ export default function useLogto() {
     throw new Error('useLogto hook must be used inside LogtoProvider context');
   }
 
-  const { logtoClient, isAuthenticated } = context;
-
-  const isLoading = !logtoClient;
-
-  return {
-    logtoClient,
-    isLoading,
-    isAuthenticated,
-  };
+  return context;
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Need a better state management for react SDK, use `useReducer` to manage login flows.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

reuse `use-logto.spec.tsx`