### PR TITLE
refactor(js): rename clientId to appId in js SDKs

### DIFF
--- a/packages/browser-sample/src/consts.js
+++ b/packages/browser-sample/src/consts.js
@@ -1,6 +1,6 @@
 export const baseUrl = window.location.origin;
 export const redirectUrl = `${baseUrl}/callback`;
-export const clientId = 'foo';
+export const appId = 'foo';
 
 // OIDC domain
 export const endpoint = 'https://logto.dev';

--- a/packages/browser-sample/src/index.js
+++ b/packages/browser-sample/src/index.js
@@ -1,13 +1,12 @@
 import LogtoClient from '@logto/browser';
 
-import { endpoint, clientId } from './consts.js';
+import { endpoint, appId } from './consts.js';
 import Callback from './pages/Callback.js';
 import Home from './pages/Home.js';
 
 import './index.scss';
 
-const logtoClient = new LogtoClient({ endpoint, clientId });
-
+const logtoClient = new LogtoClient({ endpoint, appId });
 const app = document.querySelector('#app');
 
 // Could replace this with a formal router solution

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -38,7 +38,7 @@ export * from './errors';
 
 export type LogtoConfig = {
   endpoint: string;
-  clientId: string;
+  appId: string;
   scopes?: string[];
   resources?: string[];
   usingPersistStorage?: boolean;
@@ -74,7 +74,7 @@ export default class LogtoClient {
 
   constructor(logtoConfig: LogtoConfig, requester = createRequester()) {
     this.logtoConfig = logtoConfig;
-    this.logtoStorageKey = buildLogtoKey(logtoConfig.clientId);
+    this.logtoStorageKey = buildLogtoKey(logtoConfig.appId);
     this.requester = requester;
     this._refreshToken = localStorage.getItem(buildRefreshTokenKey(this.logtoStorageKey));
     this._idToken = localStorage.getItem(buildIdTokenKey(this.logtoStorageKey));
@@ -209,7 +209,7 @@ export default class LogtoClient {
   }
 
   public async signIn(redirectUri: string) {
-    const { clientId, resources, scopes: customScopes } = this.logtoConfig;
+    const { appId: clientId, resources, scopes: customScopes } = this.logtoConfig;
     const { authorizationEndpoint } = await this.getOidcConfig();
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = await generateCodeChallenge(codeVerifier);
@@ -252,7 +252,7 @@ export default class LogtoClient {
     const { redirectUri, state, codeVerifier } = signInSession;
     const code = verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state);
 
-    const { clientId } = logtoConfig;
+    const { appId: clientId } = logtoConfig;
     const { tokenEndpoint } = await this.getOidcConfig();
     const codeTokenResponse = await fetchTokenByAuthorizationCode(
       {
@@ -275,7 +275,7 @@ export default class LogtoClient {
       throw new LogtoClientError('not_authenticated');
     }
 
-    const { clientId } = this.logtoConfig;
+    const { appId: clientId } = this.logtoConfig;
     const { endSessionEndpoint, revocationEndpoint } = await this.getOidcConfig();
 
     if (this.refreshToken) {
@@ -306,7 +306,7 @@ export default class LogtoClient {
 
     try {
       const accessTokenKey = buildAccessTokenKey(resource);
-      const { clientId } = this.logtoConfig;
+      const { appId: clientId } = this.logtoConfig;
       const { tokenEndpoint } = await this.getOidcConfig();
       const { accessToken, refreshToken, idToken, scope, expiresIn } =
         await fetchTokenByRefreshToken(
@@ -347,12 +347,12 @@ export default class LogtoClient {
   }
 
   private async verifyIdToken(idToken: string) {
-    const { clientId } = this.logtoConfig;
+    const { appId } = this.logtoConfig;
     const { issuer } = await this.getOidcConfig();
     const jwtVerifyGetKey = await this.getJwtVerifyGetKey();
 
     try {
-      await verifyIdToken(idToken, clientId, issuer, jwtVerifyGetKey);
+      await verifyIdToken(idToken, appId, issuer, jwtVerifyGetKey);
     } catch (error: unknown) {
       throw new LogtoClientError('invalid_id_token', error);
     }

--- a/packages/browser/src/utils/index.test.ts
+++ b/packages/browser/src/utils/index.test.ts
@@ -13,13 +13,13 @@ describe('browser SDK utilities', () => {
   });
 
   test('build refresh token key', () => {
-    const logtoKey = buildLogtoKey('clientIdValue');
-    expect(buildRefreshTokenKey(logtoKey)).toEqual('logto:clientIdValue:refreshToken');
+    const logtoKey = buildLogtoKey('appIdValue');
+    expect(buildRefreshTokenKey(logtoKey)).toEqual('logto:appIdValue:refreshToken');
   });
 
   test('build id token key', () => {
-    const logtoKey = buildLogtoKey('clientIdValue');
-    expect(buildIdTokenKey(logtoKey)).toEqual('logto:clientIdValue:idToken');
+    const logtoKey = buildLogtoKey('appIdValue');
+    expect(buildIdTokenKey(logtoKey)).toEqual('logto:appIdValue:idToken');
   });
 
   test('get discovery endpoint', () => {

--- a/packages/react-sample/src/App.tsx
+++ b/packages/react-sample/src/App.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import RequireAuth from './RequireAuth';
-import { clientId, endpoint } from './consts';
+import { appId, endpoint } from './consts';
 import Callback from './pages/Callback';
 import Home from './pages/Home';
 import ProtectedResource from './pages/ProtectedResource';
@@ -12,7 +12,7 @@ import './App.module.scss';
 
 export const App = () => {
   const config: LogtoConfig = {
-    clientId,
+    appId,
     endpoint,
   };
 

--- a/packages/react-sample/src/consts/index.ts
+++ b/packages/react-sample/src/consts/index.ts
@@ -1,5 +1,5 @@
 export const baseUrl = window.location.origin;
 export const redirectUrl = `${baseUrl}/callback`;
-export const clientId = 'foo';
+export const appId = 'foo';
 
 export const endpoint = 'https://logto.dev'; // OIDC domain

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -20,12 +20,12 @@ jest.mock('@logto/browser', () => {
 });
 
 const endpoint = 'https://logto.dev';
-const clientId = 'foo';
+const appId = 'foo';
 
 const createHookWrapper =
   () =>
   ({ children }: { children: ComponentType<unknown> }) =>
-    <LogtoProvider config={{ endpoint, clientId }}>{children}</LogtoProvider>;
+    <LogtoProvider config={{ endpoint, appId }}>{children}</LogtoProvider>;
 
 describe('useLogto', () => {
   test('without provider should throw', () => {
@@ -38,7 +38,7 @@ describe('useLogto', () => {
       wrapper: createHookWrapper(),
     });
 
-    expect(LogtoClient).toHaveBeenCalledWith({ endpoint, clientId });
+    expect(LogtoClient).toHaveBeenCalledWith({ endpoint, appId });
   });
 
   test('useLogto should return LogtoClient property methods', async () => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Rename `clientId` to `appId` in JS SDKs

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2252](https://linear.app/silverhand/issue/LOG-2252/rename-client-id-to-app-id-in-sdks)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed all unit tests
- [x] Tested browser sample and it worked
- [x] Tested react sample and it also worked