### PR TITLE
refactor: postLogoutRedirectUri should be optional param

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -10,7 +10,7 @@ type Logto = {
   getAccessToken: (resource?: string) => Promise<string | undefined>;
   getIdTokenClaims: () => IdTokenClaims | undefined;
   signIn: (redirectUri: string) => Promise<void>;
-  signOut: (postLogoutRedirectUri: string) => Promise<void>;
+  signOut: (postLogoutRedirectUri?: string) => Promise<void>;
 };
 
 const useLoadingState = () => {
@@ -122,7 +122,7 @@ const useLogto = (): Logto => {
   );
 
   const signOut = useCallback(
-    async (postLogoutRedirectUri: string) => {
+    async (postLogoutRedirectUri?: string) => {
       if (!logtoClient) {
         return throwContextError();
       }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -25,7 +25,7 @@ type Logto = {
   getAccessToken: (resource?: string) => Promise<string | undefined>;
   getIdTokenClaims: () => IdTokenClaims | undefined;
   signIn: (redirectUri: string) => Promise<void>;
-  signOut: (postLogoutRedirectUri: string) => Promise<void>;
+  signOut: (postLogoutRedirectUri?: string) => Promise<void>;
 };
 
 /**

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -19,7 +19,7 @@ export const createPluginMethods = (context: Context) => {
     }
   };
 
-  const signOut = async (postLogoutRedirectUri: string) => {
+  const signOut = async (postLogoutRedirectUri?: string) => {
     if (!logtoClient.value) {
       return throwContextError();
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`postLogoutRedirectUri` should be optional param. Fixed in React and Vue SDKs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] UTs passed
