### PR TITLE
feat(js): add CodeTokenResponse

### DIFF
--- a/packages/js/src/core/fetch-token.test.ts
+++ b/packages/js/src/core/fetch-token.test.ts
@@ -1,6 +1,7 @@
 import {
   fetchTokenByAuthorizationCode,
   fetchTokenByRefreshToken,
+  CodeTokenResponse,
   RefreshTokenTokenResponse,
 } from '.';
 
@@ -13,7 +14,7 @@ describe('fetch access token by providing authorization code', () => {
       scope: 'read register',
       expires_in: 3600,
     };
-    const expectedTokenResponse: RefreshTokenTokenResponse = {
+    const expectedTokenResponse: CodeTokenResponse = {
       accessToken: 'access_token_value',
       refreshToken: 'refresh_token_value',
       idToken: 'id_token_value',

--- a/packages/js/src/core/fetch-token.ts
+++ b/packages/js/src/core/fetch-token.ts
@@ -21,7 +21,17 @@ export type FetchTokenByRefreshTokenParameters = {
   scopes?: string[];
 };
 
-type TokenSnakeCaseResponse = {
+type SnakeCaseCodeTokenResponse = {
+  access_token: string;
+  refresh_token: string;
+  id_token: string;
+  scope: string;
+  expires_in: number;
+};
+
+export type CodeTokenResponse = KeysToCamelCase<SnakeCaseCodeTokenResponse>;
+
+type SnakeCaseRefreshTokenTokenResponse = {
   access_token: string;
   refresh_token: string;
   id_token?: string;
@@ -29,7 +39,7 @@ type TokenSnakeCaseResponse = {
   expires_in: number;
 };
 
-export type RefreshTokenTokenResponse = KeysToCamelCase<TokenSnakeCaseResponse>;
+export type RefreshTokenTokenResponse = KeysToCamelCase<SnakeCaseRefreshTokenTokenResponse>;
 
 export const fetchTokenByAuthorizationCode = async (
   {
@@ -41,7 +51,7 @@ export const fetchTokenByAuthorizationCode = async (
     resource,
   }: FetchTokenByAuthorizationCodeParameters,
   requester: Requester
-) => {
+): Promise<CodeTokenResponse> => {
   const parameters = new URLSearchParams();
   parameters.append(QueryKey.ClientId, clientId);
   parameters.append(QueryKey.Code, code);
@@ -53,13 +63,13 @@ export const fetchTokenByAuthorizationCode = async (
     parameters.append(QueryKey.Resource, resource);
   }
 
-  const tokenSnakeCaseResponse = await requester<TokenSnakeCaseResponse>(tokenEndpoint, {
+  const snakeCaseCodeTokenResponse = await requester<SnakeCaseCodeTokenResponse>(tokenEndpoint, {
     method: 'POST',
     headers: ContentType.formUrlEncoded,
     body: parameters,
   });
 
-  return camelcaseKeys(tokenSnakeCaseResponse);
+  return camelcaseKeys(snakeCaseCodeTokenResponse);
 };
 
 export const fetchTokenByRefreshToken = async (
@@ -79,11 +89,14 @@ export const fetchTokenByRefreshToken = async (
     parameters.append(QueryKey.Scope, scopes.join(' '));
   }
 
-  const tokenSnakeCaseResponse = await requester<TokenSnakeCaseResponse>(tokenEndpoint, {
-    method: 'POST',
-    headers: ContentType.formUrlEncoded,
-    body: parameters,
-  });
+  const snakeCaseRefreshTokenTokenResponse = await requester<SnakeCaseRefreshTokenTokenResponse>(
+    tokenEndpoint,
+    {
+      method: 'POST',
+      headers: ContentType.formUrlEncoded,
+      body: parameters,
+    }
+  );
 
-  return camelcaseKeys(tokenSnakeCaseResponse);
+  return camelcaseKeys(snakeCaseRefreshTokenTokenResponse);
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
feat(js): add CodeTokenResponse ( which is missing in #165 )

---

The core difference between `CodeTokenResponse` and `RefreshTokenTokenResponse` is `idToken`.

- `CodeTokenResponse.idToken` is required.
- `RefreshTokenTokenResponse.idToken` is optional.

![image](https://user-images.githubusercontent.com/10594507/154225533-315e9b29-cc2e-4822-b0e0-f14cbb2a9b79.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-770

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 