### PR TITLE
fix: leverage root `prepack` lifecycle for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bootstrap": "lerna bootstrap",
     "test": "lerna run test",
     "lerna": "lerna",
+    "prepack": "lerna run build --since --include-dependencies --no-private",
     "prepare": "if test \"$NODE_ENV\" != \"production\" ; then husky install ; fi"
   },
   "devDependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test"
   },
   "dependencies": {
     "@logto/js": "^0.1.3",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test"
   },
   "dependencies": {
     "@silverhand/essentials": "^1.1.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --ext .ts --ext .tsx src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test"
   },
   "dependencies": {
     "@logto/browser": "^0.1.4",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
v0.1.4 [publish failed](https://github.com/logto-io/js/runs/5598155552?check_suite_focus=true) since `@logto/js` didn't change nor build while `@logto/browser` is its dependent.

this PR leverages root `prepack` lifecycle to prevent publish failure.

see [Lifecycle Scripts](https://github.com/lerna/lerna/tree/v4.0.0/commands/publish#lifecycle-scripts) for detailed explanantion.

see https://github.com/lerna/lerna/issues/2211#issuecomment-592703853

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1973

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

modify something in `@logto/browser`, run `pnpm prepack` now builds `@logto/js`.

<img width="567" alt="image" src="https://user-images.githubusercontent.com/14722250/161390619-f1391aa6-9bc8-4748-84ba-a50092f8e636.png">
