### PR TITLE
fix(js): response_type should be hard-coded as 'code'

### DIFF
--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -3,7 +3,7 @@ export const ContentType = {
 };
 
 export enum TokenGrantType {
-  AuthorizationCode = 'authorization_code',
+  AuthorizationCode = 'code',
   RefreshToken = 'refresh_token',
 }
 

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -16,7 +16,7 @@ describe('generateSignInUri', () => {
       state,
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=authorization_code&prompt=consent&scope=openid+offline_access'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access'
     );
   });
 
@@ -31,7 +31,7 @@ describe('generateSignInUri', () => {
       resources: ['resource1', 'resource2'],
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=authorization_code&prompt=consent&scope=openid+offline_access+scope1+scope2&resource=resource1&resource=resource2'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+scope1+scope2&resource=resource1&resource=resource2'
     );
   });
 });

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -3,7 +3,7 @@ import { withReservedScopes } from '../utils';
 
 const codeChallengeMethod = 'S256';
 const prompt = 'consent';
-const responseType = 'authorization_code';
+const responseType = 'code';
 
 export type SignInUriParameters = {
   authorizationEndpoint: string;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix incorrect `response_type` used in js SDK. Should use `code` instead of `authorization_code`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed all test cases.