### PR TITLE
chore: remove only-allow pnpm from all sub-packages

### DIFF
--- a/packages/browser-sample/package.json
+++ b/packages/browser-sample/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "start": "parcel public/index.html -p 3000",
     "build": "rm -rf dist && parcel build public/index.html --no-autoinstall",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts src",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts src",

--- a/packages/react-sample/package.json
+++ b/packages/react-sample/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "start": "parcel src/index.html -p 3000",
     "check": "tsc --noEmit",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts --ext .tsx src",

--- a/packages/vue-sample/package.json
+++ b/packages/vue-sample/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "start": "vite",
     "check": "vue-tsc --noEmit",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
-    "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts src",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove `npx only-allow pnpm` from all sub-packages, leaving it only in the root package.json of our monorepo.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-3040](https://linear.app/silverhand/issue/LOG-3040/support-npm-i-for-logto-js-sdks)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A