### PR TITLE
fix(ci): fix jest coverage file extension bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
         run: pnpm -- lerna run --parallel test:coverage
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v2
+        run: pnpm -- lerna run --parallel test:report

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,36 +1,25 @@
+comment: false
+
 coverage:
+  require_changes: true
   status:
     project:
       default:
-        target: 80%
-        threshold: 50%
+        target: 70
       client:
         flags:
           - client
-        target: 80%
-        threshold: 80%
       react:
         flags:
           - react
-        target: 80%
-        threshold: 50%
       playground:
         flags:
           - playground
-        target: 1%
-        threshold: 1%
       react-playground:
         flags:
           - react-playground
-        target: 1%
-        threshold: 1%
 
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false
-
-flag:
+flags:
   client:
     paths:
       - ./packages/client

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,14 +4,26 @@ coverage:
       default:
         target: 80%
         threshold: 50%
-      core:
-        flags: core
+      client:
+        flags:
+          - client
+        target: 80%
+        threshold: 80%
       react:
-        flags: react
+        flags:
+          - react
+        target: 80%
+        threshold: 50%
       playground:
-        flags: playground
+        flags:
+          - playground
+        target: 1%
+        threshold: 1%
       react-playground:
-        flags: react-playground
+        flags:
+          - react-playground
+        target: 1%
+        threshold: 1%
 
 comment:
   layout: "reach, diff, flags, files"
@@ -19,15 +31,15 @@ comment:
   require_changes: false
 
 flag:
-  core:
+  client:
     paths:
-      - packages/client
+      - ./packages/client
   react:
     paths:
-      - packages/react
+      - ./packages/react
   playground:
     paths:
-      - packages/playround
+      - ./packages/playround
   react-playground:
     paths:
-      - packages/react-playground
+      - ./packages/react-playground

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],
-  collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
   coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
-  coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
+  coverageReporters: ['text-summary', 'lcov'],
 };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,7 @@
     "package": "webpack",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
+    "test:report": "codecov -F client",
     "prepublish": "npm run build && npm run package",
     "report": "WITH_REPORT=true npm run package"
   },
@@ -30,6 +31,7 @@
     "@silverhand/ts-config": "^0.5.0",
     "@types/jest": "^26.0.24",
     "@types/webpack": "^5.28.0",
+    "codecov": "^3.8.3",
     "eslint": "^8.1.0",
     "jest": "^27.0.6",
     "lint-staged": "^11.1.2",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,6 +15,7 @@
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
     "test:coverage": "razzle test --env=jsdom --silent --coverage",
+    "test:report": "codecov -F playground",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "@types/react-router-dom": "^5.1.7",
     "@types/webpack-env": "^1.16.0",
     "babel-preset-razzle": "^4.2.6",
+    "codecov": "^3.8.3",
     "concurrently": "^6.2.0",
     "eslint": "^8.1.0",
     "eslint-formatter-pretty": "^4.1.0",

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -39,7 +39,7 @@ module.exports = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
       coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
