### PR TITLE
refactor(react): use LogtoClientError as error type in React SDK

### DIFF
--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config.InitialOptions = {
   preset: 'ts-jest',
   collectCoverageFrom: ['src/**/*.{ts|tsx}'],
   coverageReporters: ['lcov', 'text-summary'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',
   transform: {
     '\\.(ts|js)x?$': 'ts-jest',

--- a/packages/react/jest.setup.js
+++ b/packages/react/jest.setup.js
@@ -1,0 +1,18 @@
+// Need to disable following rules to mock text-decode/text-encoder and crypto for jsdom
+// https://github.com/jsdom/jsdom/issues/1612
+/* eslint-disable unicorn/prefer-module */
+const crypto = require('crypto');
+
+const { location } = require('jest-location-mock');
+const { TextDecoder, TextEncoder } = require('text-encoder');
+/* eslint-enable unicorn/prefer-module */
+
+/* eslint-disable @silverhand/fp/no-mutation */
+global.crypto = {
+  getRandomValues: (buffer) => crypto.randomFillSync(buffer),
+  subtle: crypto.webcrypto.subtle,
+};
+global.location = location;
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+/* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,14 +1,14 @@
-import LogtoClient from '@logto/browser';
+import LogtoClient, { LogtoClientError } from '@logto/browser';
 import { createContext } from 'react';
 
 export type LogtoContextProps = {
   logtoClient?: LogtoClient;
   isAuthenticated: boolean;
   loadingCount: number;
-  error?: Error;
+  error?: LogtoClientError;
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
   setLoadingCount: React.Dispatch<React.SetStateAction<number>>;
-  setError: React.Dispatch<React.SetStateAction<Error | undefined>>;
+  setError: React.Dispatch<React.SetStateAction<LogtoClientError | undefined>>;
 };
 
 export const throwContextError = (): never => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,10 @@
 export type { LogtoContextProps } from './context';
-export type { LogtoConfig, IdTokenClaims, UserInfoResponse } from '@logto/browser';
+export type {
+  LogtoConfig,
+  IdTokenClaims,
+  UserInfoResponse,
+  LogtoClientError,
+  LogtoClientErrorCode,
+} from '@logto/browser';
 export * from './provider';
 export { useLogto, useHandleSignInCallback } from './hooks';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,4 +1,4 @@
-import LogtoClient, { LogtoConfig } from '@logto/browser';
+import LogtoClient, { LogtoClientError, LogtoConfig } from '@logto/browser';
 import React, { ReactNode, useMemo, useState } from 'react';
 
 import { LogtoContext } from './context';
@@ -14,7 +14,7 @@ export const LogtoProvider = ({ config, children }: LogtoProviderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState(
     memorizedLogtoClient.logtoClient.isAuthenticated
   );
-  const [error, setError] = useState<Error>();
+  const [error, setError] = useState<LogtoClientError>();
   const memorizedContextValue = useMemo(
     () => ({
       ...memorizedLogtoClient,

--- a/packages/react/tsconfig.test.json
+++ b/packages/react/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "allowJs": true,
+  }
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Use `LogtoClientError` instead of generic `Error` as error type in React SDK.
* Export `LogtoClientError` and `LogtoClientErrorCode` types from React SDK

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2172](https://linear.app/silverhand/issue/LOG-2712/refactor-error-type-in-react-sdk)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed UTs