### PR TITLE
fix(js): refresh access token without a resource should return id token

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -319,7 +319,7 @@ export default class LogtoClient {
             tokenEndpoint,
             refreshToken: this.refreshToken,
             resource,
-            scopes: ['offline_access'], // Force remove openid scope from the request
+            scopes: resource ? ['offline_access'] : undefined, // Force remove openid scope from the request
           },
           this.requester
         );


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refresh access token without a resource should return id token. Only if the resource is provided, hard code the scope as `offline_access`.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
@logto-io/eng 