### PR TITLE
fix(browser): should use prompt param on sign-in

### DIFF
--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -26,6 +26,14 @@ const mockedSignInUri = generateSignInUri({
   codeChallenge: mockCodeChallenge,
   state: mockedState,
 });
+const mockedSignInUriWithLoginPrompt = generateSignInUri({
+  authorizationEndpoint,
+  clientId: appId,
+  redirectUri,
+  codeChallenge: mockCodeChallenge,
+  state: mockedState,
+  prompt: Prompt.Login,
+});
 
 const refreshTokenStorageKey = `logto:${appId}:refreshToken`;
 const idTokenStorageKey = `logto:${appId}:idToken`;
@@ -197,6 +205,12 @@ describe('LogtoClient', () => {
       const logtoClient = new LogtoClient({ endpoint, appId }, requester);
       await logtoClient.signIn(redirectUri);
       expect(window.location.toString()).toEqual(mockedSignInUri);
+    });
+
+    it('should redirect to signInUri just after calling signIn with user specified prompt', async () => {
+      const logtoClient = new LogtoClient({ endpoint, appId, prompt: Prompt.Login }, requester);
+      await logtoClient.signIn(redirectUri);
+      expect(window.location.toString()).toEqual(mockedSignInUriWithLoginPrompt);
     });
   });
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -200,7 +200,7 @@ export default class LogtoClient {
   }
 
   public async signIn(redirectUri: string) {
-    const { appId: clientId, resources, scopes } = this.logtoConfig;
+    const { appId: clientId, prompt, resources, scopes } = this.logtoConfig;
     const { authorizationEndpoint } = await this.getOidcConfig();
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = await generateCodeChallenge(codeVerifier);
@@ -214,6 +214,7 @@ export default class LogtoClient {
       state,
       scopes,
       resources,
+      prompt,
     });
 
     this.signInSession = { redirectUri, codeVerifier, state };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Should use user specified prompt type in logtoClient when calling `.signIn()` method

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Unit test case added, all passed
- [x] Tested locally with React sample. Login was successful, and there was no `refreshToken` in localStorage
