### PR TITLE
refactor(js,client): createRequester

### DIFF
--- a/packages/client/src/utils/requester.ts
+++ b/packages/client/src/utils/requester.ts
@@ -1,15 +1,21 @@
-import { LogtoRequestError, LogtoRequestErrorBody, Requester } from '@logto/js';
+import { LogtoError, LogtoRequestError, logtoRequestErrorSchema, Requester } from '@logto/js';
 
 export const createRequester = (fetchFunction: typeof fetch): Requester => {
   return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
     const response = await fetchFunction(...args);
 
     if (!response.ok) {
+      const responseJson = await response.json();
+
+      if (!logtoRequestErrorSchema.is(responseJson)) {
+        throw new LogtoError('unexpected_response_error', responseJson);
+      }
+
       // Expected request error from server
-      const { code, message } = await response.json<LogtoRequestErrorBody>();
+      const { code, message } = responseJson;
       throw new LogtoRequestError(code, message);
     }
 
-    return response.json<T>();
+    return response.json();
   };
 };

--- a/packages/js/src/utils/errors.test.ts
+++ b/packages/js/src/utils/errors.test.ts
@@ -1,5 +1,10 @@
-import { OidcError } from '.';
-import { LogtoError, LogtoErrorCode, LogtoRequestError } from './errors';
+import {
+  LogtoError,
+  LogtoErrorCode,
+  LogtoRequestError,
+  logtoRequestErrorSchema,
+  OidcError,
+} from './errors';
 
 describe('LogtoError', () => {
   test('new LogtoError should contain correct properties', () => {
@@ -24,10 +29,25 @@ describe('LogtoError', () => {
   });
 });
 
+const code = 'some code';
+const message = 'some message';
+
+describe('logtoRequestErrorSchema checks the error response from the server', () => {
+  it('should be false when the error response is empty', () => {
+    expect(logtoRequestErrorSchema.is({})).toBeFalsy();
+  });
+
+  it('should be true when the error response contains the expected properties', () => {
+    expect(logtoRequestErrorSchema.is({ code, message })).toBeTruthy();
+  });
+
+  it('should be true when the error response contains more than the expected properties', () => {
+    expect(logtoRequestErrorSchema.is({ code, message, foo: 'bar' })).toBeTruthy();
+  });
+});
+
 describe('LogtoRequestError', () => {
   test('new LogtoRequestError should contain correct properties', () => {
-    const code = 'some code';
-    const message = 'some message';
     const logtoRequestError = new LogtoRequestError(code, message);
     expect(logtoRequestError).toHaveProperty('code', code);
     expect(logtoRequestError).toHaveProperty('message', message);

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import { NormalizeKeyPaths } from '@silverhand/essentials';
 import get from 'lodash.get';
+import * as s from 'superstruct';
 
 const logtoErrorCodes = Object.freeze({
   id_token: {
@@ -17,6 +18,7 @@ const logtoErrorCodes = Object.freeze({
     not_provide_fetch: 'Should provide a fetch function under Node.js',
   },
   crypto_subtle_unavailable: 'Crypto.subtle is unavailable in insecure contexts (non-HTTPS).',
+  unexpected_response_error: 'Unexpected response error from the server.',
 });
 
 export type LogtoErrorCode = NormalizeKeyPaths<typeof logtoErrorCodes>;
@@ -42,6 +44,11 @@ export class LogtoError extends Error {
     this.data = data;
   }
 }
+
+export const logtoRequestErrorSchema = s.type({
+  code: s.string(),
+  message: s.string(),
+});
 
 export class LogtoRequestError extends Error {
   code: string;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add `logtoRequestErrorSchema` to check Logto request error
- Refactor `createRequester`
    - Throw Logto request error when the response contains both `code` and `message`
    - Otherwise, throw Logto error with the message `Unexpected response error from the server.`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="756" alt="image" src="https://user-images.githubusercontent.com/10594507/181229452-3bea0d56-884c-423a-aada-6f1d87011ce7.png">

<img width="815" alt="image" src="https://user-images.githubusercontent.com/10594507/181229508-2c2da175-30a3-490c-95f1-ac89d3f59bc5.png">

- [x] Locally tested on Admin Console.

    Original

    ![image](https://user-images.githubusercontent.com/10594507/181439453-8dfdf8c7-7653-4fb9-a0a9-b01ddf2fe9cb.png)

    Now

    ![image](https://user-images.githubusercontent.com/10594507/181439502-d55427b2-d3be-49ac-99d3-8e3b825323e8.png)
