### PR TITLE
refactor(browser): use strict check logic in isSignInRedirected function

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -243,8 +243,9 @@ export default class LogtoClient {
       return false;
     }
     const { redirectUri } = signInSession;
+    const { origin, pathname } = new URL(url);
 
-    return url.startsWith(redirectUri);
+    return `${origin}${pathname}` === redirectUri;
   }
 
   public async handleSignInCallback(callbackUri: string) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve `isSignInRedirected` logic in browser SDK. Instead of using `startWith`, we should use strict check on the redirect URL, the origin and pathname must be exactly matched. 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1860](https://linear.app/silverhand/issue/LOG-1860/improve-issigninredirected-logic-in-browser-sdk)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] passed unit tests