### PR TITLE
refactor(react): improve hooks in react sdk

### DIFF
--- a/packages/react-sample/src/pages/Callback/index.tsx
+++ b/packages/react-sample/src/pages/Callback/index.tsx
@@ -1,10 +1,12 @@
-import { useLogto } from '@logto/react';
+import { useHandleSignInCallback, useLogto } from '@logto/react';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const Callback = () => {
   const { isAuthenticated, isLoading } = useLogto();
   const navigate = useNavigate();
+
+  useHandleSignInCallback();
 
   useEffect(() => {
     if (isAuthenticated && !isLoading) {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -3,7 +3,9 @@ import { createContext } from 'react';
 
 export type LogtoContextProps = {
   logtoClient?: LogtoClient;
+  isAuthenticated: boolean;
   loadingCount: number;
+  setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
   setLoadingCount: React.Dispatch<React.SetStateAction<number>>;
 };
 
@@ -13,6 +15,8 @@ export const throwContextError = (): never => {
 
 export const LogtoContext = createContext<LogtoContextProps>({
   logtoClient: undefined,
+  isAuthenticated: false,
   loadingCount: 0,
+  setIsAuthenticated: throwContextError,
   setLoadingCount: throwContextError,
 });

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -2,7 +2,7 @@ import LogtoClient from '@logto/browser';
 import { renderHook, act } from '@testing-library/react-hooks';
 import React, { ComponentType } from 'react';
 
-import useLogto from '.';
+import { useLogto, useHandleSignInCallback } from '.';
 import { LogtoProvider } from '../provider';
 
 const isSignInRedirected = jest.fn(() => false);
@@ -59,18 +59,32 @@ describe('useLogto', () => {
   });
 
   test('not in callback url should not call `handleSignInCallback`', async () => {
-    const { result } = renderHook(() => useLogto(), {
-      wrapper: createHookWrapper(),
-    });
+    const { result } = renderHook(
+      () => {
+        useHandleSignInCallback();
+
+        return useLogto();
+      },
+      {
+        wrapper: createHookWrapper(),
+      }
+    );
     await act(async () => result.current.signIn('redirectUri'));
     expect(handleSignInCallback).not.toHaveBeenCalled();
   });
 
   test('in callback url should call `handleSignInCallback`', async () => {
     isSignInRedirected.mockImplementation(() => true);
-    const { result, waitFor } = renderHook(() => useLogto(), {
-      wrapper: createHookWrapper(),
-    });
+    const { result, waitFor } = renderHook(
+      () => {
+        useHandleSignInCallback();
+
+        return useLogto();
+      },
+      {
+        wrapper: createHookWrapper(),
+      }
+    );
     await act(async () => result.current.signIn('redirectUri'));
     await waitFor(() => {
       expect(handleSignInCallback).toHaveBeenCalledTimes(1);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
 export type { LogtoContextProps } from './context';
 export type { LogtoConfig, IdTokenClaims, UserInfoResponse } from '@logto/browser';
 export * from './provider';
-export { default as useLogto } from './hooks';
+export { useLogto, useHandleSignInCallback } from './hooks';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -11,13 +11,18 @@ export type LogtoProviderProps = {
 export const LogtoProvider = ({ config, children }: LogtoProviderProps) => {
   const [loadingCount, setLoadingCount] = useState(0);
   const memorizedLogtoClient = useMemo(() => ({ logtoClient: new LogtoClient(config) }), [config]);
+  const [isAuthenticated, setIsAuthenticated] = useState(
+    memorizedLogtoClient.logtoClient.isAuthenticated
+  );
   const memorizedContextValue = useMemo(
     () => ({
       ...memorizedLogtoClient,
+      isAuthenticated,
+      setIsAuthenticated,
       loadingCount,
       setLoadingCount,
     }),
-    [memorizedLogtoClient, loadingCount]
+    [memorizedLogtoClient, isAuthenticated, loadingCount]
   );
 
   return <LogtoContext.Provider value={memorizedContextValue}>{children}</LogtoContext.Provider>;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve hooks in React SDK, by extracting `handleSignInCallback` logic from the main `useLogto` hook, in order to avoid issues caused by multiple useEffect executions.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1905](https://linear.app/silverhand/issue/LOG-1905/refactor-react-sdk-hooks)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] passed all test cases