### PR TITLE
fix(js): oidc error description should be optional string

### DIFF
--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -54,9 +54,9 @@ export class LogtoRequestError extends Error {
 
 export class OidcError {
   error: string;
-  errorDescription: string;
+  errorDescription?: string;
 
-  constructor(error: string, errorDescription: string) {
+  constructor(error: string, errorDescription?: string) {
     this.error = error;
     this.errorDescription = errorDescription;
   }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`errorDescription` in OidcError should be optional string, according to OIDC provider definitions.

<img width="415" alt="image" src="https://user-images.githubusercontent.com/12833674/170807044-4a9fe6d1-2ff2-4d7c-a278-282828ef9631.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A