### PR TITLE
refactor(js): rename scope to scopes in fetchTokenByRefreshToken

### DIFF
--- a/packages/js/src/core/fetch-token.test.ts
+++ b/packages/js/src/core/fetch-token.test.ts
@@ -14,7 +14,7 @@ describe('fetch access token by providing valid refresh token', () => {
       accessToken: 'access_token',
       refreshToken: 'refresh_token',
       idToken: 'id_token',
-      scope: ['read', 'register', 'manage'],
+      scope: 'read register manage',
       expiresIn: 3600,
     };
 
@@ -26,7 +26,7 @@ describe('fetch access token by providing valid refresh token', () => {
         tokenEndPoint: 'https://logto.dev/oidc/token',
         refreshToken: 'refresh_token',
         resource: 'resource',
-        scope: ['read', 'register', 'manage'],
+        scopes: ['read', 'register', 'manage'],
       },
       fetchFunction // Always passing `fetchFunction` since Jest has no `fetch()`
     );

--- a/packages/js/src/core/fetch-token.ts
+++ b/packages/js/src/core/fetch-token.ts
@@ -1,6 +1,5 @@
 import { KeysToCamelCase } from '@silverhand/essentials';
 import camelcaseKeys from 'camelcase-keys';
-import { Except } from 'type-fest';
 
 import { ContentType } from '../consts';
 import { Requester } from '../utils';
@@ -10,23 +9,21 @@ export type FetchTokenByRefreshTokenParameters = {
   tokenEndPoint: string;
   refreshToken: string;
   resource?: string;
-  scope?: string[];
+  scopes?: string[];
 };
 
 type TokenSnakeCaseResponse = {
   access_token: string;
   refresh_token: string;
   id_token: string;
-  scope?: string;
+  scope: string;
   expires_in: number;
 };
 
-export type RefreshTokenTokenResponse = {
-  scope?: string[];
-} & Except<KeysToCamelCase<TokenSnakeCaseResponse>, 'scope'>;
+export type RefreshTokenTokenResponse = KeysToCamelCase<TokenSnakeCaseResponse>;
 
 export const fetchTokenByRefreshToken = async (
-  { clientId, tokenEndPoint, refreshToken, resource, scope }: FetchTokenByRefreshTokenParameters,
+  { clientId, tokenEndPoint, refreshToken, resource, scopes }: FetchTokenByRefreshTokenParameters,
   requester: Requester
 ): Promise<RefreshTokenTokenResponse> => {
   const parameters = new URLSearchParams();
@@ -37,8 +34,8 @@ export const fetchTokenByRefreshToken = async (
     parameters.append('resource', resource);
   }
 
-  if (scope?.length) {
-    parameters.append('scope', scope.join(' '));
+  if (scopes?.length) {
+    parameters.append('scope', scopes.join(' '));
   }
 
   const tokenSnakeCaseResponse = await requester<TokenSnakeCaseResponse>(tokenEndPoint, {
@@ -47,7 +44,5 @@ export const fetchTokenByRefreshToken = async (
     body: parameters,
   });
 
-  const scopeValues = tokenSnakeCaseResponse.scope?.split(' ');
-
-  return camelcaseKeys({ ...tokenSnakeCaseResponse, scope: scopeValues });
+  return camelcaseKeys(tokenSnakeCaseResponse);
 };

--- a/packages/js/src/core/fetch-token.ts
+++ b/packages/js/src/core/fetch-token.ts
@@ -15,7 +15,7 @@ export type FetchTokenByRefreshTokenParameters = {
 type TokenSnakeCaseResponse = {
   access_token: string;
   refresh_token: string;
-  id_token: string;
+  id_token?: string;
   scope: string;
   expires_in: number;
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- [refactor(js): rename scope to scopes in fetchTokenByRefreshToken and fix scope type](https://github.com/logto-io/js/pull/164/commits/3c7e8f6245f4bc59794907d89e169ed2aada9358)
- [chore(js): make RefreshTokenTokenResponse.idToken optional](https://github.com/logto-io/js/pull/164/commits/741cdfecbc3a3023a9e29032d98b3003dd59f1c4)

Summary:
- function parameter: `scopes: string[]`
- function response: `scope: string`
- /oidc/token api parameter: `scope: string`
- /oidc/token api response: `scope: string`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
Related:  LOG-771

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 