### PR TITLE
refactor: add callback function param to useHandleSignInCallback hook

### DIFF
--- a/packages/react-sample/src/pages/Callback/index.tsx
+++ b/packages/react-sample/src/pages/Callback/index.tsx
@@ -1,8 +1,12 @@
 import { useHandleSignInCallback } from '@logto/react';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const Callback = () => {
-  const { isLoading } = useHandleSignInCallback('/');
+  const navigate = useNavigate();
+  const { isLoading } = useHandleSignInCallback(() => {
+    navigate('/');
+  });
 
   return isLoading ? <p>Redirecting...</p> : null;
 };

--- a/packages/vue-sample/src/views/CallbackView.vue
+++ b/packages/vue-sample/src/views/CallbackView.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useHandleSignInCallback } from "@logto/vue";
-const { isLoading } = useHandleSignInCallback();
+import router from "@/router";
+
+const { isLoading } = useHandleSignInCallback(() => {
+  router.push("/");
+});
 </script>
 
 <template>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -113,20 +113,21 @@ export const useLogto = (): Logto => {
  *
  * Use this in the setup script of your Callback page to make sure the injection works
  */
-export const useHandleSignInCallback = (returnToPageUrl = window.location.origin) => {
+export const useHandleSignInCallback = (callback?: () => void) => {
   const context = inject<Context>(contextInjectionKey);
 
   if (!context) {
     return throwContextError();
   }
 
-  const currentPageUrl = window.location.href;
   const { isAuthenticated, isLoading, logtoClient, error } = context;
   const { handleSignInCallback } = createPluginMethods(context);
 
   watchEffect(() => {
+    const currentPageUrl = window.location.href;
+
     if (!isAuthenticated.value && logtoClient.value?.isSignInRedirected(currentPageUrl)) {
-      void handleSignInCallback(currentPageUrl, returnToPageUrl);
+      void handleSignInCallback(currentPageUrl, callback);
     }
   });
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,7 +1,7 @@
 import { Context, throwContextError } from './context';
 
 export const createPluginMethods = (context: Context) => {
-  const { logtoClient, setLoading, setError } = context;
+  const { logtoClient, setLoading, setError, setIsAuthenticated } = context;
 
   const signIn = async (redirectUri: string) => {
     if (!logtoClient.value) {
@@ -83,7 +83,7 @@ export const createPluginMethods = (context: Context) => {
     }
   };
 
-  const handleSignInCallback = async (callbackUri: string, returnToPageUrl: string) => {
+  const handleSignInCallback = async (callbackUri: string, callbackFunction?: () => void) => {
     if (!logtoClient.value) {
       return throwContextError();
     }
@@ -91,12 +91,8 @@ export const createPluginMethods = (context: Context) => {
     try {
       setLoading(true);
       await logtoClient.value.handleSignInCallback(callbackUri);
-
-      // We deliberately do NOT set isAuthenticated to true here, because the app state may change immediately
-      // even before navigating to the return page URL, which might cause rendering problems.
-      // Moreover, since the location will be redirected, the isAuthenticated state will not matter any more.
-
-      window.location.assign(returnToPageUrl);
+      setIsAuthenticated(true);
+      callbackFunction?.();
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while handling sign in callback.');
     } finally {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refactor `useHandleSignInCallback` hook method in React and Vue SDKs.
* Pass in a `callback` function instead of a `returnToPageUrl`
* Set `isAuthenticated` to true immediately after successfully handling the sign in callback
* Execute the `callback` method after successfully handling the sign in callback, instead of navigating the page using `window.location.assign`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in React sample and Vue sample projects. Worked fine