### PR TITLE
test: add test coverage scripts and actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   main:
@@ -16,8 +16,7 @@ jobs:
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v1.0.2
         with:
-          node-version:
-            16
+          node-version: 16
 
       - name: Build
         run: pnpm -- lerna run --stream build
@@ -27,3 +26,9 @@ jobs:
 
       - name: Test
         run: pnpm -- lerna run --parallel test
+
+      - name: Coverage
+        uses: artiomtr/jest-coverage-report-action@v1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          threshold: 80

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,7 @@ jobs:
         run: pnpm -- lerna run --parallel lint
 
       - name: Test
-        run: pnpm -- lerna run --parallel test
+        run: pnpm -- lerna run --parallel test:coverage
 
-      - name: Coverage
-        uses: artiomtr/jest-coverage-report-action@v1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          threshold: 80
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # testing
 /packages/*/coverage
+/coverage/*
 
 # production
 /packages/*/dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ node_modules
 
 # testing
 /packages/*/coverage
-/coverage/*
 
 # production
 /packages/*/dist

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 50%
+      core:
+        flags: core
+      react:
+        flags: react
+      playground:
+        flags: playground
+      react-playground:
+        flags: react-playground
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+flag:
+  core:
+    paths:
+      - packages/client
+  react:
+    paths:
+      - packages/react
+  playground:
+    paths:
+      - packages/playround
+  react-playground:
+    paths:
+      - packages/react-playground

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -7,4 +7,20 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],
+  collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    './src/**/*.{ts,tsx,js}': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  coverageReporters: ['json', 'html'],
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -8,19 +8,5 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],
   collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
-  coverageThreshold: {
-    global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-    './src/**/*.{ts,tsx,js}': {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-  },
-  coverageReporters: ['json', 'html'],
+  coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
 };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint --ext .ts src",
     "package": "webpack",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "prepublish": "npm run build && npm run package",
     "report": "WITH_REPORT=true npm run package"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .ts src",
     "package": "webpack",
     "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --silent --coverage",
     "prepublish": "npm run build && npm run package",
     "report": "WITH_REPORT=true npm run package"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --format pretty --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
+    "test:coverage": "razzle test --env=jsdom --coverage",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --format pretty --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
-    "test:coverage": "razzle test --env=jsdom --coverage",
+    "test:coverage": "razzle test --env=jsdom --silent --coverage",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -39,7 +39,6 @@ module.exports = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
       collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
-      coverageReporters: ['json', 'html'],
       coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
     };
 

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -34,16 +34,32 @@ module.exports = {
   },
   modifyJestConfig: ({ jestConfig }) => {
     /** @type {import('@jest/types').Config.InitialOptions} **/
-    const config = { ...jestConfig };
+    const config = {
+      ...jestConfig,
+      setupFilesAfterEnv: ['./jest.setup.js'],
+      collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+      coverageReporters: ['json', 'html'],
+      coverageThreshold: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+        './src/**/*.{ts,tsx,js}': {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    };
 
     config.moduleNameMapper = {
       ...config.moduleNameMapper,
       '^.+\\.(css|less|scss)$': 'babel-jest',
       '@/(.*)': '<rootDir>/src/$1',
     };
-
-    config.setupFilesAfterEnv =['./jest.setup.js'];
-
     return config;
   },
 };

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -34,25 +34,13 @@ module.exports = {
   },
   modifyJestConfig: ({ jestConfig }) => {
     /** @type {import('@jest/types').Config.InitialOptions} **/
+
     const config = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
       collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
       coverageReporters: ['json', 'html'],
-      coverageThreshold: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-        './src/**/*.{ts,tsx,js}': {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
+      coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
     };
 
     config.moduleNameMapper = {

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --format pretty --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
+    "test:coverage": "razzle test --env=jsdom --coverage",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --format pretty --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
-    "test:coverage": "razzle test --env=jsdom --coverage",
+    "test:coverage": "razzle test --env=jsdom --silent --coverage",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {

--- a/packages/react-playground/razzle.config.js
+++ b/packages/react-playground/razzle.config.js
@@ -34,15 +34,32 @@ module.exports = {
   },
   modifyJestConfig: ({ jestConfig }) => {
     /** @type {import('@jest/types').Config.InitialOptions} **/
-    const config = { ...jestConfig };
+    const config = {
+      ...jestConfig,
+      setupFilesAfterEnv: ['./jest.setup.js'],
+      collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+      coverageReporters: ['json', 'html'],
+      coverageThreshold: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+        './src/**/*.{ts,tsx,js}': {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    };
 
     config.moduleNameMapper = {
       ...config.moduleNameMapper,
       '^.+\\.(css|less|scss)$': 'babel-jest',
       '@/(.*)': '<rootDir>/src/$1',
     };
-
-    config.setupFilesAfterEnv =['./jest.setup.js'];
 
     return config;
   },

--- a/packages/react-playground/razzle.config.js
+++ b/packages/react-playground/razzle.config.js
@@ -38,21 +38,7 @@ module.exports = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
       collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
-      coverageReporters: ['json', 'html'],
-      coverageThreshold: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-        './src/**/*.{ts,tsx,js}': {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
+      coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
     };
 
     config.moduleNameMapper = {

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -6,4 +6,20 @@ module.exports = {
   testPathIgnorePatterns: ['lib'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
+  collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    './src/**/*.{ts,tsx,js}': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  coverageReporters: ['json', 'html'],
 };

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -7,19 +7,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
   collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
-  coverageThreshold: {
-    global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-    './src/**/*.{ts,tsx,js}': {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-  },
-  coverageReporters: ['json', 'html'],
+  coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,6 +44,7 @@
     "lint": "eslint --ext .ts src",
     "build": "tsc",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "prepublish": "npm run build"
   },
   "bugs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint --ext .ts src",
     "build": "tsc",
     "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --silent --coverage",
     "prepublish": "npm run build"
   },
   "bugs": {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Add test coverage scripts and actions, with coverage threshold set to 80%.
 - client
 - react
 - playground
 - react-playground

script: `pnpm test:coverage`
reportpath: `/coverage`


<!-- MANDATORY -->
## Testing
test locally
![image](https://user-images.githubusercontent.com/36393111/148007505-e9fc157b-cbf5-4ac4-9ce3-b65cf820dd39.png)

![image](https://user-images.githubusercontent.com/36393111/148007577-0234783b-edb2-4e78-b056-e15be16787b5.png)

@logto-io/eng 

<!-- How did you test this PR? -->