### PR TITLE
feat(next): set getAccessToken as an option

### DIFF
--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -28,4 +28,14 @@ export type LogtoNextConfig = LogtoConfig & {
 export type LogtoUser = {
   isAuthenticated: boolean;
   claims?: IdTokenClaims;
+  accessToken?: string;
+};
+
+/**
+ * @getAccessToken: if set to true, will try to get an access token and attach to req.user,
+ * if unable to grant an access token, will set req.user.isAuthenticated to false,
+ * this can make sure the refresh token is not revoked and still valid, so is considered more secure.
+ */
+export type WithLogtoConfig = {
+  getAccessToken?: boolean;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

For checking isAuthenticated, there are 2 steps:

1. check `logtoClient.isAuthenticated`, that actually means that `idToken` is exist (session is exist).
2. try to get an accessToken, make sure the refresh token is still valid.

step 2 is optional and skiped by default.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs and local tested with sample.
