### PR TITLE
refactor: expose OidcError class from SDKs

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from './utils';
 
 export type { IdTokenClaims, UserInfoResponse } from '@logto/js';
+export { OidcError } from '@logto/js';
 export * from './errors';
 
 export type LogtoConfig = {

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -51,3 +51,13 @@ export class LogtoRequestError extends Error {
     this.code = code;
   }
 }
+
+export class OidcError {
+  error: string;
+  errorDescription: string;
+
+  constructor(error: string, errorDescription: string) {
+    this.error = error;
+    this.errorDescription = errorDescription;
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,7 +7,7 @@ export type {
   LogtoClientErrorCode,
 } from '@logto/browser';
 
-export { LogtoClientError } from '@logto/browser';
+export { LogtoClientError, OidcError } from '@logto/browser';
 
 export * from './provider';
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -12,7 +12,7 @@ export type {
   LogtoClientErrorCode,
 } from '@logto/browser';
 
-export { LogtoClientError } from '@logto/browser';
+export { LogtoClientError, OidcError } from '@logto/browser';
 
 type LogtoVuePlugin = {
   install: (app: App, config: LogtoConfig) => void;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Previously, in our LogtoError class, there is a `data` property and its type is `unknown`, which makes the it difficult for any client that integrated our SDK to load content in `error.data`. The user will have to write a lousy type guard in order to make it work.

Therefore, we provide a new `OidcError` class from our core SDK, and export it in all js SDKs, in order to make it possible to write:

```ts
if (error.data instanceof OidcError) {
  const { error, errorDesccription } = error.data;
  ...
}
```

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->