### PR TITLE
fix(js): grant type should be 'authorization_code'  instead of 'code'

### DIFF
--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -3,7 +3,7 @@ export const ContentType = {
 };
 
 export enum TokenGrantType {
-  AuthorizationCode = 'code',
+  AuthorizationCode = 'authorization_code',
   RefreshToken = 'refresh_token',
 }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix incorrect `grant_type` usage in js SDK. The value of enum `GrantType.Authorization` should be `authorization_code` instead of `code`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed all test cases