### PR TITLE
feat(react): add error prop to useLogto context

### DIFF
--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -5,8 +5,10 @@ export type LogtoContextProps = {
   logtoClient?: LogtoClient;
   isAuthenticated: boolean;
   loadingCount: number;
+  error?: Error;
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
   setLoadingCount: React.Dispatch<React.SetStateAction<number>>;
+  setError: React.Dispatch<React.SetStateAction<Error | undefined>>;
 };
 
 export const throwContextError = (): never => {
@@ -17,6 +19,8 @@ export const LogtoContext = createContext<LogtoContextProps>({
   logtoClient: undefined,
   isAuthenticated: false,
   loadingCount: 0,
+  error: undefined,
   setIsAuthenticated: throwContextError,
   setLoadingCount: throwContextError,
+  setError: throwContextError,
 });

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -14,6 +14,7 @@ export const LogtoProvider = ({ config, children }: LogtoProviderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState(
     memorizedLogtoClient.logtoClient.isAuthenticated
   );
+  const [error, setError] = useState<Error>();
   const memorizedContextValue = useMemo(
     () => ({
       ...memorizedLogtoClient,
@@ -21,8 +22,10 @@ export const LogtoProvider = ({ config, children }: LogtoProviderProps) => {
       setIsAuthenticated,
       loadingCount,
       setLoadingCount,
+      error,
+      setError,
     }),
-    [memorizedLogtoClient, isAuthenticated, loadingCount]
+    [memorizedLogtoClient, isAuthenticated, loadingCount, error]
   );
 
   return <LogtoContext.Provider value={memorizedContextValue}>{children}</LogtoContext.Provider>;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add `error` prop to `useLogto` hook context.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1927](https://linear.app/silverhand/issue/LOG-1927/add-error-prop-to-uselogto-context)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed new unit test case