### PR TITLE
refactor(react): move statements to try blocks

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -59,18 +59,18 @@ const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
       if (!logtoClient) {
         return throwContextError();
       }
-      setLoadingState(true);
 
       try {
+        setLoadingState(true);
+
         await logtoClient.handleSignInCallback(callbackUri);
         setIsAuthenticated(true);
+        window.location.assign(returnToPageUrl);
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while handling sign in callback.');
       } finally {
         setLoadingState(false);
       }
-
-      window.location.assign(returnToPageUrl);
     },
     [logtoClient, returnToPageUrl, setIsAuthenticated, setLoadingState, handleError]
   );
@@ -101,9 +101,9 @@ const useLogto = (): Logto => {
         return throwContextError();
       }
 
-      setLoadingState(true);
-
       try {
+        setLoadingState(true);
+
         await logtoClient.signIn(redirectUri);
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while signing in.');
@@ -119,9 +119,10 @@ const useLogto = (): Logto => {
       if (!logtoClient) {
         return throwContextError();
       }
-      setLoadingState(true);
 
       try {
+        setLoadingState(true);
+
         await logtoClient.signOut(postLogoutRedirectUri);
         setIsAuthenticated(false);
       } catch (error: unknown) {
@@ -137,9 +138,10 @@ const useLogto = (): Logto => {
     if (!logtoClient) {
       return throwContextError();
     }
-    setLoadingState(true);
 
     try {
+      setLoadingState(true);
+
       return await logtoClient.fetchUserInfo();
     } catch (error: unknown) {
       handleError(error, 'Unexpected error occurred while fetching user info.');
@@ -154,9 +156,9 @@ const useLogto = (): Logto => {
         return throwContextError();
       }
 
-      setLoadingState(true);
-
       try {
+        setLoadingState(true);
+
         return await logtoClient.getAccessToken(resource);
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while getting access token.');


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Move statements to try blocks as much as possible.

Fixed an infinite loop issue caused by executing `window.location.assign` even on error occurred, which can be avoided by moving these staments into try blocks.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2600](https://linear.app/silverhand/issue/LOG-2600/move-locationassign-to-try-block-in-react-sdk)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally