### PR TITLE
fix(browser): getAccessToken saves refreshToken and idToken

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -135,10 +135,12 @@ export default class LogtoClient {
       });
 
       localStorage.setItem(`${this.logtoStorageKey}:refreshToken`, refreshToken);
+      this.refreshToken = refreshToken;
 
       if (idToken) {
         await this.verifyIdToken(idToken);
         localStorage.setItem(`${this.logtoStorageKey}:idToken`, idToken);
+        this.idToken = idToken;
       }
 
       return accessToken;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- fix(browser): getAccessToken saves refreshToken and idToken
    - Bug: forget to save refreshToken and idToken in the related object properties.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1147

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.
(The tests will be added in LOG-1572 later.)

---
@logto-io/eng 