### PR TITLE
feat(client): support node

### DIFF
--- a/packages/client/src/api.test.ts
+++ b/packages/client/src/api.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+
+import { createRequester } from './api';
+
+describe('api (NodeJS)', () => {
+  test('should throw on empty fetchFunction', () => {
+    expect(() => createRequester()).toThrowError('You should provide a fetch function in NodeJS');
+  });
+});

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,3 +1,5 @@
+import { isNode } from '@silverhand/essentials';
+
 import { LogtoError } from './errors';
 
 declare interface LogtoErrorResponse {
@@ -18,9 +20,13 @@ const getResponseErrorMessage = async (response: Response): Promise<string> => {
   }
 };
 
-export const createRequester = (fetchFunction: typeof fetch = fetch) => {
+export const createRequester = (fetchFunction?: typeof fetch) => {
+  if (!fetchFunction && isNode()) {
+    throw new Error('You should provide a fetch function in NodeJS');
+  }
+
   return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
-    const response = await fetchFunction(...args);
+    const response = await (fetchFunction ?? fetch)(...args);
     if (!response.ok) {
       throw new LogtoError({
         message: await getResponseErrorMessage(response),

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -18,15 +18,19 @@ const getResponseErrorMessage = async (response: Response): Promise<string> => {
   }
 };
 
-export const requestWithFetch = async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
-  const response = await fetch(...args);
-  if (!response.ok) {
-    throw new LogtoError({
-      message: await getResponseErrorMessage(response),
-      response,
-    });
-  }
+export const createRequester = (fetchFunction: typeof fetch = fetch) => {
+  return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
+    const response = await fetchFunction(...args);
+    if (!response.ok) {
+      throw new LogtoError({
+        message: await getResponseErrorMessage(response),
+        response,
+      });
+    }
 
-  const data = (await response.json()) as T;
-  return data;
+    const data = (await response.json()) as T;
+    return data;
+  };
 };
+
+export type Requester = ReturnType<typeof createRequester>;

--- a/packages/client/src/discover.ts
+++ b/packages/client/src/discover.ts
@@ -1,6 +1,6 @@
 import * as s from 'superstruct';
 
-import { requestWithFetch } from './api';
+import { createRequester, Requester } from './api';
 import { LogtoError } from './errors';
 
 const OIDCConfigurationSchema = s.type({
@@ -22,8 +22,11 @@ const appendSlashIfNeeded = (url: string): string => {
   return url + '/';
 };
 
-export default async function discover(url: string): Promise<OIDCConfiguration> {
-  const response = await requestWithFetch<OIDCConfiguration>(
+export default async function discover(
+  url: string,
+  requester: Requester = createRequester()
+): Promise<OIDCConfiguration> {
+  const response = await requester<OIDCConfiguration>(
     `${appendSlashIfNeeded(url)}oidc/.well-known/openid-configuration`
   );
 

--- a/packages/client/src/grant-token.test.ts
+++ b/packages/client/src/grant-token.test.ts
@@ -62,11 +62,11 @@ describe('grantTokenByRefreshToken', () => {
       .post('/oidc/token')
       .reply(200, successResponse);
 
-    const tokenSet = await grantTokenByRefreshToken(
-      'https://logto.dev/oidc/token',
-      'client_id',
-      'refresh_token'
-    );
+    const tokenSet = await grantTokenByRefreshToken({
+      endpoint: 'https://logto.dev/oidc/token',
+      clientId: 'client_id',
+      refreshToken: 'refresh_token',
+    });
 
     expect(tokenSet).toMatchObject(successResponse);
   });

--- a/packages/client/src/grant-token.ts
+++ b/packages/client/src/grant-token.ts
@@ -1,6 +1,6 @@
 import * as s from 'superstruct';
 
-import { requestWithFetch } from './api';
+import { createRequester, Requester } from './api';
 import { LogtoError } from './errors';
 
 const TokenSetParametersSchema = s.type({
@@ -12,7 +12,7 @@ const TokenSetParametersSchema = s.type({
 
 export type TokenSetParameters = s.Infer<typeof TokenSetParametersSchema>;
 
-type GrantTokenPayload = {
+type GrantTokenByAuthorizationPayload = {
   endpoint: string;
   code: string;
   redirectUri: string;
@@ -20,13 +20,10 @@ type GrantTokenPayload = {
   clientId: string;
 };
 
-export const grantTokenByAuthorizationCode = async ({
-  endpoint,
-  code,
-  redirectUri,
-  codeVerifier,
-  clientId,
-}: GrantTokenPayload): Promise<TokenSetParameters> => {
+export const grantTokenByAuthorizationCode = async (
+  { endpoint, code, redirectUri, codeVerifier, clientId }: GrantTokenByAuthorizationPayload,
+  requester: Requester = createRequester()
+): Promise<TokenSetParameters> => {
   const parameters = new URLSearchParams();
   parameters.append('grant_type', 'authorization_code');
   parameters.append('code', code);
@@ -34,7 +31,7 @@ export const grantTokenByAuthorizationCode = async ({
   parameters.append('code_verifier', codeVerifier);
   parameters.append('client_id', clientId);
 
-  const response = await requestWithFetch(endpoint, {
+  const response = await requester(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -54,17 +51,22 @@ export const grantTokenByAuthorizationCode = async ({
   }
 };
 
+type GrantTokenByRefreshTokenPayload = {
+  endpoint: string;
+  refreshToken: string;
+  clientId: string;
+};
+
 export const grantTokenByRefreshToken = async (
-  endpoint: string,
-  clientId: string,
-  refreshToken: string
+  { endpoint, clientId, refreshToken }: GrantTokenByRefreshTokenPayload,
+  requester: Requester = createRequester()
 ): Promise<TokenSetParameters> => {
   const parameters = new URLSearchParams();
   parameters.append('grant_type', 'refresh_token');
   parameters.append('client_id', clientId);
   parameters.append('refresh_token', refreshToken);
 
-  const response = await requestWithFetch(endpoint, {
+  const response = await requester(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,6 +15,7 @@ import { getLogoutUrl } from './request-logout';
 import SessionManager from './session-manager';
 import { ClientStorage, LocalStorage } from './storage';
 import TokenSet from './token-set';
+import { createDefaultOnRedirect } from './utils';
 import { createJWKS, verifyIdToken } from './verify-id-token';
 
 export * from './storage';
@@ -66,7 +67,7 @@ export default class LogtoClient {
 
   public async loginWithRedirect(
     redirectUri: string,
-    onRedirect: (url: string) => void = window.location.assign
+    onRedirect: (url: string) => void = createDefaultOnRedirect()
   ) {
     const { url, codeVerifier } = await getLoginUrlAndCodeVerifier({
       baseUrl: this.oidcConfiguration.authorization_endpoint,
@@ -179,7 +180,10 @@ export default class LogtoClient {
     return this.tokenSet.accessToken;
   }
 
-  public logout(redirectUri: string, onRedirect: (url: string) => void = window.location.assign) {
+  public logout(
+    redirectUri: string,
+    onRedirect: (url: string) => void = createDefaultOnRedirect()
+  ) {
     this.sessionManager.clear();
     if (this.onAuthStateChange) {
       this.onAuthStateChange();

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -1,3 +1,4 @@
+import { isNode } from '@silverhand/essentials';
 import * as s from 'superstruct';
 
 const fullfillBase64 = (input: string) => {
@@ -57,3 +58,11 @@ export const decodeToken = (token: string): IDToken => {
 };
 
 export const nowRoundToSec = () => Math.floor(Date.now() / 1000);
+
+export const createDefaultOnRedirect = () => {
+  if (isNode()) {
+    throw new Error('You should provide a onRedirect function in NodeJS');
+  }
+
+  return window.location.assign;
+};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Do 2 things to support running both in node and browser(already supported):

1. can pass in custom `fetchFunction` in constructer
2. onRedirect parameter, defaults to `window.location.assign`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

change `testEnvironment` to `node` and run test for file `index.test.ts`