-      coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
+      coverageReporters: ['text-summary', 'lcov'],
     };
 
     config.moduleNameMapper = {

--- a/packages/playground/razzle.config.js
+++ b/packages/playground/razzle.config.js
@@ -38,7 +38,7 @@ module.exports = {
     const config = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
-      collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+      coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
       coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
     };
 

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -14,6 +14,7 @@
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "razzle test --env=jsdom",
     "test:coverage": "razzle test --env=jsdom --silent --coverage",
+    "test:report": "codecov -F react-playground",
     "report": "WITH_REPORT=true razzle build"
   },
   "dependencies": {
@@ -32,6 +33,7 @@
     "@types/react": "^17.0.35",
     "@types/react-router-dom": "^5.3.2",
     "babel-preset-razzle": "4.2.7",
+    "codecov": "^3.8.3",
     "concurrently": "^6.2.0",
     "eslint": "^8.2.0",
     "eslint-formatter-pretty": "^4.1.0",

--- a/packages/react-playground/razzle.config.js
+++ b/packages/react-playground/razzle.config.js
@@ -38,7 +38,7 @@ module.exports = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
       coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
-      coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
+      coverageReporters: ['text-summary', 'lcov'],
     };
 
     config.moduleNameMapper = {

--- a/packages/react-playground/razzle.config.js
+++ b/packages/react-playground/razzle.config.js
@@ -37,7 +37,7 @@ module.exports = {
     const config = {
       ...jestConfig,
       setupFilesAfterEnv: ['./jest.setup.js'],
-      collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+      coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
       coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
     };
 

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -7,5 +7,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
-  coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
+  coverageReporters: ['text-summary', 'lcov'],
 };

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -6,6 +6,6 @@ module.exports = {
   testPathIgnorePatterns: ['lib'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testEnvironment: 'jsdom',
-  collectCoverageFrom: ['**/*.{ts, tsx, js}', '!**/node_modules/**', '!**/lib/**'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
   coverageReporters: ['json', 'html', 'text-summary', 'lcov'],
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,6 +16,7 @@
     "@types/jest": "^26.0.24",
     "@types/react": "^17.0.33",
     "@types/react-router-dom": "^5.3.2",
+    "codecov": "^3.8.3",
     "eslint": "^8.1.0",
     "jest": "^27.0.6",
     "lint-staged": "^11.1.2",
@@ -45,6 +46,7 @@
     "build": "tsc",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
+    "test:report": "codecov -F react",
     "prepublish": "npm run build"
   },
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ importers:
       '@silverhand/ts-config': ^0.5.0
       '@types/jest': ^26.0.24
       '@types/webpack': ^5.28.0
+      codecov: ^3.8.3
       eslint: ^8.1.0
       jest: ^27.0.6
       jose: ^4.1.4
@@ -57,6 +58,7 @@ importers:
       '@silverhand/ts-config': 0.5.0_typescript@4.3.5
       '@types/jest': 26.0.24
       '@types/webpack': 5.28.0_webpack-cli@4.9.1
+      codecov: 3.8.3
       eslint: 8.2.0
       jest: 27.0.6
       lint-staged: 11.1.2
@@ -85,6 +87,7 @@ importers:
       '@types/react-router-dom': ^5.1.7
       '@types/webpack-env': ^1.16.0
       babel-preset-razzle: ^4.2.6
+      codecov: ^3.8.3
       concurrently: ^6.2.0
       eslint: ^8.1.0
       eslint-formatter-pretty: ^4.1.0
@@ -127,6 +130,7 @@ importers:
       '@types/react-router-dom': 5.3.2
       '@types/webpack-env': 1.16.3
       babel-preset-razzle: 4.2.6
+      codecov: 3.8.3
       concurrently: 6.3.0
       eslint: 8.2.0
       eslint-formatter-pretty: 4.1.0
@@ -157,6 +161,7 @@ importers:
       '@types/jest': ^26.0.24
       '@types/react': ^17.0.33
       '@types/react-router-dom': ^5.3.2
+      codecov: ^3.8.3
       eslint: ^8.1.0
       jest: ^27.0.6
       lint-staged: ^11.1.2
@@ -178,6 +183,7 @@ importers:
       '@types/jest': 26.0.24
       '@types/react': 17.0.33
       '@types/react-router-dom': 5.3.2
+      codecov: 3.8.3
       eslint: 8.2.0
       jest: 27.0.6
       lint-staged: 11.1.2
@@ -201,6 +207,7 @@ importers:
       '@types/react': ^17.0.35
       '@types/react-router-dom': ^5.3.2
       babel-preset-razzle: 4.2.7
+      codecov: ^3.8.3
       concurrently: ^6.2.0
       eslint: ^8.2.0
       eslint-formatter-pretty: ^4.1.0
@@ -235,6 +242,7 @@ importers:
       '@types/react': 17.0.35
       '@types/react-router-dom': 5.3.2
       babel-preset-razzle: 4.2.7
+      codecov: 3.8.3
       concurrently: 6.3.0
       eslint: 8.2.0
       eslint-formatter-pretty: 4.1.0
@@ -4439,6 +4447,11 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /argv/0.0.2:
+    resolution: {integrity: sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=}
+    engines: {node: '>=0.6.10'}
+    dev: true
+
   /aria-query/5.0.0:
     resolution: {integrity: sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==}
     engines: {node: '>=6.0'}
@@ -5677,6 +5690,21 @@ packages:
   /code-point-at/1.1.0:
     resolution: {integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /codecov/3.8.3:
+    resolution: {integrity: sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==}
+    engines: {node: '>=4.0'}
+    deprecated: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
+    hasBin: true
+    dependencies:
+      argv: 0.0.2
+      ignore-walk: 3.0.4
+      js-yaml: 3.14.1
+      teeny-request: 7.1.1
+      urlgrey: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /collect-v8-coverage/1.0.1:
@@ -7118,7 +7146,7 @@ packages:
       '@typescript-eslint/eslint-plugin': '>=4.28.1'
       eslint: '>=7.30.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.6.0_85c6ab1406c522bb26958d9e32219a86
+      '@typescript-eslint/eslint-plugin': 5.6.0_cfa0f0550d794f774b69ded00bc577ac
       eslint: 8.2.0
       typescript: 4.4.4
     dev: true
@@ -7781,6 +7809,12 @@ packages:
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
+    dev: true
+
+  /fast-url-parser/1.1.3:
+    resolution: {integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=}
+    dependencies:
+      punycode: 1.4.1
     dev: true
 
   /fastest-levenshtein/1.0.12:
@@ -15074,6 +15108,12 @@ packages:
       stream-shift: 1.0.1
     dev: true
 
+  /stream-events/1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+    dependencies:
+      stubs: 3.0.0
+    dev: true
+
   /stream-http/2.8.3:
     resolution: {integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==}
     dependencies:
@@ -15273,6 +15313,10 @@ packages:
       duplexer: 0.1.2
       minimist: 1.2.5
       through: 2.3.8
+    dev: true
+
+  /stubs/3.0.0:
+    resolution: {integrity: sha1-6NK6H6nJBXAwPAMLaQD31fiavls=}
     dev: true
 
   /style-loader/2.0.0_webpack@4.46.0:
@@ -15537,6 +15581,19 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
+
+  /teeny-request/7.1.1:
+    resolution: {integrity: sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==}
+    engines: {node: '>=10'}
+    dependencies:
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.0
+      node-fetch: 2.6.6
+      stream-events: 1.0.5
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /temp-dir/1.0.0:
@@ -16283,6 +16340,12 @@ packages:
       querystring: 0.2.0
     dev: true
 
+  /urlgrey/1.0.0:
+    resolution: {integrity: sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==}
+    dependencies:
+      fast-url-parser: 1.1.3
+    dev: true
+
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
@@ -16345,7 +16408,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
-    optional: true
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Fix  Jest coverage jsx file extensions not recognized bug


<!-- MANDATORY -->
## Testing
Run `pnpm test:coverage` locally 

Before:
![image](https://user-images.githubusercontent.com/36393111/148318722-0207c0e5-9966-4165-b545-03349d2aab2c.png)


After:
![image](https://user-images.githubusercontent.com/36393111/148318658-7f8344bd-6021-439b-9d5c-15b1c4395f0b.png)

<!-- How did you test this PR? -->