### PR TITLE
fix(client): wrap window.location.assign

### DIFF
--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -64,5 +64,7 @@ export const createDefaultOnRedirect = () => {
     throw new Error('You should provide a onRedirect function in NodeJS');
   }
 
-  return window.location.assign;
+  return (url: string) => {
+    window.location.assign(url);
+  };
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

fix the problem:

<img width="561" alt="截屏2021-11-16 下午4 45 29" src="https://user-images.githubusercontent.com/5717882/141952952-54d4a766-fa44-4e60-af88-368ec0eee48f.png">

a possible reason is that returning `window.location.assign` directly will lose context

[https://stackoverflow.com/questions/10743596/why-are-certain-function-calls-termed-illegal-invocations-in-javascript](https://stackoverflow.com/questions/10743596/why-are-certain-function-calls-termed-illegal-invocations-in-javascript)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->