### PR TITLE
refactor(react): remove handleSignInCallback export from useLogto hook

### DIFF
--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -47,11 +47,14 @@ describe('useLogto', () => {
     });
 
     await waitFor(() => {
-      const { signIn, signOut, handleSignInCallback } = result.current;
+      const { signIn, signOut, fetchUserInfo, getAccessToken, getIdTokenClaims } = result.current;
 
+      expect(result.error).toBeUndefined();
       expect(signIn).not.toBeUndefined();
       expect(signOut).not.toBeUndefined();
-      expect(handleSignInCallback).not.toBeUndefined();
+      expect(fetchUserInfo).not.toBeUndefined();
+      expect(getAccessToken).not.toBeUndefined();
+      expect(getIdTokenClaims).not.toBeUndefined();
     });
   });
 

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -10,7 +10,6 @@ type Logto = {
   fetchUserInfo: () => Promise<UserInfoResponse>;
   getAccessToken: (resource?: string) => Promise<Nullable<string>>;
   getIdTokenClaims: () => IdTokenClaims;
-  handleSignInCallback: (callbackUri: string) => Promise<void>;
   signIn: (redirectUri: string) => Promise<void>;
   signOut: (postLogoutRedirectUri: string) => Promise<void>;
 };
@@ -116,7 +115,6 @@ export default function useLogto(): Logto {
     isAuthenticated,
     isLoading,
     signIn,
-    handleSignInCallback,
     signOut,
     fetchUserInfo,
     getAccessToken,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove handleSignInCallback method from useLogto export in React SDK, for it's automatically called in the SDK itself once the sign-in is redirected

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1859](https://linear.app/silverhand/issue/LOG-1859/remove-handlesignincallback-from-uselogto-export)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] passed all unit tests
- [x] authentication works in react sample project