### PR TITLE
refactor(react): simplify callback logic in sample app

### DIFF
--- a/packages/react-sample/src/pages/Callback/index.tsx
+++ b/packages/react-sample/src/pages/Callback/index.tsx
@@ -1,20 +1,10 @@
-import { useHandleSignInCallback, useLogto } from '@logto/react';
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useHandleSignInCallback } from '@logto/react';
+import React from 'react';
 
 const Callback = () => {
-  const { isAuthenticated, isLoading } = useLogto();
-  const navigate = useNavigate();
+  const { isLoading } = useHandleSignInCallback('/');
 
-  useHandleSignInCallback();
-
-  useEffect(() => {
-    if (isAuthenticated && !isLoading) {
-      navigate('/', { replace: true });
-    }
-  }, [isAuthenticated, isLoading, navigate]);
-
-  return <p>Redirecting...</p>;
+  return isLoading ? <p>Redirecting...</p> : null;
 };
 
 export default Callback;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Try simplify the callback logics in user apps. Now `useHandleSignInCallback` hook will accept a return URL param, and will navigate the browser to that URL once the sign-in callback process is completed successfully.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] React sample app works