### PR TITLE
refactor(js): refactor requester and LogtoError, add LogtoRequestError

### DIFF
--- a/packages/js/src/include.d/dom.d.ts
+++ b/packages/js/src/include.d/dom.d.ts
@@ -1,0 +1,3 @@
+interface Body {
+  json<T>(): Promise<T>;
+}

--- a/packages/js/src/utils/callback-uri.test.ts
+++ b/packages/js/src/utils/callback-uri.test.ts
@@ -23,14 +23,14 @@ describe('verifyAndParseCodeFromCallbackUri', () => {
   test('callback uri, containing error parameter, should throw', () => {
     const callbackUrl = `http://localhost:3000/callback?code=${code}&state=${state}&error=${error}`;
     expect(() => verifyAndParseCodeFromCallbackUri(callbackUrl, redirectUri, state)).toMatchError(
-      new LogtoError('callback_uri_verification.error_found', error)
+      new LogtoError('callback_uri_verification.error_found', { error })
     );
   });
 
   test('callback uri, containing error and error_description parameters, should throw', () => {
     const callbackUrl = `http://localhost:3000/callback?code=${code}&state=${state}&error=${error}&error_description=${errorDescription}`;
     expect(() => verifyAndParseCodeFromCallbackUri(callbackUrl, redirectUri, state)).toMatchError(
-      new LogtoError('callback_uri_verification.error_found', error, errorDescription)
+      new LogtoError('callback_uri_verification.error_found', { error, errorDescription })
     );
   });
 

--- a/packages/js/src/utils/callback-uri.ts
+++ b/packages/js/src/utils/callback-uri.ts
@@ -33,7 +33,7 @@ export const verifyAndParseCodeFromCallbackUri = (
   } = authenticationResult;
 
   if (error) {
-    throw new LogtoError('callback_uri_verification.error_found', error, errorDescription);
+    throw new LogtoError('callback_uri_verification.error_found', { error, errorDescription });
   }
 
   if (!stateFromCallbackUri) {

--- a/packages/js/src/utils/errors.test.ts
+++ b/packages/js/src/utils/errors.test.ts
@@ -1,25 +1,33 @@
-import { LogtoError, LogtoErrorCode } from './errors';
+import { LogtoError, LogtoErrorCode, LogtoRequestError } from './errors';
 
 describe('LogtoError', () => {
   test('new LogtoError should contain correct properties', () => {
-    const errorCode: LogtoErrorCode = 'callback_uri_verification.missing_code';
+    const code: LogtoErrorCode = 'callback_uri_verification.missing_code';
     const error = 'error_value';
     const errorDescription = 'error_description_content';
-    const logtoError = new LogtoError(errorCode, error, errorDescription);
-    expect(logtoError).toHaveProperty('code', errorCode);
+    const logtoError = new LogtoError(code, { error, errorDescription });
+    expect(logtoError).toHaveProperty('code', code);
     expect(logtoError).toHaveProperty('message', 'Missing code');
-    expect(logtoError).toHaveProperty('error', error);
-    expect(logtoError).toHaveProperty('errorDescription', errorDescription);
+    expect(logtoError).toHaveProperty('data', { error, errorDescription });
   });
 
   test('new LogtoError with error code, which is not related to unique message, should contain message equaling to error code', () => {
-    const errorCode: LogtoErrorCode = 'callback_uri_verification';
+    const code: LogtoErrorCode = 'callback_uri_verification';
     const error = 'error_value';
     const errorDescription = 'error_description_content';
-    const logtoError = new LogtoError(errorCode, error, errorDescription);
-    expect(logtoError).toHaveProperty('code', errorCode);
-    expect(logtoError).toHaveProperty('message', errorCode);
-    expect(logtoError).toHaveProperty('error', error);
-    expect(logtoError).toHaveProperty('errorDescription', errorDescription);
+    const logtoError = new LogtoError(code, { error, errorDescription });
+    expect(logtoError).toHaveProperty('code', code);
+    expect(logtoError).toHaveProperty('message', code);
+    expect(logtoError).toHaveProperty('data', { error, errorDescription });
+  });
+});
+
+describe('LogtoRequestError', () => {
+  test('new LogtoRequestError should contain correct properties', () => {
+    const code = 'some code';
+    const message = 'some message';
+    const logtoRequestError = new LogtoRequestError(code, message);
+    expect(logtoRequestError).toHaveProperty('code', code);
+    expect(logtoRequestError).toHaveProperty('message', message);
   });
 });

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -17,6 +17,9 @@ const logtoErrorCodes = Object.freeze({
     failed: 'Failed',
     not_provide_fetch: 'Should provide a fetch function under Node.js',
   },
+  struct_verification: {
+    request_error_struct_mismatched: 'Request error struct mismatched',
+  },
 });
 
 export type LogtoErrorCode = NormalizeKeyPaths<typeof logtoErrorCodes>;
@@ -35,13 +38,20 @@ const getMessageByErrorCode = (errorCode: LogtoErrorCode): string => {
 
 export class LogtoError extends Error {
   code: LogtoErrorCode;
-  error?: string;
-  errorDescription?: string;
+  data: unknown;
 
-  constructor(code: LogtoErrorCode, error?: string, errorDescription?: string, message?: string) {
-    super(message ?? getMessageByErrorCode(code));
+  constructor(code: LogtoErrorCode, data?: unknown) {
+    super(getMessageByErrorCode(code));
     this.code = code;
-    this.error = error;
-    this.errorDescription = errorDescription;
+    this.data = data;
+  }
+}
+
+export class LogtoRequestError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Refactor `LogtoError`
- Add LogtoRequestError and refactor requester
    - Throw LogtoRequestError when the request fails due to Logto core server.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1422

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 