### PR TITLE
refactor(vue): use LogtoClientError as error type in Vue SDK

### DIFF
--- a/packages/vue/jest.config.ts
+++ b/packages/vue/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config.InitialOptions = {
   preset: 'ts-jest',
   collectCoverageFrom: ['src/**/*.ts'],
   coverageReporters: ['lcov', 'text-summary'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',
 };
 

--- a/packages/vue/jest.setup.js
+++ b/packages/vue/jest.setup.js
@@ -1,0 +1,18 @@
+// Need to disable following rules to mock text-decode/text-encoder and crypto for jsdom
+// https://github.com/jsdom/jsdom/issues/1612
+/* eslint-disable unicorn/prefer-module */
+const crypto = require('crypto');
+
+const { location } = require('jest-location-mock');
+const { TextDecoder, TextEncoder } = require('text-encoder');
+/* eslint-enable unicorn/prefer-module */
+
+/* eslint-disable @silverhand/fp/no-mutation */
+global.crypto = {
+  getRandomValues: (buffer) => crypto.randomFillSync(buffer),
+  subtle: crypto.webcrypto.subtle,
+};
+global.location = location;
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+/* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,11 +1,11 @@
-import LogtoClient from '@logto/browser';
+import LogtoClient, { LogtoClientError } from '@logto/browser';
 import { computed, ComputedRef, reactive, Ref, toRefs, UnwrapRef } from 'vue';
 
 type LogtoContextProperties = {
   logtoClient: LogtoClient | undefined;
   isAuthenticated: boolean;
   loadingCount: number;
-  error: Error | undefined;
+  error: LogtoClientError | undefined;
 };
 
 export type Context = {
@@ -13,7 +13,7 @@ export type Context = {
   logtoClient: Ref<UnwrapRef<LogtoClient | undefined>>;
   isAuthenticated: Ref<boolean>;
   loadingCount: Ref<number>;
-  error: Ref<Error | undefined>;
+  error: Ref<LogtoClientError | undefined>;
   isLoading: ComputedRef<boolean>;
   setError: (error: unknown, fallbackErrorMessage?: string | undefined) => void;
   setIsAuthenticated: (isAuthenticated: boolean) => void;
@@ -35,11 +35,11 @@ export const createContext = (client: LogtoClient): Context => {
   const isLoading = computed(() => loadingCount.value > 0);
 
   /* eslint-disable @silverhand/fp/no-mutation */
-  const setError = (_error: unknown, fallbackErrorMessage?: string) => {
-    if (_error instanceof Error) {
+  const setError = (_error: unknown) => {
+    if (_error instanceof LogtoClientError) {
       error.value = _error;
-    } else if (fallbackErrorMessage) {
-      error.value = new Error(fallbackErrorMessage);
+    } else {
+      throw _error;
     }
   };
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,11 +1,22 @@
-import LogtoClient, { IdTokenClaims, LogtoConfig, UserInfoResponse } from '@logto/browser';
+import LogtoClient, {
+  IdTokenClaims,
+  LogtoClientError,
+  LogtoConfig,
+  UserInfoResponse,
+} from '@logto/browser';
 import { App, inject, readonly, Ref, watchEffect } from 'vue';
 
 import { logtoInjectionKey, contextInjectionKey } from './consts';
 import { Context, createContext, throwContextError } from './context';
 import { createPluginMethods } from './plugin';
 
-export type { LogtoConfig, IdTokenClaims, UserInfoResponse } from '@logto/browser';
+export type {
+  LogtoConfig,
+  IdTokenClaims,
+  UserInfoResponse,
+  LogtoClientError,
+  LogtoClientErrorCode,
+} from '@logto/browser';
 
 type LogtoVuePlugin = {
   install: (app: App, config: LogtoConfig) => void;
@@ -14,7 +25,7 @@ type LogtoVuePlugin = {
 type Logto = {
   isAuthenticated: Readonly<Ref<boolean>>;
   isLoading: Readonly<Ref<boolean>>;
-  error?: Readonly<Ref<Error | undefined>>;
+  error: Readonly<Ref<LogtoClientError | undefined>>;
   fetchUserInfo: () => Promise<UserInfoResponse | undefined>;
   getAccessToken: (resource?: string) => Promise<string | undefined>;
   getIdTokenClaims: () => IdTokenClaims | undefined;
@@ -113,7 +124,7 @@ export const useHandleSignInCallback = (returnToPageUrl = window.location.origin
   }
 
   const currentPageUrl = window.location.href;
-  const { isAuthenticated, isLoading, logtoClient } = context;
+  const { isAuthenticated, isLoading, logtoClient, error } = context;
   const { handleSignInCallback } = createPluginMethods(context);
 
   watchEffect(() => {
@@ -125,5 +136,6 @@ export const useHandleSignInCallback = (returnToPageUrl = window.location.origin
   return {
     isLoading: readonly(isLoading),
     isAuthenticated: readonly(isAuthenticated),
+    error: readonly(error),
   };
 };

--- a/packages/vue/tsconfig.test.json
+++ b/packages/vue/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "allowJs": true,
+  }
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Use `LogtoClientError` instead of generic `Error` as error type in Vue SDK.
* Export `LogtoClientError` and `LogtoClientErrorCode` types from Vue SDK

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2173](https://linear.app/silverhand/issue/LOG-2713/refactor-error-type-in-vue-sdk)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed UTs