### PR TITLE
refactor: use `console.error` to output all caught errors in debugger console

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -42,6 +42,7 @@ const useErrorHandler = () => {
       } else if (fallbackErrorMessage) {
         setError(new Error(fallbackErrorMessage));
       }
+      console.error(error);
     },
     [setError]
   );

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -41,6 +41,7 @@ export const createContext = (client: LogtoClient): Context => {
     } else if (fallbackErrorMessage) {
       error.value = new Error(fallbackErrorMessage);
     }
+    console.error(error);
   };
 
   const setLoading = (isLoading: boolean) => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Use 'console.error' to output all caught errors in browser debugger console in React and Vue SDKs. So that the user can quickly navigate to the code line where the error is thrown.

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/170876975-7e8affbd-0a5b-42e0-940e-b1a470379f1f.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally in admin console and we can see error output in debugger console