### PR TITLE
refactor(client): replace whitespaces in tokenSetCacheKey

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -24,7 +24,9 @@ const CLIENT_ID = 'client1';
 const SUBJECT = 'subject1';
 const REDIRECT_URI = 'http://localhost:3000';
 const CODE = 'code1';
-const LOGTO_TOKEN_SET_CACHE_KEY = `LOGTO_TOKEN_SET_CACHE::${ISSUER}::${CLIENT_ID}::${DEFAULT_SCOPE_STRING}`;
+const LOGTO_TOKEN_SET_CACHE_KEY = encodeURIComponent(
+  `LOGTO_TOKEN_SET_CACHE::${ISSUER}::${CLIENT_ID}::${DEFAULT_SCOPE_STRING}`
+);
 
 const discoverResponse = {
   authorization_endpoint: `${BASE_URL}/oidc/auth`,
@@ -421,7 +423,9 @@ describe('LogtoClient', () => {
       const onAuthStateChange = jest.fn();
       const storage = new MemoryStorage();
       storage.setItem(
-        `LOGTO_TOKEN_SET_CACHE::${discoverResponse.issuer}::${CLIENT_ID}::${DEFAULT_SCOPE_STRING}`,
+        encodeURIComponent(
+          `LOGTO_TOKEN_SET_CACHE::${discoverResponse.issuer}::${CLIENT_ID}::${DEFAULT_SCOPE_STRING}`
+        ),
         {
           ...fakeTokenResponse,
           id_token: (await generateIdToken()).idToken,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -210,7 +210,9 @@ export default class LogtoClient {
   }
 
   private get tokenSetCacheKey() {
-    return `${TOKEN_SET_CACHE_KEY}::${this.oidcConfiguration.issuer}::${this.clientId}::${this.scope}`;
+    return encodeURIComponent(
+      `${TOKEN_SET_CACHE_KEY}::${this.oidcConfiguration.issuer}::${this.clientId}::${this.scope}`
+    );
   }
 
   private createTokenSetFromCache() {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Replace whitespaces in `tokenSetCacheKey` via `encodeURI` method
    - Fix related unit tests.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing unit tests.