### PR TITLE
chore(js): remove eslint override of max-params

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -51,18 +51,7 @@
     "webpack-cli": "^4.9.1"
   },
   "eslintConfig": {
-    "extends": "@silverhand",
-    "overrides": [
-      {
-        "files": ["*.ts"],
-        "rules": {
-          "max-params": [
-            "warn",
-            { "max": 6 }
-          ]
-        }
-      }
-    ]
+    "extends": "@silverhand"
   },
   "prettier": "@silverhand/eslint-config/.prettierrc"
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Revert the changes made in #155 as we decided to use the object pattern in the end.
Thus, remove the override of eslint rule of `max-params` in js project

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No need