### PR TITLE
fix: remove `prepublish` script

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -17,7 +17,6 @@
     "package": "pnpm build && webpack",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepublish": "pnpm package",
     "report": "WITH_REPORT=true pnpm package",
     "prepack": "pnpm test && pnpm build"
   },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -17,7 +17,6 @@
     "package": "pnpm build && webpack",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent --coverage",
-    "prepublish": "pnpm package",
     "report": "WITH_REPORT=true pnpm package",
     "prepack": "pnpm test && pnpm build"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,6 @@
     "lint": "eslint --ext .ts --ext .tsx src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepublish": "pnpm build",
     "report": "WITH_REPORT=true pnpm build",
     "prepack": "pnpm test && pnpm build"
   },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
it's deprecated

<img width="701" alt="image" src="https://user-images.githubusercontent.com/14722250/157644135-4dcfb984-85bf-474f-bc1b-5e0c4635481c.png">

https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts
