### PR TITLE
refactor: remove setIsAuthenticated false from sign out

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -90,8 +90,7 @@ const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
 };
 
 const useLogto = (): Logto => {
-  const { logtoClient, loadingCount, isAuthenticated, error, setIsAuthenticated } =
-    useContext(LogtoContext);
+  const { logtoClient, loadingCount, isAuthenticated, error } = useContext(LogtoContext);
   const { setLoadingState } = useLoadingState();
   const { handleError } = useErrorHandler();
 
@@ -126,14 +125,17 @@ const useLogto = (): Logto => {
         setLoadingState(true);
 
         await logtoClient.signOut(postLogoutRedirectUri);
-        setIsAuthenticated(false);
+
+        // We deliberately do NOT set isAuthenticated to false here, because the app state may change immediately
+        // even before navigating to the oidc end session endpoint, which might cause rendering problems.
+        // Instead, we will reload isAuthenticated state when the user is redirected back to the app.
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while signing out.');
       } finally {
         setLoadingState(false);
       }
     },
-    [logtoClient, setIsAuthenticated, setLoadingState, handleError]
+    [logtoClient, setLoadingState, handleError]
   );
 
   const fetchUserInfo = useCallback(async () => {

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -28,7 +28,10 @@ export const createPluginMethods = (context: Context) => {
       setLoading(true);
 
       await logtoClient.value.signOut(postLogoutRedirectUri);
-      setIsAuthenticated(false);
+
+      // We deliberately do NOT set isAuthenticated to false here, because the app state may change immediately
+      // even before navigating to the oidc end session endpoint, which might cause rendering problems.
+      // Instead, we will reload isAuthenticated state when the user is redirected back to the app.
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while signing out.');
     } finally {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Removed `setIsAuthenticated(false)` from `signOut` method in React and Vue SDKs, for it will cause an immediate state change in the client app, which might lead to problems that prevent browser navigating to the end session endpoint.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally in AC, and the sign out worked as expected