### PR TITLE
feat(browser): export js core types from browser SDK

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -33,6 +33,7 @@ import {
   buildRefreshTokenKey,
 } from './utils';
 
+export type { IdTokenClaims, UserInfoResponse } from '@logto/js';
 export * from './errors';
 
 export type LogtoConfig = {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Export two js core types from browser SDK
* IdTokenClaims
* UserInfoResponse

The exported types will be used in the upcoming React SDK.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] The two new types can be imported from `@logto/browser`, along with the default `LogtoClient`