### PR TITLE
refactor(js): improve error data type in callback URI verification

### DIFF
--- a/packages/js/src/utils/callback-uri.test.ts
+++ b/packages/js/src/utils/callback-uri.test.ts
@@ -1,5 +1,5 @@
 import { verifyAndParseCodeFromCallbackUri } from './callback-uri';
-import { LogtoError } from './errors';
+import { LogtoError, OidcError } from './errors';
 
 const code = 'some_code';
 const state = 'some_state';
@@ -23,7 +23,7 @@ describe('verifyAndParseCodeFromCallbackUri', () => {
   test('callback uri, containing error parameter, should throw', () => {
     const callbackUrl = `http://localhost:3000/callback?code=${code}&state=${state}&error=${error}`;
     expect(() => verifyAndParseCodeFromCallbackUri(callbackUrl, redirectUri, state)).toMatchError(
-      new LogtoError('callback_uri_verification.error_found', { error, errorDescription: null })
+      new LogtoError('callback_uri_verification.error_found', new OidcError(error))
     );
   });
 

--- a/packages/js/src/utils/callback-uri.ts
+++ b/packages/js/src/utils/callback-uri.ts
@@ -1,5 +1,7 @@
+import { conditional } from '@silverhand/essentials';
+
 import { QueryKey } from '../consts';
-import { LogtoError } from './errors';
+import { LogtoError, OidcError } from './errors';
 
 export const parseUriParameters = (uri: string) => {
   const [, queryString = ''] = uri.split('?');
@@ -18,14 +20,14 @@ export const verifyAndParseCodeFromCallbackUri = (
   }
   const uriParameters = parseUriParameters(callbackUri);
 
-  const error = uriParameters.get(QueryKey.Error);
-  const errorDescription = uriParameters.get(QueryKey.ErrorDescription);
+  const error = conditional(uriParameters.get(QueryKey.Error));
+  const errorDescription = conditional(uriParameters.get(QueryKey.ErrorDescription));
 
   if (error) {
-    throw new LogtoError('callback_uri_verification.error_found', {
-      error,
-      errorDescription,
-    });
+    throw new LogtoError(
+      'callback_uri_verification.error_found',
+      new OidcError(error, errorDescription)
+    );
   }
 
   const stateFromCallbackUri = uriParameters.get(QueryKey.State);

--- a/packages/js/src/utils/errors.test.ts
+++ b/packages/js/src/utils/errors.test.ts
@@ -1,3 +1,4 @@
+import { OidcError } from '.';
 import { LogtoError, LogtoErrorCode, LogtoRequestError } from './errors';
 
 describe('LogtoError', () => {
@@ -15,10 +16,11 @@ describe('LogtoError', () => {
     const code: LogtoErrorCode = 'callback_uri_verification';
     const error = 'error_value';
     const errorDescription = 'error_description_content';
-    const logtoError = new LogtoError(code, { error, errorDescription });
+    const logtoError = new LogtoError(code, new OidcError(error, errorDescription));
     expect(logtoError).toHaveProperty('code', code);
     expect(logtoError).toHaveProperty('message', code);
     expect(logtoError).toHaveProperty('data', { error, errorDescription });
+    expect(logtoError.data).toBeInstanceOf(OidcError);
   });
 });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Improved error data type handling in callback URI verification. Now use `OidcError` class instead of plain `Object`.
* Added unit test case

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed UTs.
- [x] The error thrown from callback URI verification now contains a `OidcError` data property.