### PR TITLE
refactor: export LogtoClientError from SDKs

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -50,7 +50,7 @@ const useErrorHandler = () => {
 };
 
 const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
-  const { logtoClient, isAuthenticated, setIsAuthenticated } = useContext(LogtoContext);
+  const { logtoClient, isAuthenticated, error, setIsAuthenticated } = useContext(LogtoContext);
   const { isLoading, setLoadingState } = useLoadingState();
   const { handleError } = useErrorHandler();
 
@@ -84,6 +84,7 @@ const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
   return {
     isLoading,
     isAuthenticated,
+    error,
   };
 };
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,10 @@
 export type { LogtoContextProps } from './context';
-export type { LogtoConfig, IdTokenClaims, UserInfoResponse } from '@logto/browser';
+export type {
+  LogtoConfig,
+  IdTokenClaims,
+  UserInfoResponse,
+  LogtoClientError,
+  LogtoClientErrorCode,
+} from '@logto/browser';
 export * from './provider';
 export { useLogto, useHandleSignInCallback } from './hooks';

--- a/packages/vue/src/index.test.ts
+++ b/packages/vue/src/index.test.ts
@@ -98,7 +98,7 @@ describe('useLogto', () => {
 
     expect(isAuthenticated.value).toBe(false);
     expect(isLoading.value).toBe(false);
-    expect(error?.value).toBeUndefined();
+    expect(error.value).toBeUndefined();
     expect(signIn).toBeInstanceOf(Function);
     expect(signOut).toBeInstanceOf(Function);
     expect(getAccessToken).toBeInstanceOf(Function);

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,7 +5,13 @@ import { logtoInjectionKey, contextInjectionKey } from './consts';
 import { Context, createContext, throwContextError } from './context';
 import { createPluginMethods } from './plugin';
 
-export type { LogtoConfig, IdTokenClaims, UserInfoResponse } from '@logto/browser';
+export type {
+  LogtoConfig,
+  IdTokenClaims,
+  UserInfoResponse,
+  LogtoClientError,
+  LogtoClientErrorCode,
+} from '@logto/browser';
 
 type LogtoVuePlugin = {
   install: (app: App, config: LogtoConfig) => void;
@@ -14,7 +20,7 @@ type LogtoVuePlugin = {
 type Logto = {
   isAuthenticated: Readonly<Ref<boolean>>;
   isLoading: Readonly<Ref<boolean>>;
-  error?: Readonly<Ref<Error | undefined>>;
+  error: Readonly<Ref<Error | undefined>>;
   fetchUserInfo: () => Promise<UserInfoResponse | undefined>;
   getAccessToken: (resource?: string) => Promise<string | undefined>;
   getIdTokenClaims: () => IdTokenClaims | undefined;
@@ -113,7 +119,7 @@ export const useHandleSignInCallback = (returnToPageUrl = window.location.origin
   }
 
   const currentPageUrl = window.location.href;
-  const { isAuthenticated, isLoading, logtoClient } = context;
+  const { isAuthenticated, isLoading, logtoClient, error } = context;
   const { handleSignInCallback } = createPluginMethods(context);
 
   watchEffect(() => {
@@ -125,5 +131,6 @@ export const useHandleSignInCallback = (returnToPageUrl = window.location.origin
   return {
     isLoading: readonly(isLoading),
     isAuthenticated: readonly(isAuthenticated),
+    error: readonly(error),
   };
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Export `LogtoClientError` and `LogtoClientErrorCode` from all js SDKs
* Return `error` object from `useHandleSignInCallback` hook

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] UT passed