### PR TITLE
refactor: remove setIsAuthenticated true from handleSignInCallback

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -51,7 +51,7 @@ const useErrorHandler = () => {
 };
 
 const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
-  const { logtoClient, isAuthenticated, error, setIsAuthenticated } = useContext(LogtoContext);
+  const { logtoClient, isAuthenticated, error } = useContext(LogtoContext);
   const { isLoading, setLoadingState } = useLoadingState();
   const { handleError } = useErrorHandler();
 
@@ -65,7 +65,11 @@ const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
         setLoadingState(true);
 
         await logtoClient.handleSignInCallback(callbackUri);
-        setIsAuthenticated(true);
+
+        // We deliberately do NOT set isAuthenticated to true here, because the app state may change immediately
+        // even before navigating to the return page URL, which might cause rendering problems.
+        // Instead, we will reload isAuthenticated state when the user is redirected back and the client app is reloaded.
+
         window.location.assign(returnToPageUrl);
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while handling sign in callback.');
@@ -73,7 +77,7 @@ const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
         setLoadingState(false);
       }
     },
-    [logtoClient, returnToPageUrl, setIsAuthenticated, setLoadingState, handleError]
+    [logtoClient, returnToPageUrl, setLoadingState, handleError]
   );
 
   useEffect(() => {
@@ -128,7 +132,7 @@ const useLogto = (): Logto => {
 
         // We deliberately do NOT set isAuthenticated to false here, because the app state may change immediately
         // even before navigating to the oidc end session endpoint, which might cause rendering problems.
-        // Instead, we will reload isAuthenticated state when the user is redirected back to the app.
+        // Instead, we will reload isAuthenticated state when the user is redirected back and the client app is reloaded.
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while signing out.');
       } finally {

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,7 +1,7 @@
 import { Context, throwContextError } from './context';
 
 export const createPluginMethods = (context: Context) => {
-  const { logtoClient, setLoading, setError, setIsAuthenticated } = context;
+  const { logtoClient, setLoading, setError } = context;
 
   const signIn = async (redirectUri: string) => {
     if (!logtoClient.value) {
@@ -31,7 +31,7 @@ export const createPluginMethods = (context: Context) => {
 
       // We deliberately do NOT set isAuthenticated to false here, because the app state may change immediately
       // even before navigating to the oidc end session endpoint, which might cause rendering problems.
-      // Instead, we will reload isAuthenticated state when the user is redirected back to the app.
+      // Instead, we will reload isAuthenticated state when the user is redirected back and the client app is reloaded.
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while signing out.');
     } finally {
@@ -91,7 +91,11 @@ export const createPluginMethods = (context: Context) => {
     try {
       setLoading(true);
       await logtoClient.value.handleSignInCallback(callbackUri);
-      setIsAuthenticated(true);
+
+      // We deliberately do NOT set isAuthenticated to true here, because the app state may change immediately
+      // even before navigating to the return page URL, which might cause rendering problems.
+      // Instead, we will reload isAuthenticated state when the user is redirected back and the client app is reloaded.
+
       window.location.assign(returnToPageUrl);
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while handling sign in callback.');


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove `setIsAuthenticated(true)` from `handleSignInCallback` method.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally with AC