### PR TITLE
fix(browser-sample): add typescript to browser-sample dev dependencies

### DIFF
--- a/packages/browser-sample/package.json
+++ b/packages/browser-sample/package.json
@@ -26,7 +26,8 @@
     "postcss": "^8.4.6",
     "prettier": "^2.5.1",
     "process": "^0.11.10",
-    "stylelint": "^14.8.2"
+    "stylelint": "^14.8.2",
+    "typescript": "^4.6.2"
   },
   "eslintConfig": {
     "extends": "@silverhand",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,13 +82,14 @@ importers:
       prettier: ^2.5.1
       process: ^0.11.10
       stylelint: ^14.8.2
+      typescript: ^4.6.2
     dependencies:
       '@logto/browser': link:../browser
     devDependencies:
       '@parcel/core': 2.3.2
       '@parcel/transformer-sass': 2.3.2_@parcel+core@2.3.2
-      '@silverhand/eslint-config': 0.14.0_o3yyxvqqntu2psyhklvnrymevm
-      '@silverhand/eslint-config-react': 0.14.0_ytn3cfaekkntpobubxackssdp4
+      '@silverhand/eslint-config': 0.14.0_olllqumueb3v7rts5ghh64o4um
+      '@silverhand/eslint-config-react': 0.14.0_7ccgw2hms7sbmtc6ldwgpujtxm
       buffer: 6.0.3
       eslint: 8.9.0
       lint-staged: 12.3.4
@@ -97,6 +98,7 @@ importers:
       prettier: 2.5.1
       process: 0.11.10
       stylelint: 14.8.2
+      typescript: 4.6.2
 
   packages/js:
     specifiers:
@@ -2635,12 +2637,12 @@ packages:
       - typescript
     dev: true
 
-  /@silverhand/eslint-config-react/0.14.0_ytn3cfaekkntpobubxackssdp4:
+  /@silverhand/eslint-config-react/0.14.0_7ccgw2hms7sbmtc6ldwgpujtxm:
     resolution: {integrity: sha512-7ylw/SFiYHbcCUNCki9Hv+zdMBIieW6AmNNmqjX3Orn8CvlN/yAUxN/hy9JPpuOCOXquz6mVMDYtmWFGndwy2Q==}
     peerDependencies:
       stylelint: ^14.8.2
     dependencies:
-      '@silverhand/eslint-config': 0.14.0_o3yyxvqqntu2psyhklvnrymevm
+      '@silverhand/eslint-config': 0.14.0_olllqumueb3v7rts5ghh64o4um
       eslint-config-xo-react: 0.25.0_qz4xqql3u5wwuyk5yn2xotjnt4
       eslint-plugin-react: 7.29.4_eslint@8.9.0
       eslint-plugin-react-hooks: 4.3.0_eslint@8.9.0
@@ -2668,37 +2670,6 @@ packages:
       eslint-config-prettier: 8.4.0_eslint@8.9.0
       eslint-config-xo: 0.40.0_eslint@8.9.0
       eslint-config-xo-typescript: 0.50.0_j5lx745m5a5mhkgwniio6hgz24
-      eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
-      eslint-plugin-consistent-default-export-name: 0.0.7
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.9.0
-      eslint-plugin-import: 2.25.4_eslint@8.9.0
-      eslint-plugin-no-use-extend-native: 0.5.0
-      eslint-plugin-node: 11.1.0_eslint@8.9.0
-      eslint-plugin-prettier: 3.4.1_t5rlqxhdzybjjhn5fth7z27jl4
-      eslint-plugin-promise: 6.0.0_eslint@8.9.0
-      eslint-plugin-sql: 2.1.0_eslint@8.9.0
-      eslint-plugin-unicorn: 39.0.0_eslint@8.9.0
-      pkg-dir: 4.2.0
-      prettier: 2.5.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@silverhand/eslint-config/0.14.0_o3yyxvqqntu2psyhklvnrymevm:
-    resolution: {integrity: sha512-Fiaf3FUSbHzPeYqmMncgw5sQ/48rF7MMTzKhgKQ5RhVy7ja7rmD7XaptRxqIHkxnsVcQK4NkPMGa+tjIASwRzg==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      eslint: ^8.1.0
-      prettier: ^2.3.2
-    dependencies:
-      '@silverhand/eslint-plugin-fp': 2.5.0_eslint@8.9.0
-      '@typescript-eslint/eslint-plugin': 5.12.1_xarqyfa3bttng37r4mnqofphu4
-      '@typescript-eslint/parser': 5.12.1_eslint@8.9.0
-      eslint: 8.9.0
-      eslint-config-prettier: 8.4.0_eslint@8.9.0
-      eslint-config-xo: 0.40.0_eslint@8.9.0
-      eslint-config-xo-typescript: 0.50.0_jonz64vfjlw7rid3254xwnmqy4
       eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
       eslint-plugin-consistent-default-export-name: 0.0.7
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.9.0
@@ -3089,51 +3060,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.12.1_xarqyfa3bttng37r4mnqofphu4:
-    resolution: {integrity: sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.12.1_eslint@8.9.0
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/type-utils': 5.12.1_eslint@8.9.0
-      '@typescript-eslint/utils': 5.12.1_eslint@8.9.0
-      debug: 4.3.3
-      eslint: 8.9.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.3.5
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser/5.12.1_eslint@8.9.0:
-    resolution: {integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1
-      debug: 4.3.3
-      eslint: 8.9.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.12.1_fhzmdq77bspfhxkfuzq4fbrdsy:
     resolution: {integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3182,24 +3108,6 @@ packages:
       '@typescript-eslint/visitor-keys': 5.12.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.12.1_eslint@8.9.0:
-    resolution: {integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/utils': 5.12.1_eslint@8.9.0
-      debug: 4.3.3
-      eslint: 8.9.0
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils/5.12.1_fhzmdq77bspfhxkfuzq4fbrdsy:
     resolution: {integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3243,26 +3151,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.12.1:
-    resolution: {integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/visitor-keys': 5.12.1
-      debug: 4.3.3
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.5
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.12.1_typescript@4.5.5:
     resolution: {integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3303,24 +3191,6 @@ packages:
       typescript: 4.6.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils/5.12.1_eslint@8.9.0:
-    resolution: {integrity: sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1
-      eslint: 8.9.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.9.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils/5.12.1_fhzmdq77bspfhxkfuzq4fbrdsy:
@@ -4915,18 +4785,6 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.12.1_vi5pmobbcwscu4omhcfxwlbqwm
       eslint: 8.9.0
       typescript: 4.5.5
-    dev: true
-
-  /eslint-config-xo-typescript/0.50.0_jonz64vfjlw7rid3254xwnmqy4:
-    resolution: {integrity: sha512-Ru2tXB8y2w9fFHLm4v2AVfY6P81UbfEuDZuxEpeXlfV65Ezlk0xO4nBaT899ojIFkWfr60rP9Ye4CdVUUT1UYg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': '>=5.8.0'
-      eslint: '>=8.0.0'
-      typescript: '>=4.4'
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.1_xarqyfa3bttng37r4mnqofphu4
-      eslint: 8.9.0
     dev: true
 
   /eslint-config-xo/0.40.0_eslint@8.9.0:
@@ -10291,15 +10149,6 @@ packages:
 
   /tslib/2.3.1:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
-    dev: true
-
-  /tsutils/3.21.0:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
     dev: true
 
   /tsutils/3.21.0_typescript@4.5.5:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
As discussed offline with @gao-sun , add typescript to devDependencies of browser-sample project, in order to get rid of the annoying warnings from eslint-configs.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] `pnpm i` does not print error messages of missing `typescript` peer dependencies