### PR TITLE
feat(js): requester

### DIFF
--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -13,6 +13,10 @@ const logtoErrorCodes = Object.freeze({
     state_mismatched: 'State mismatched',
     missing_code: 'Missing code',
   },
+  requester: {
+    failed: 'Failed',
+    not_provide_fetch: 'Should provide a fetch function under Node.js',
+  },
 });
 
 export type LogtoErrorCode = NormalizeKeyPaths<typeof logtoErrorCodes>;
@@ -33,8 +37,8 @@ export class LogtoError extends Error {
   error?: string;
   errorDescription?: string;
 
-  constructor(code: LogtoErrorCode, error?: string, errorDescription?: string) {
-    super(getMessageByErrorCode(code));
+  constructor(code: LogtoErrorCode, error?: string, errorDescription?: string, message?: string) {
+    super(message ?? getMessageByErrorCode(code));
     this.code = code;
     this.error = error;
     this.errorDescription = errorDescription;

--- a/packages/js/src/utils/requester.node.test.ts
+++ b/packages/js/src/utils/requester.node.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+import { LogtoError } from './errors';
+import { createRequester } from './requester';
+
+describe('createRequester', () => {
+  test('should throw when not providing fetch function under node.js environment', () => {
+    expect(() => createRequester()).toMatchError(new LogtoError('requester.not_provide_fetch'));
+  });
+});

--- a/packages/js/src/utils/requester.test.ts
+++ b/packages/js/src/utils/requester.test.ts
@@ -1,0 +1,89 @@
+import { LogtoError } from './errors';
+import { createRequester } from './requester';
+
+describe('createRequester', () => {
+  describe('successful response', () => {
+    test('should return data', async () => {
+      const data = { foo: 'bar' };
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => data,
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).resolves.toEqual(data);
+    });
+  });
+
+  describe('non-ok response', () => {
+    test('json text with error and error description should throw LogtoError with error and error description', async () => {
+      const error = 'some error';
+      const errorDescription = 'some error description';
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: false,
+        text: async () => {
+          return JSON.stringify({
+            error,
+            error_description: errorDescription,
+          });
+        },
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchError(
+        new LogtoError('requester.failed', error, errorDescription)
+      );
+    });
+
+    test('json text with only error should throw LogtoError with error', async () => {
+      const error = 'some error';
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: false,
+        text: async () => {
+          return JSON.stringify({ error });
+        },
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchError(
+        new LogtoError('requester.failed', error)
+      );
+    });
+
+    test('json text with only error description should throw LogtoError with error description', async () => {
+      const errorDescription = 'some error description';
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: false,
+        text: async () => {
+          return JSON.stringify({ error_description: errorDescription });
+        },
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchError(
+        new LogtoError('requester.failed', undefined, errorDescription)
+      );
+    });
+
+    test('json text without error and error description should throw LogtoError with response status text', async () => {
+      const statusText = 'some error status';
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: false,
+        text: async () => JSON.stringify({}),
+        statusText,
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchError(
+        new LogtoError('requester.failed', undefined, undefined, statusText)
+      );
+    });
+
+    test('non-json text should throw LogtoError with response text', async () => {
+      const errorText = 'some error text';
+      const fetchFunction = jest.fn().mockResolvedValue({
+        ok: false,
+        text: async () => errorText,
+      });
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchError(
+        new LogtoError('requester.failed', undefined, undefined, errorText)
+      );
+    });
+  });
+});

--- a/packages/js/src/utils/requester.ts
+++ b/packages/js/src/utils/requester.ts
@@ -1,0 +1,55 @@
+import { isNode } from '@silverhand/essentials';
+
+import { LogtoError } from './errors';
+
+interface LogtoErrorResponse {
+  error?: string;
+  error_description?: string;
+}
+
+interface LogtoErrorParameters extends LogtoErrorResponse {
+  message?: string;
+}
+
+const getLogtoErrorParametersByResponse = async (
+  response: Response
+): Promise<LogtoErrorParameters> => {
+  const text = await response.text();
+  try {
+    const data = JSON.parse(text) as LogtoErrorResponse;
+    if (data.error || data.error_description) {
+      return {
+        error: data.error,
+        error_description: data.error_description,
+      };
+    }
+
+    return { message: response.statusText };
+  } catch {
+    return { message: text };
+  }
+};
+
+export const createRequester = (fetchFunction?: typeof fetch) => {
+  if (!fetchFunction && isNode()) {
+    throw new LogtoError('requester.not_provide_fetch');
+  }
+
+  return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
+    const response = await (fetchFunction ?? fetch)(...args);
+
+    if (!response.ok) {
+      const logtoErrorMessage = await getLogtoErrorParametersByResponse(response);
+      throw new LogtoError(
+        'requester.failed',
+        logtoErrorMessage.error,
+        logtoErrorMessage.error_description,
+        logtoErrorMessage.message
+      );
+    }
+
+    return (await response.json()) as T;
+  };
+};
+
+export type Requester = ReturnType<typeof createRequester>;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add Requester for `fetch` Response
    - [`fetchOidcConfig`](https://www.notion.so/silverhand/fetchOidcConfig-887d329a10de43b5acc2f279c04dba4b) requires `Requester` to fetch data.
        - Reference: [packages/client/src/api/discover.ts](https://github.com/logto-io/js/blob/master/packages/client/src/api/discover.ts)
    - The developers should provide his/her `Requester` (`fetch` function) under Node.js environments according to the code implemented by @wangsijie before.
        - Reference: [packages/client/src/utils/requester.ts](https://github.com/logto-io/js/blob/master/packages/client/src/utils/requester.ts)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-766 → LOG-1421

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/150962096-7573cb05-4bb9-442b-be0d-35ac57738d95.png)
![image](https://user-images.githubusercontent.com/10594507/150962160-2de0cc07-072d-4bbe-8d50-cf785d7db828.png)

---
@logto-io/eng 