### PR TITLE
feat(browser): only append reserved scopes in LogtoClient constructor

### DIFF
--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -1,7 +1,7 @@
 import { generateSignInUri } from '@logto/js';
 import { Nullable } from '@silverhand/essentials';
 
-import LogtoClient, { AccessToken, LogtoClientError, LogtoSignInSessionItem } from '.';
+import LogtoClient, { AccessToken, LogtoClientError, LogtoConfig, LogtoSignInSessionItem } from '.';
 
 const appId = 'app_id_value';
 const endpoint = 'https://logto.dev';
@@ -84,6 +84,10 @@ jest.mock('jose', () => ({
  * Make LogtoClient.signInSession accessible for test
  */
 class LogtoClientSignInSessionAccessor extends LogtoClient {
+  public getLogtoConfig(): Nullable<LogtoConfig> {
+    return this.logtoConfig;
+  }
+
   public getSignInSessionItem(): Nullable<LogtoSignInSessionItem> {
     return this.signInSession;
   }
@@ -98,8 +102,23 @@ class LogtoClientSignInSessionAccessor extends LogtoClient {
 }
 
 describe('LogtoClient', () => {
-  test('constructor', () => {
-    expect(() => new LogtoClient({ endpoint, appId }, requester)).not.toThrow();
+  describe('constructor', () => {
+    it('should not throw', () => {
+      expect(() => new LogtoClient({ endpoint, appId }, requester)).not.toThrow();
+    });
+
+    it('should append reserved scopes', () => {
+      const logtoClient = new LogtoClientSignInSessionAccessor(
+        { endpoint, appId, scopes: ['foo'] },
+        requester
+      );
+      expect(logtoClient.getLogtoConfig()).toHaveProperty('scopes', [
+        'openid',
+        'offline_access',
+        'profile',
+        'foo',
+      ]);
+    });
   });
 
   describe('signInSession', () => {

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -73,7 +73,10 @@ export default class LogtoClient {
   private _idToken: Nullable<string>;
 
   constructor(logtoConfig: LogtoConfig, requester = createRequester()) {
-    this.logtoConfig = logtoConfig;
+    this.logtoConfig = {
+      ...logtoConfig,
+      scopes: withReservedScopes(logtoConfig.scopes).split(' '),
+    };
     this.logtoStorageKey = buildLogtoKey(logtoConfig.appId);
     this.requester = requester;
     this._idToken = localStorage.getItem(buildIdTokenKey(this.logtoStorageKey));
@@ -207,12 +210,11 @@ export default class LogtoClient {
   }
 
   public async signIn(redirectUri: string) {
-    const { appId: clientId, resources, scopes: customScopes } = this.logtoConfig;
+    const { appId: clientId, resources, scopes } = this.logtoConfig;
     const { authorizationEndpoint } = await this.getOidcConfig();
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = await generateCodeChallenge(codeVerifier);
     const state = generateState();
-    const scopes = withReservedScopes(customScopes).split(' ');
 
     const signInUri = generateSignInUri({
       authorizationEndpoint,
@@ -308,12 +310,11 @@ export default class LogtoClient {
 
     try {
       const accessTokenKey = buildAccessTokenKey(resource);
-      const { appId: clientId, scopes: customScopes } = this.logtoConfig;
+      const { appId: clientId } = this.logtoConfig;
       const { tokenEndpoint } = await this.getOidcConfig();
-      const scopes = withReservedScopes(customScopes).split(' ');
       const { accessToken, refreshToken, idToken, scope, expiresIn } =
         await fetchTokenByRefreshToken(
-          { clientId, tokenEndpoint, refreshToken: this.refreshToken, resource, scopes },
+          { clientId, tokenEndpoint, refreshToken: this.refreshToken, resource },
           this.requester
         );
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

- Append the reserved scopes to the custom ones in `LogtoClient` constructor.
    - See Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1655098928722249)
- Remove the parameter `scopes` when `getAccessTokenByRefreshToken`, that aligns with Kotlin and Swift SDK for now
    - Next up: LOG-1464 @simeng-li will deal with the required scopes when `getAccessTokenByRefreshToken`. See Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1655099458314629)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3006

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs.

<img width="292" alt="image" src="https://user-images.githubusercontent.com/10594507/173335610-ffec9cd8-56fb-49db-ab1f-bcfc1322ef78.png">
