### PR TITLE
fix(js SDK): getAccessTokenByRefreshToken should not return idToken

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -314,7 +314,13 @@ export default class LogtoClient {
       const { tokenEndpoint } = await this.getOidcConfig();
       const { accessToken, refreshToken, idToken, scope, expiresIn } =
         await fetchTokenByRefreshToken(
-          { clientId, tokenEndpoint, refreshToken: this.refreshToken, resource },
+          {
+            clientId,
+            tokenEndpoint,
+            refreshToken: this.refreshToken,
+            resource,
+            scopes: ['offline_access'], // Force remove openid scope from the request
+          },
           this.requester
         );
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
getAccessTokenByRefreshToken should not return idToken. Pur our offline discussion, always pass the `offline_access` scope in.
<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="723" alt="WX20220625-115009@2x" src="https://user-images.githubusercontent.com/36393111/175757132-0d67469b-a74c-4fed-9ef3-1a4d4cb39c23.png">
<img width="876" alt="WX20220625-115017@2x" src="https://user-images.githubusercontent.com/36393111/175757136-62d85fe6-4a01-46a2-9958-0d8cc812d3bb.png">

@logto-io/eng 