### PR TITLE
feat(js,browser): configurable prompt

### DIFF
--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -1,4 +1,4 @@
-import { generateSignInUri, PromptValue } from '@logto/js';
+import { generateSignInUri, Prompt } from '@logto/js';
 import { Nullable } from '@silverhand/essentials';
 
 import LogtoClient, { AccessToken, LogtoClientError, LogtoConfig, LogtoSignInSessionItem } from '.';
@@ -127,12 +127,12 @@ describe('LogtoClient', () => {
 
     it('should use the default prompt value "consent" if we does not provide the custom prompt', () => {
       const logtoClient = new LogtoClientSignInSessionAccessor({ endpoint, appId }, requester);
-      expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', PromptValue.Consent);
+      expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', Prompt.Consent);
     });
 
     it('should use the custom prompt value "login"', () => {
       const logtoClient = new LogtoClientSignInSessionAccessor(
-        { endpoint, appId, prompt: PromptValue.Login },
+        { endpoint, appId, prompt: Prompt.Login },
         requester
       );
       expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', 'login');

--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -1,4 +1,4 @@
-import { generateSignInUri } from '@logto/js';
+import { generateSignInUri, PromptValue } from '@logto/js';
 import { Nullable } from '@silverhand/essentials';
 
 import LogtoClient, { AccessToken, LogtoClientError, LogtoConfig, LogtoSignInSessionItem } from '.';
@@ -123,6 +123,19 @@ describe('LogtoClient', () => {
         'profile',
         'foo',
       ]);
+    });
+
+    it('should use the default prompt value "consent" if we does not provide the custom prompt', () => {
+      const logtoClient = new LogtoClientSignInSessionAccessor({ endpoint, appId }, requester);
+      expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', PromptValue.Consent);
+    });
+
+    it('should use the custom prompt value "login"', () => {
+      const logtoClient = new LogtoClientSignInSessionAccessor(
+        { endpoint, appId, prompt: PromptValue.Login },
+        requester
+      );
+      expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', 'login');
     });
   });
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -12,6 +12,7 @@ import {
   generateSignOutUri,
   generateState,
   IdTokenClaims,
+  PromptValue,
   Requester,
   revoke,
   UserInfoResponse,
@@ -42,6 +43,7 @@ export type LogtoConfig = {
   appId: string;
   scopes?: string[];
   resources?: string[];
+  prompt?: PromptValue;
   usingPersistStorage?: boolean;
 };
 
@@ -75,6 +77,7 @@ export default class LogtoClient {
   constructor(logtoConfig: LogtoConfig, requester = createRequester()) {
     this.logtoConfig = {
       ...logtoConfig,
+      prompt: logtoConfig.prompt ?? PromptValue.Consent,
       scopes: withReservedScopes(logtoConfig.scopes).split(' '),
     };
     this.logtoStorageKey = buildLogtoKey(logtoConfig.appId);
@@ -375,7 +378,7 @@ export default class LogtoClient {
     accessToken,
     expiresIn,
   }: CodeTokenResponse) {
-    this.refreshToken = refreshToken;
+    this.refreshToken = refreshToken ?? null;
     this.idToken = idToken;
 
     // NOTE: Will add scope to accessTokenKey when needed. (Linear issue LOG-1589)

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -12,7 +12,7 @@ import {
   generateSignOutUri,
   generateState,
   IdTokenClaims,
-  PromptValue,
+  Prompt,
   Requester,
   revoke,
   UserInfoResponse,
@@ -43,7 +43,7 @@ export type LogtoConfig = {
   appId: string;
   scopes?: string[];
   resources?: string[];
-  prompt?: PromptValue;
+  prompt?: Prompt;
   usingPersistStorage?: boolean;
 };
 
@@ -77,7 +77,7 @@ export default class LogtoClient {
   constructor(logtoConfig: LogtoConfig, requester = createRequester()) {
     this.logtoConfig = {
       ...logtoConfig,
-      prompt: logtoConfig.prompt ?? PromptValue.Consent,
+      prompt: logtoConfig.prompt ?? Prompt.Consent,
       scopes: withReservedScopes(logtoConfig.scopes).split(' '),
     };
     this.logtoStorageKey = buildLogtoKey(logtoConfig.appId);

--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -28,3 +28,8 @@ export enum QueryKey {
   State = 'state',
   Token = 'token',
 }
+
+export enum PromptValue {
+  Consent = 'consent',
+  Login = 'login',
+}

--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -29,7 +29,7 @@ export enum QueryKey {
   Token = 'token',
 }
 
-export enum PromptValue {
+export enum Prompt {
   Consent = 'consent',
   Login = 'login',
 }

--- a/packages/js/src/core/fetch-token.ts
+++ b/packages/js/src/core/fetch-token.ts
@@ -23,7 +23,7 @@ export type FetchTokenByRefreshTokenParameters = {
 
 type SnakeCaseCodeTokenResponse = {
   access_token: string;
-  refresh_token: string;
+  refresh_token?: string;
   id_token: string;
   scope: string;
   expires_in: number;

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -1,4 +1,4 @@
-import { PromptValue } from '../consts';
+import { Prompt } from '../consts';
 import { generateSignInUri } from './sign-in';
 
 const authorizationEndpoint = 'https://logto.dev/oidc/sign-in';
@@ -30,7 +30,7 @@ describe('generateSignInUri', () => {
       state,
       scopes: ['scope1', 'scope2'],
       resources: ['resource1', 'resource2'],
-      prompt: PromptValue.Login,
+      prompt: Prompt.Login,
     });
     expect(signInUri).toEqual(
       'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=login&scope=openid+offline_access+profile+scope1+scope2&resource=resource1&resource=resource2'

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -1,3 +1,4 @@
+import { PromptValue } from '../consts';
 import { generateSignInUri } from './sign-in';
 
 const authorizationEndpoint = 'https://logto.dev/oidc/sign-in';
@@ -7,7 +8,7 @@ const codeChallenge = 'codeChallenge';
 const state = 'state';
 
 describe('generateSignInUri', () => {
-  test('without scopes and resources', () => {
+  test('without prompt, scopes and resources', () => {
     const signInUri = generateSignInUri({
       authorizationEndpoint,
       clientId,
@@ -20,7 +21,7 @@ describe('generateSignInUri', () => {
     );
   });
 
-  test('with scopes and resources', () => {
+  test('with prompt, scopes and resources', () => {
     const signInUri = generateSignInUri({
       authorizationEndpoint,
       clientId,
@@ -29,9 +30,10 @@ describe('generateSignInUri', () => {
       state,
       scopes: ['scope1', 'scope2'],
       resources: ['resource1', 'resource2'],
+      prompt: PromptValue.Login,
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile+scope1+scope2&resource=resource1&resource=resource2'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=login&scope=openid+offline_access+profile+scope1+scope2&resource=resource1&resource=resource2'
     );
   });
 });

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -1,4 +1,4 @@
-import { PromptValue, QueryKey } from '../consts';
+import { Prompt, QueryKey } from '../consts';
 import { withReservedScopes } from '../utils';
 
 const codeChallengeMethod = 'S256';
@@ -12,7 +12,7 @@ export type SignInUriParameters = {
   state: string;
   scopes?: string[];
   resources?: string[];
-  prompt?: PromptValue;
+  prompt?: Prompt;
 };
 
 export const generateSignInUri = ({
@@ -32,7 +32,7 @@ export const generateSignInUri = ({
     [QueryKey.CodeChallengeMethod]: codeChallengeMethod,
     [QueryKey.State]: state,
     [QueryKey.ResponseType]: responseType,
-    [QueryKey.Prompt]: prompt ?? PromptValue.Consent,
+    [QueryKey.Prompt]: prompt ?? Prompt.Consent,
     [QueryKey.Scope]: withReservedScopes(scopes),
   });
 

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -1,8 +1,7 @@
-import { QueryKey } from '../consts';
+import { PromptValue, QueryKey } from '../consts';
 import { withReservedScopes } from '../utils';
 
 const codeChallengeMethod = 'S256';
-const prompt = 'consent';
 const responseType = 'code';
 
 export type SignInUriParameters = {
@@ -13,6 +12,7 @@ export type SignInUriParameters = {
   state: string;
   scopes?: string[];
   resources?: string[];
+  prompt?: PromptValue;
 };
 
 export const generateSignInUri = ({
@@ -23,6 +23,7 @@ export const generateSignInUri = ({
   state,
   scopes,
   resources,
+  prompt,
 }: SignInUriParameters) => {
   const urlSearchParameters = new URLSearchParams({
     [QueryKey.ClientId]: clientId,
@@ -31,7 +32,7 @@ export const generateSignInUri = ({
     [QueryKey.CodeChallengeMethod]: codeChallengeMethod,
     [QueryKey.State]: state,
     [QueryKey.ResponseType]: responseType,
-    [QueryKey.Prompt]: prompt,
+    [QueryKey.Prompt]: prompt ?? PromptValue.Consent,
     [QueryKey.Scope]: withReservedScopes(scopes),
   });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`prompt` value can be configurable on our SDK.

To change the refresh token in the `CodeTokenResponse` to be optional for we won't get a refresh token from it if the prompt value is `login`. See Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1649906832335309)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2936

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="303" alt="image" src="https://user-images.githubusercontent.com/10594507/175868455-3d7b982d-2a09-47a2-a962-cf1a44ae2a76.png">
<img width="647" alt="image" src="https://user-images.githubusercontent.com/10594507/175868465-79db9623-dd11-4fd8-bd1b-6c716d58705a.png">
