### PR TITLE
fix(browser): should use userinfo_endpoint in fetchUserInfo function

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -204,14 +204,14 @@ export default class LogtoClient {
   }
 
   public async fetchUserInfo(): Promise<UserInfoResponse> {
-    const { authorizationEndpoint } = await this.getOidcConfig();
+    const { userinfoEndpoint } = await this.getOidcConfig();
     const accessToken = await this.getAccessToken();
 
     if (!accessToken) {
       throw new LogtoClientError('fetch_user_info_failed');
     }
 
-    return fetchUserInfo(authorizationEndpoint, accessToken, this.requester);
+    return fetchUserInfo(userinfoEndpoint, accessToken, this.requester);
   }
 
   public async signIn(redirectUri: string) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`fetchUserInfo` function should use `userinfo_endpoint` instead of `authorization_endpoint`. This PR addresses the issue.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1853](https://linear.app/silverhand/issue/LOG-1853/fix-wrong-endpoint-used-in-fetchuserinfo-in-browser-sdk)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] passed unit tests