### PR TITLE
fix: should export 'LogtoClientError' as a class instead of a type

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,14 @@
 export type { LogtoContextProps } from './context';
+
 export type {
   LogtoConfig,
   IdTokenClaims,
   UserInfoResponse,
-  LogtoClientError,
   LogtoClientErrorCode,
 } from '@logto/browser';
+
+export { LogtoClientError } from '@logto/browser';
+
 export * from './provider';
+
 export { useLogto, useHandleSignInCallback } from './hooks';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -9,9 +9,10 @@ export type {
   LogtoConfig,
   IdTokenClaims,
   UserInfoResponse,
-  LogtoClientError,
   LogtoClientErrorCode,
 } from '@logto/browser';
+
+export { LogtoClientError } from '@logto/browser';
 
 type LogtoVuePlugin = {
   install: (app: App, config: LogtoConfig) => void;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix an issue in React and Vue SDKs.

The exported `LogtoClientError` should be a class not a type.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally in admin console, should work with expressions like `error instanceof LogtoClientError`