### PR TITLE
refactor: add 'profile' to reserved scopes in js sdk

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -308,11 +308,12 @@ export default class LogtoClient {
 
     try {
       const accessTokenKey = buildAccessTokenKey(resource);
-      const { appId: clientId } = this.logtoConfig;
+      const { appId: clientId, scopes: customScopes } = this.logtoConfig;
       const { tokenEndpoint } = await this.getOidcConfig();
+      const scopes = withReservedScopes(customScopes).split(' ');
       const { accessToken, refreshToken, idToken, scope, expiresIn } =
         await fetchTokenByRefreshToken(
-          { clientId, tokenEndpoint, refreshToken: this.refreshToken, resource },
+          { clientId, tokenEndpoint, refreshToken: this.refreshToken, resource, scopes },
           this.requester
         );
 

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -16,7 +16,7 @@ describe('generateSignInUri', () => {
       state,
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile'
     );
   });
 
@@ -31,7 +31,7 @@ describe('generateSignInUri', () => {
       resources: ['resource1', 'resource2'],
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+scope1+scope2&resource=resource1&resource=resource2'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile+scope1+scope2&resource=resource1&resource=resource2'
     );
   });
 });

--- a/packages/js/src/utils/scopes.test.ts
+++ b/packages/js/src/utils/scopes.test.ts
@@ -4,7 +4,8 @@ const email = 'email';
 const name = 'name';
 const offlineAccess = 'offline_access';
 const openid = 'openid';
-const reservedScopes = [openid, offlineAccess];
+const profile = 'profile';
+const reservedScopes = [openid, offlineAccess, profile];
 const reservedScopesString = reservedScopes.join(' ');
 
 describe('withReservedScopes', () => {

--- a/packages/js/src/utils/scopes.ts
+++ b/packages/js/src/utils/scopes.ts
@@ -3,7 +3,7 @@
  * @return scopes should contain all reserved scopes ( Logto requires `openid` and `offline_access` )
  */
 export const withReservedScopes = (originalScopes?: string[]): string => {
-  const uniqueScopes = new Set(['openid', 'offline_access', ...(originalScopes ?? [])]);
+  const uniqueScopes = new Set(['openid', 'offline_access', 'profile', ...(originalScopes ?? [])]);
 
   return Array.from(uniqueScopes).join(' ');
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add 'profile' to reserved scopes in js sdk

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally, AC can sign in successfully
- [x] `fetchUserInfo` api can receive more user informations