### PR TITLE
chore(js): add LogtoErrorCode.idToken.invalidToken and jest-matcher-specific-error

### DIFF
--- a/packages/js/jest.config.js
+++ b/packages/js/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
   coverageReporters: ['text-summary', 'lcov'],
   moduleFileExtensions: ['ts', 'js'],
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  setupFilesAfterEnv: ['./jest.setup.js', 'jest-matcher-specific-error'],
   testPathIgnorePatterns: ['lib'],
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|js)$',
   transform: {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -32,6 +32,7 @@
     "codecov": "^3.8.3",
     "eslint": "^8.1.0",
     "jest": "^27.0.6",
+    "jest-matcher-specific-error": "^1.0.0",
     "lint-staged": "^11.1.2",
     "nock": "^13.1.3",
     "node-fetch": "2.6.6",

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -16,6 +16,7 @@ const logtoErrorCodes = Object.freeze({
     verification: {
       invalidIat: 'Invalid issued at time',
     },
+    invalidToken: 'Invalid token',
   },
 });
 

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -13,9 +13,7 @@ type Normalize<T> = keyof T | Normalize2<T>;
 
 const logtoErrorCodes = Object.freeze({
   idToken: {
-    verification: {
-      invalidIat: 'Invalid issued at time',
-    },
+    invalidIat: 'Invalid issued at time',
     invalidToken: 'Invalid token',
   },
 });

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -206,7 +206,7 @@ describe('verifyIdToken', () => {
     const jwks = createDefaultJwks();
 
     await expect(verifyIdToken(idToken, 'qux', 'foo', jwks)).rejects.toThrowError(
-      new LogtoError('idToken.verification.invalidIat')
+      new LogtoError('idToken.invalidIat')
     );
   });
 });

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -255,7 +255,7 @@ describe('decodeIdToken', () => {
   });
 
   test('decoding invalid JWT string should throw Error', async () => {
-    expect(() => decodeIdToken('invalid-JWT')).toThrow('invalid token');
+    expect(() => decodeIdToken('invalid-JWT')).toThrow(new LogtoError('idToken.invalidToken'));
   });
 
   test('decoding valid JWT without issuer should throw StructError', async () => {

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -205,7 +205,7 @@ describe('verifyIdToken', () => {
 
     const jwks = createDefaultJwks();
 
-    await expect(verifyIdToken(idToken, 'qux', 'foo', jwks)).rejects.toThrowError(
+    await expect(verifyIdToken(idToken, 'qux', 'foo', jwks)).rejects.toMatchError(
       new LogtoError('idToken.invalidIat')
     );
   });
@@ -255,7 +255,7 @@ describe('decodeIdToken', () => {
   });
 
   test('decoding invalid JWT string should throw Error', async () => {
-    expect(() => decodeIdToken('invalid-JWT')).toThrow(new LogtoError('idToken.invalidToken'));
+    expect(() => decodeIdToken('invalid-JWT')).toMatchError(new LogtoError('idToken.invalidToken'));
   });
 
   test('decoding valid JWT without issuer should throw StructError', async () => {

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -35,7 +35,7 @@ export const verifyIdToken = async (
 export const decodeIdToken = (token: string): IdTokenClaims => {
   const { 1: encodedPayload } = token.split('.');
   if (!encodedPayload) {
-    throw new Error('invalid token');
+    throw new LogtoError('idToken.invalidToken');
   }
 
   const json = UrlSafeBase64.decode(encodedPayload);

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -28,7 +28,7 @@ export const verifyIdToken = async (
 ) => {
   const result = await jwtVerify(idToken, jwks, { audience: clientId, issuer });
   if (Math.abs((result?.payload?.iat ?? 0) - Date.now() / 1000) > issuedAtTimeTolerance) {
-    throw new LogtoError('idToken.verification.invalidIat');
+    throw new LogtoError('idToken.invalidIat');
   }
 };
 

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -2,7 +2,12 @@
     "extends": "@silverhand/ts-config/tsconfig.base",
     "compilerOptions": {
         "outDir": "lib",
-        "target": "es5"
+        "target": "es5",
+        "types": [
+            "node",
+            "jest",
+            "jest-matcher-specific-error"
+        ]
     },
     "include": [
         "src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ importers:
       codecov: ^3.8.3
       eslint: ^8.1.0
       jest: ^27.0.6
+      jest-matcher-specific-error: ^1.0.0
       jose: ^4.3.8
       js-base64: ^3.7.2
       lint-staged: ^11.1.2
@@ -112,6 +113,7 @@ importers:
       codecov: 3.8.3
       eslint: 8.2.0
       jest: 27.0.6
+      jest-matcher-specific-error: 1.0.0
       lint-staged: 11.1.2
       nock: 13.1.3
       node-fetch: 2.6.6
@@ -10044,6 +10046,10 @@ packages:
     dependencies:
       jest-get-type: 27.0.6
       pretty-format: 27.0.6
+    dev: true
+
+  /jest-matcher-specific-error/1.0.0:
+    resolution: {integrity: sha512-thJdy9ibhDo8k+0arFalNCQBJ0u7eqTfpTzS2MzL3iCLmbRCkI+yhhKSiAxEi55e5ZUyf01ySa0fMqzF+sblAw==}
     dev: true
 
   /jest-matcher-utils/26.6.2:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Add `LogtoErrorCode.idToken.invalidToken`
    - Make decodeIdToken throw `LogtoErrorCode.idToken.invalidToken` when needed
- Simplify `LogtoErrorCode.idToken.verification.invalidIat` to `LogtoErrorCode.idToken.invalidIat`
- Add development dependency `jest-matcher-specific-error` for matching specific error

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1382
LOG-1355

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 