### PR TITLE
fix(browser): clear authenticated status before signing-in

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -223,6 +223,9 @@ export default class LogtoClient {
     });
 
     this.signInSession = { redirectUri, codeVerifier, state };
+    this.refreshToken = null;
+    this.idToken = null;
+
     window.location.assign(signInUri);
   }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove `idToken` and `refreshToken` from localStorage before navigating to sign-in page, in order to clear the authenticated status in application.

This is helpful when session is expired and user would need to re-sign-in to the app. Restoring these two token would help provider a cleaner environment in the re-signing-in process.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed UT
- [x] React sample works