### PR TITLE
chore(js): override eslint config to allow 6 params at max

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -51,7 +51,18 @@
     "webpack-cli": "^4.9.1"
   },
   "eslintConfig": {
-    "extends": "@silverhand/eslint-config"
+    "extends": "@silverhand/eslint-config",
+    "overrides": [
+      {
+        "files": ["*.ts"],
+        "rules": {
+          "max-params": [
+            "warn",
+            { "max": 6 }
+          ]
+        }
+      }
+    ]
   },
   "prettier": "@silverhand/eslint-config/.prettierrc"
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Override eslint config in project `logto-io/js` to allow 6 function parameters at maximum

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Eslint will prompt a warning message when declaring over 6 parameters in any function
![image](https://user-images.githubusercontent.com/12833674/151694005-6f11aec1-3861-4ca0-a902-dcfca4b3649e.png)
