### PR TITLE
chore: change license to MIT

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,7 +7,7 @@
   "files": [
     "lib"
   ],
-  "license": "MPL-2.0",
+  "license": "MIT",
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "preinstall": "npx only-allow pnpm",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -7,7 +7,7 @@
   "files": [
     "lib"
   ],
-  "license": "MPL-2.0",
+  "license": "MIT",
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "preinstall": "npx only-allow pnpm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "files": [
     "lib"
   ],
-  "license": "MPL-2.0",
+  "license": "MIT",
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
MPL 2.0 is too large and it's ok to use MIT for SDKs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A