### PR TITLE
feat(js): add state value to prevent csrf attacking

### DIFF
--- a/packages/client/src/parse-callback.test.ts
+++ b/packages/client/src/parse-callback.test.ts
@@ -11,6 +11,6 @@ describe('parseRedirectCallback', () => {
   });
 
   test('no query params should fail', () => {
-    expect(() => parseRedirectCallback('http://localhost:3000')).toThrow();
+    expect(parseRedirectCallback('http://localhost:3000')).toHaveProperty('error');
   });
 });

--- a/packages/client/src/parse-callback.ts
+++ b/packages/client/src/parse-callback.ts
@@ -2,17 +2,17 @@ import qs from 'query-string';
 
 export interface AuthenticationResult {
   code?: string;
+  state?: string;
   error?: string;
   error_description?: string;
 }
 
-export const parseRedirectCallback = (url: string) => {
+export const parseRedirectCallback = (url: string): AuthenticationResult => {
   const [, queryString] = url.split('?');
   if (!queryString) {
-    throw new Error('There are no query params available for parsing.');
+    return { error: 'There are no query params available for parsing.' };
   }
 
-  const result = qs.parse(queryString) as AuthenticationResult;
-
+  const result = qs.parse(queryString);
   return result;
 };

--- a/packages/client/src/request-login.test.ts
+++ b/packages/client/src/request-login.test.ts
@@ -1,11 +1,108 @@
-import { getLoginUrlAndCodeVerifier } from './request-login';
+import { DEFAULT_SCOPE_STRING } from './constants';
+import { getLoginUrlWithCodeVerifierAndState } from './request-login';
 
-test('getLoginUrlAndCodeVerifier', async () => {
-  const { url } = await getLoginUrlAndCodeVerifier({
-    baseUrl: 'http://logto.dev/oidc/auth',
-    clientId: 'foo',
-    scope: 'openid offline_access',
-    redirectUri: 'http://localhost:3000',
+const BASE_URL = 'http://logto.dev/oidc/auth';
+const CLIENT_ID = 'foo';
+const REDIRECT_URI = 'http://localhost:3000';
+
+describe('getLoginUrlWithCodeVerifierAndState', () => {
+  test('url must start with baseUrl', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url.startsWith(BASE_URL)).toBeTruthy();
   });
-  expect(url).toContain('code_challenge_method=S256');
+
+  test('url must contain expected client_id', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain(`client_id=${CLIENT_ID}`);
+  });
+
+  test('url must contains expected scope', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain(`scope=${encodeURI(DEFAULT_SCOPE_STRING)}`);
+  });
+
+  test('url must contain expected response_type', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain('response_type=code');
+  });
+
+  test('url must contain expected redirect_uri', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain(`redirect_uri=${encodeURIComponent(REDIRECT_URI)}`);
+  });
+
+  test('url must contain expected prompt', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain('prompt=consent');
+  });
+
+  test('url must contain expected redirect_uri', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain(`redirect_uri=${encodeURIComponent(REDIRECT_URI)}`);
+  });
+
+  test('url must contain expected code_challenge', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url.search('code_challenge=[^&=]+')).toBeGreaterThan(0);
+  });
+
+  test('url must contain expected code_challenge_method', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url).toContain('code_challenge_method=S256');
+  });
+
+  test('url must contain expected state', async () => {
+    const { url } = await getLoginUrlWithCodeVerifierAndState({
+      baseUrl: BASE_URL,
+      clientId: CLIENT_ID,
+      scope: DEFAULT_SCOPE_STRING,
+      redirectUri: REDIRECT_URI,
+    });
+    expect(url.search('state=[^&=]+')).toBeGreaterThan(0);
+  });
 });

--- a/packages/client/src/request-login.ts
+++ b/packages/client/src/request-login.ts
@@ -1,6 +1,6 @@
 import qs from 'query-string';
 
-import { generateCodeChallenge, generateCodeVerifier } from './generators';
+import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators';
 
 export interface LoginPrepareParameters {
   baseUrl: string;
@@ -9,12 +9,13 @@ export interface LoginPrepareParameters {
   redirectUri: string;
 }
 
-export const getLoginUrlAndCodeVerifier = async (
+export const getLoginUrlWithCodeVerifierAndState = async (
   parameters: LoginPrepareParameters
-): Promise<{ url: string; codeVerifier: string }> => {
+): Promise<{ url: string; codeVerifier: string; state: string }> => {
   const { baseUrl, clientId, scope, redirectUri } = parameters;
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateState();
 
   const url = `${baseUrl}?${qs.stringify({
     client_id: clientId,
@@ -24,7 +25,8 @@ export const getLoginUrlAndCodeVerifier = async (
     prompt: 'consent',
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
+    state,
   })}`;
 
-  return { url, codeVerifier };
+  return { url, codeVerifier, state };
 };

--- a/packages/client/src/session-manager.test.ts
+++ b/packages/client/src/session-manager.test.ts
@@ -1,10 +1,11 @@
 import { SESSION_MANAGER_KEY } from './constants';
-import SessionManager from './session-manager';
+import SessionManager, { Session } from './session-manager';
 import { SessionStorage } from './storage';
 
-const transaction = {
+const transaction: Session = {
   codeVerifier: 'codeVerifier',
   redirectUri: 'redirectUri',
+  state: 'state',
 };
 
 describe('SessionManager', () => {

--- a/packages/client/src/session-manager.ts
+++ b/packages/client/src/session-manager.ts
@@ -3,9 +3,10 @@ import { Optional } from '@silverhand/essentials';
 import { SESSION_EXPIRES_MILLISECONDS, SESSION_MANAGER_KEY } from './constants';
 import { ClientStorage } from './storage';
 
-interface Session {
+export interface Session {
   codeVerifier: string;
   redirectUri: string;
+  state: string;
 }
 
 export default class SessionManager {

--- a/packages/client/src/utils.test.ts
+++ b/packages/client/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPair, SignJWT } from 'jose';
+import { SignJWT, generateKeyPair } from 'jose';
 import { StructError } from 'superstruct';
 
 import { decodeToken } from './utils';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Login with random state value to prevent csrf attacking
    - Related notion doc : https://www.notion.so/silverhand/OAuth-2-0-Security-b7b1f43d5c784b599c084d3ff356525c

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- Pass all existing tests

- Add necessary test cases for `getLoginUrlAndCodeVerifier` method

- `handleCallback` require correct `state` parameter value in url so updated related unit tests

- `isLoginRedirect` require a `state` parameter value ( but do not need to confirm its correctness ) in url so updated related unit tests

- **Testing on js/playground**

    1. loginWithRedirect : 

        i. generate state

        ![image](https://user-images.githubusercontent.com/10594507/141422102-4e40d897-b56f-450c-a034-84b02c40d407.png)

        ii. save state

        ![image](https://user-images.githubusercontent.com/10594507/141422150-8a5d51bb-3122-400b-af71-69f47d86aa44.png)

    2. handleCallback : get and check state

        ![image](https://user-images.githubusercontent.com/10594507/141422280-fe8f24b1-7113-4232-87b6-45dfe8e69969.png)

    3. succeed to login

        ![image](https://user-images.githubusercontent.com/10594507/141422303-24ee8ed4-5f56-44f7-af9f-5a30d3ae323f.png)


