### PR TITLE
refactor(js): assign LogtoError code to message

### DIFF
--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -24,8 +24,8 @@ export type LogtoErrorCode = Normalize<typeof logtoErrorCodes>;
 export class LogtoError extends Error {
   code: LogtoErrorCode;
 
-  constructor(code: LogtoErrorCode, message?: string) {
-    super(message);
+  constructor(code: LogtoErrorCode) {
+    super(code);
     this.code = code;
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
refactor(js): assign LogtoError code to message too

---

Problem:

```ts
  test('callback uri, without code, should throw', () => {
    ……
    expect(() => ……).toThrowError(new LogtoError('callbackUri.missingCode'));
  });
```

is as same as

```ts
  test('callback uri, without code, should throw', () => {
    ……
    expect(() => ……).toThrowError();
  });
```

because

```ts
/**
 * If you want to test that a specific error is thrown inside a function.
 */
toThrowError(error?: string | Constructable | RegExp | Error): R;
```

`toThrowError` can only check the properties (e.g. `message`) defined in `Error`,
and cannot check the properties (e.g. `code`) defined in classes `extends` from `Error`.

My solution is to assign the property `LogtoError.code` to its parent class property `Error.message` 
so that `toThrowError` can assert the content of `LogtoError.code`.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
Related #127 #131 LOG-1355 LOG1356

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing unit tests.

---
@logto-io/eng 