### PR TITLE
fix(browser): read/write refreshToken from/to localStorage only

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -69,14 +69,12 @@ export default class LogtoClient {
   protected readonly accessTokenMap = new Map<string, AccessToken>();
 
   private readonly getAccessTokenPromiseMap = new Map<string, Promise<string>>();
-  private _refreshToken: Nullable<string>;
   private _idToken: Nullable<string>;
 
   constructor(logtoConfig: LogtoConfig, requester = createRequester()) {
     this.logtoConfig = logtoConfig;
     this.logtoStorageKey = buildLogtoKey(logtoConfig.appId);
     this.requester = requester;
-    this._refreshToken = localStorage.getItem(buildRefreshTokenKey(this.logtoStorageKey));
     this._idToken = localStorage.getItem(buildIdTokenKey(this.logtoStorageKey));
   }
 
@@ -113,12 +111,10 @@ export default class LogtoClient {
   }
 
   get refreshToken() {
-    return this._refreshToken;
+    return localStorage.getItem(buildRefreshTokenKey(this.logtoStorageKey));
   }
 
   private set refreshToken(refreshToken: Nullable<string>) {
-    this._refreshToken = refreshToken;
-
     const refreshTokenKey = buildRefreshTokenKey(this.logtoStorageKey);
 
     if (!refreshToken) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Read/write refreshToken from localStorage only, instead of loading from browser memory object.

This fix aims to prevent using an expired refreshToken when more application tabs are open. Since we have the refreshToken rotations enabled, refreshToken will expire immediately after it is used to exchange for the accessToken.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2328](https://linear.app/silverhand/issue/LOG-2328/always-getset-refresh-token-from-local-storage)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested react sample project in two browser tabs, both worked fine.