### PR TITLE
test(react): mock isLoginRedirect to fix test

### DIFF
--- a/packages/react/src/ProtectedRoute.spec.tsx
+++ b/packages/react/src/ProtectedRoute.spec.tsx
@@ -7,19 +7,25 @@ import ProtectedRoute from './ProtectedRoute';
 
 const loginWithRedirect = jest.fn();
 const isAuthenticated = jest.fn();
+const isLoginRedirect = jest.fn();
 
 jest.mock('@logto/client', () => {
-  const Mocked = jest.fn().mockImplementation(() => {
+  const Mocked = jest.fn(() => {
     return {
-      loginWithRedirect,
       isAuthenticated,
+      isLoginRedirect,
+      loginWithRedirect,
     };
   });
   return {
     default: Mocked,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    create: jest.fn().mockImplementation(() => new Mocked()),
+    create: jest.fn(() => new Mocked()),
   };
+});
+
+afterEach(() => {
+  isAuthenticated.mockClear();
+  isLoginRedirect.mockClear();
 });
 
 const renderWrapper = (children: React.ReactNode) => {
@@ -55,7 +61,7 @@ describe('ProtectedRoute', () => {
         expect(loginWithRedirect).toHaveBeenCalled();
       });
 
-      expect(loginWithRedirect).toHaveBeenCalledTimes(1);
+      expect(loginWithRedirect).toHaveBeenCalled();
     });
 
     test('protected content should not be rendered', async () => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Since #92 , `isLoginRedirect` will be called automaticly, but is not mocked in `ProtectedRoute.spec.tsx`, causing test failed.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->