### PR TITLE
chore(client): remove useless uri property in LogtoError

### DIFF
--- a/packages/client/src/modules/errors.ts
+++ b/packages/client/src/modules/errors.ts
@@ -7,7 +7,6 @@ interface LogtoErrorParameters {
 }
 
 export class LogtoError extends Error {
-  public uri?: string;
   public response?: Response;
   public cause?: Error | StructError;
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- The property `uri` is unnecessary in LogtoError now.
- Reference: https://www.notion.so/silverhand/Error-Handling-Conventions-fc4b89a0d3bb456699da61dd8f3f997f

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passing all existing tests