### PR TITLE
fix(browser): remove session item after successful sign-in

### DIFF
--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -30,6 +30,7 @@ const mockedSignInUri = generateSignInUri({
 
 const refreshTokenStorageKey = `logto:${appId}:refreshToken`;
 const idTokenStorageKey = `logto:${appId}:idToken`;
+const signInSessionStorageKey = `logto:${appId}`;
 
 const accessToken = 'access_token_value';
 const refreshToken = 'new_refresh_token_value';
@@ -200,11 +201,13 @@ describe('LogtoClient', () => {
       const code = `code_value`;
       const callbackUri = `${redirectUri}?code=${code}&state=${mockedState}&codeVerifier=${mockedCodeVerifier}`;
 
+      expect(sessionStorage.getItem(signInSessionStorageKey)).not.toBeNull();
       await expect(logtoClient.handleSignInCallback(callbackUri)).resolves.not.toThrow();
       await expect(logtoClient.getAccessToken()).resolves.toEqual(accessToken);
       expect(localStorage.getItem(refreshTokenStorageKey)).toEqual(refreshToken);
       expect(localStorage.getItem(idTokenStorageKey)).toEqual(idToken);
       expect(requester).toHaveBeenCalledWith(tokenEndpoint, expect.anything());
+      expect(sessionStorage.getItem(signInSessionStorageKey)).toBeNull();
     });
   });
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -268,6 +268,7 @@ export default class LogtoClient {
     await this.verifyIdToken(codeTokenResponse.idToken);
 
     this.saveCodeToken(codeTokenResponse);
+    this.signInSession = null;
   }
 
   public async signOut(postLogoutRedirectUri?: string) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove sign-in session item from sessionStorage after a succesful sign-in

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2330](https://linear.app/silverhand/issue/LOG-2330/clear-session-after-sign-in)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed unit tests
- [x] Tested in react sample project. And sessionStorage was cleared after successfully signing in.