### PR TITLE
refactor(js): add userinfo props to id token claims type

### DIFF
--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -16,6 +16,10 @@ const IdTokenClaimsSchema = s.type({
   exp: s.number(),
   iat: s.number(),
   at_hash: s.optional(s.string()),
+  name: s.optional(s.string()),
+  username: s.optional(s.string()),
+  avatar: s.optional(s.string()),
+  role_names: s.optional(s.array(s.string())),
 });
 
 export type IdTokenClaims = s.Infer<typeof IdTokenClaimsSchema>;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add userinfo props to id token claims type, since we already have these values in idTokenClaims.
The client app can decode userinfo from idTokenClaims without requesting from the `/oidc/me` interface

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A