### PR TITLE
chore(browser): make necessary LogtoClient properties nullable

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@logto/js": "^0.0.1",
-    "@silverhand/essentials": "^1.1.5",
+    "@silverhand/essentials": "^1.1.6",
     "lodash.get": "^4.4.2",
     "superstruct": "^0.15.3"
   },

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -11,7 +11,7 @@ import {
   revoke,
   withReservedScopes,
 } from '@logto/js';
-import { conditional, Optional } from '@silverhand/essentials';
+import { Nullable, Optional } from '@silverhand/essentials';
 import { assert, Infer, string, type } from 'superstruct';
 
 import { LogtoClientError } from './errors';
@@ -43,8 +43,8 @@ export type LogtoSignInSessionItem = Infer<typeof LogtoSignInSessionItemSchema>;
 
 export default class LogtoClient {
   protected accessTokenMap = new Map<string, AccessToken>();
-  protected refreshToken?: string;
-  protected idToken?: string;
+  protected refreshToken: Nullable<string>;
+  protected idToken: Nullable<string>;
   protected logtoConfig: LogtoConfig;
   protected oidcConfig?: OidcConfigResponse;
   protected logtoStorageKey: string;
@@ -54,8 +54,8 @@ export default class LogtoClient {
     this.logtoConfig = logtoConfig;
     this.logtoStorageKey = getLogtoKey(logtoConfig.clientId);
     this.requester = requester;
-    this.refreshToken = conditional(localStorage.getItem(`${this.logtoStorageKey}:refreshToken`));
-    this.idToken = conditional(localStorage.getItem(`${this.logtoStorageKey}:idToken`));
+    this.refreshToken = localStorage.getItem(`${this.logtoStorageKey}:refreshToken`);
+    this.idToken = localStorage.getItem(`${this.logtoStorageKey}:idToken`);
   }
 
   public get isAuthenticated() {
@@ -138,8 +138,8 @@ export default class LogtoClient {
     localStorage.removeItem(`${this.logtoStorageKey}:refreshToken`);
 
     this.accessTokenMap.clear();
-    this.idToken = undefined;
-    this.refreshToken = undefined;
+    this.refreshToken = null;
+    this.idToken = null;
 
     window.location.assign(url);
   }

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -124,7 +124,7 @@ export default class LogtoClient {
       try {
         await revoke(revocationEndpoint, clientId, this.refreshToken, this.requester);
       } catch {
-        // Do nothing at this point, as we don't want to break the sign out flow even if the revocation is failed
+        // Do nothing at this point, as we don't want to break the sign-out flow even if the revocation is failed
       }
     }
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -19,7 +19,7 @@
     "report": "WITH_REPORT=true pnpm package"
   },
   "dependencies": {
-    "@silverhand/essentials": "^1.1.5",
+    "@silverhand/essentials": "^1.1.6",
     "camelcase-keys": "^7.0.1",
     "jose": "^4.3.8",
     "js-base64": "^3.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     specifiers:
       '@logto/js': ^0.0.1
       '@silverhand/eslint-config': ^0.7.0
-      '@silverhand/essentials': ^1.1.5
+      '@silverhand/essentials': ^1.1.6
       '@silverhand/ts-config': ^0.7.0
       '@types/lodash.get': ^4.4.6
       codecov: ^3.8.3
@@ -43,7 +43,7 @@ importers:
       webpack-cli: ^4.9.1
     dependencies:
       '@logto/js': link:../js
-      '@silverhand/essentials': 1.1.5
+      '@silverhand/essentials': 1.1.6
       lodash.get: 4.4.2
       superstruct: 0.15.3
     devDependencies:
@@ -93,7 +93,7 @@ importers:
       webpack-bundle-analyzer: ^4.5.0
       webpack-cli: ^4.9.1
     dependencies:
-      '@silverhand/essentials': 1.1.2
+      '@silverhand/essentials': 1.1.6
       jose: 4.1.4
       js-base64: 3.7.2
       nanoid: 3.1.30
@@ -124,7 +124,7 @@ importers:
     specifiers:
       '@peculiar/webcrypto': ^1.1.7
       '@silverhand/eslint-config': ^0.7.0
-      '@silverhand/essentials': ^1.1.5
+      '@silverhand/essentials': ^1.1.6
       '@silverhand/ts-config': ^0.7.0
       '@types/jest': ^26.0.24
       '@types/lodash.get': ^4.4.6
@@ -151,7 +151,7 @@ importers:
       webpack-bundle-analyzer: ^4.5.0
       webpack-cli: ^4.9.1
     dependencies:
-      '@silverhand/essentials': 1.1.5
+      '@silverhand/essentials': 1.1.6
       camelcase-keys: 7.0.1
       jose: 4.3.8
       js-base64: 3.7.2
@@ -3496,16 +3496,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@silverhand/essentials/1.1.2:
-    resolution: {integrity: sha512-LentlcxRnZ0pOwgH9lGERCrHwhnhoRgP5seHJkJRa9Y5DCAaNTabZ3ihlC7GhA8r7vEJsvRGp9JL7T2a2c6xFA==}
-    engines: {node: '>=14.15.0', pnpm: '>=6'}
-    dependencies:
-      lodash.orderby: 4.6.0
-      lodash.pick: 4.4.0
-    dev: false
-
-  /@silverhand/essentials/1.1.5:
-    resolution: {integrity: sha512-lpOdV/e/5+tvY/RQt6yTsId7MxxhJSShRE0ts8UR4O5Lr32/naFjxl79yoPD8O0ABEnLQbwYlxRks1G+8jxkuA==}
+  /@silverhand/essentials/1.1.6:
+    resolution: {integrity: sha512-Vl57z4HnEW/iSTHlFCPeJDLbg3OegrJy3gg0dbZsZwPifK0O5l5uBnrcpIYIPl3IhLSWw1ZqTyP7QWFpKadpEQ==}
     engines: {node: '>=14.15.0', pnpm: '>=6'}
     dependencies:
       lodash.orderby: 4.6.0
@@ -4438,7 +4430,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.1_ffb4ca0d42777c3f95985c39e374aaf9
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
     dev: true
 
   /@webpack-cli/serve/1.6.0_webpack-cli@4.9.1:
@@ -4450,7 +4442,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.9.1_ffb4ca0d42777c3f95985c39e374aaf9
+      webpack-cli: 4.9.1_51b97b2ad784f46f7873debea239ad34
     dev: true
 
   /@xtuc/ieee754/1.2.0:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Main:

- [chore(browser): make necessary LogtoClient properties nullable](https://github.com/logto-io/js/commit/a971af4e13391c01747c5d504b8da36fa09969cb)
- [chore(js,browser): upgrade @silverhand/essentials to version 1.1.6](https://github.com/logto-io/js/commit/6aae68d478607227c37a89714dbf0fa5ad17b415)

Others:
- [chore(browser): fix grammatical error in the comment](https://github.com/logto-io/js/pull/189/commits/d47fb5602f6833f7795334aa17a4c808b43491d4)

---

Because `idToken` and `refreshToken` can be retrieved from `localStroage` via `getItem(key): string | null`, 
better define related properties as type `Nullable<string>` (i.e. `string | null`).

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1576

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 