### PR TITLE
fix(react): calling getIdTokenClaims will not cause infinite loop

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -178,10 +178,10 @@ const useLogto = (): Logto => {
 
     try {
       return logtoClient.getIdTokenClaims();
-    } catch (error: unknown) {
-      handleError(error, 'Unexpected error occurred while getting id token claims.');
+    } catch {
+      // Do nothing if any exception occurs. Caller will get undefined value.
     }
-  }, [logtoClient, handleError]);
+  }, [logtoClient]);
 
   if (!logtoClient) {
     return throwContextError();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove `handleError` from `getIdTokenClaims` catch block, in order to avoid an infinite loop issue when calling it on component is first rendered.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
Related internal discusstion:
[LOG-2799](https://linear.app/silverhand/issue/LOG-2799/discussion-infinite-loop-on-calling-getidtokenclaims-on-component)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in react sample project, calling `getIdTokenClaims` outside `useEffect` didn't end up in infinite loop any more.