### PR TITLE
feat(client): persist access token

### DIFF
--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -106,9 +106,13 @@ export const createAdapters = () => ({
   generateState,
 });
 
-export const createClient = (prompt?: Prompt, storage = new MockedStorage()) =>
+export const createClient = (
+  prompt?: Prompt,
+  storage = new MockedStorage(),
+  persistAccessToken?: boolean
+) =>
   new LogtoClient(
-    { endpoint, appId, prompt },
+    { endpoint, appId, prompt, persistAccessToken },
     {
       ...createAdapters(),
       storage,

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -1,0 +1,29 @@
+import { Prompt } from '@logto/js';
+import { Infer, number, record, string, type } from 'superstruct';
+
+export type LogtoConfig = {
+  endpoint: string;
+  appId: string;
+  scopes?: string[];
+  resources?: string[];
+  prompt?: Prompt;
+  persistAccessToken?: boolean;
+};
+
+export const AccessTokenSchema = type({
+  token: string(),
+  scope: string(),
+  expiresAt: number(),
+});
+
+export type AccessToken = Infer<typeof AccessTokenSchema>;
+
+export const LogtoSignInSessionItemSchema = type({
+  redirectUri: string(),
+  codeVerifier: string(),
+  state: string(),
+});
+
+export const LogtoAccessTokenMapSchema = record(string(), AccessTokenSchema);
+
+export type LogtoSignInSessionItem = Infer<typeof LogtoSignInSessionItemSchema>;

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -35,12 +35,18 @@ export default class LogtoClient {
   private createNodeClient(request: NextApiRequest) {
     this.storage = new NextStorage(request);
 
-    return new NodeClient(this.config, {
-      storage: this.storage,
-      navigate: (url) => {
-        this.navigateUrl = url;
+    return new NodeClient(
+      {
+        ...this.config,
+        persistAccessToken: this.config.persistAccessToken ?? true,
       },
-    });
+      {
+        storage: this.storage,
+        navigate: (url) => {
+          this.navigateUrl = url;
+        },
+      }
+    );
   }
 
   private withIronSession(handler: NextApiHandler) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add an optional feature: persist access token to storage.

Before this, access token is only saved in instance property, when creating a new instance, it doesn't have any access token, but it can reuse refresh token from storage, and then grant a new access token. This is fine for SPA, since it only have an instance when the user navigates between pages. But in other circumstances, especially in traditional app when LogtoClient is run in server side, it will create a new instance each time when receiving a request, that means there will be so many instances sharing the same storage. Then, it'll be good to reuse access token.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs.
