### PR TITLE
refactor: make storage functions async

### DIFF
--- a/packages/browser/src/storage.test.ts
+++ b/packages/browser/src/storage.test.ts
@@ -7,43 +7,43 @@ describe('BrowserStorage', () => {
   });
 
   describe('Basic functions', () => {
-    it('should set and get item', () => {
+    it('should set and get item', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('idToken', 'value');
-      expect(storage.getItem('idToken')).toBe('value');
+      await storage.setItem('idToken', 'value');
+      await expect(storage.getItem('idToken')).resolves.toBe('value');
     });
 
-    it('should remove item', () => {
+    it('should remove item', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('idToken', 'value');
-      storage.removeItem('idToken');
-      expect(storage.getItem('idToken')).toBeNull();
+      await storage.setItem('idToken', 'value');
+      await storage.removeItem('idToken');
+      await expect(storage.getItem('idToken')).resolves.toBeNull();
     });
 
-    it('should set and get item (signInSession)', () => {
+    it('should set and get item (signInSession)', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('signInSession', 'value');
-      expect(storage.getItem('signInSession')).toBe('value');
+      await storage.setItem('signInSession', 'value');
+      await expect(storage.getItem('signInSession')).resolves.toBe('value');
     });
 
-    it('should remove item (signInSession)', () => {
+    it('should remove item (signInSession)', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('signInSession', 'value');
-      storage.removeItem('signInSession');
-      expect(storage.getItem('signInSession')).toBeNull();
+      await storage.setItem('signInSession', 'value');
+      await storage.removeItem('signInSession');
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
     });
   });
 
   describe('Real storage check', () => {
-    it('should set item to localStorage', () => {
+    it('should set item to localStorage', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('idToken', 'value');
+      await storage.setItem('idToken', 'value');
       expect(localStorage.getItem(`${logtoStorageItemKeyPrefix}:appId:idToken`)).toBe('value');
     });
 
-    it('should set item to sessionStorage', () => {
+    it('should set item to sessionStorage', async () => {
       const storage = new BrowserStorage('appId');
-      storage.setItem('signInSession', 'value');
+      await storage.setItem('signInSession', 'value');
       expect(sessionStorage.getItem(`${logtoStorageItemKeyPrefix}:appId`)).toBe('value');
     });
   });

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -10,7 +10,7 @@ export class BrowserStorage implements Storage {
     this.storageKey = `${logtoStorageItemKeyPrefix}:${appId}`;
   }
 
-  getItem(key: StorageKey): Nullable<string> {
+  async getItem(key: StorageKey): Promise<Nullable<string>> {
     if (key === 'signInSession') {
       return sessionStorage.getItem(this.storageKey);
     }
@@ -18,7 +18,7 @@ export class BrowserStorage implements Storage {
     return localStorage.getItem(`${this.storageKey}:${key}`);
   }
 
-  setItem(key: StorageKey, value: string): void {
+  async setItem(key: StorageKey, value: string): Promise<void> {
     if (key === 'signInSession') {
       sessionStorage.setItem(this.storageKey, value);
 
@@ -27,7 +27,7 @@ export class BrowserStorage implements Storage {
     localStorage.setItem(`${this.storageKey}:${key}`, value);
   }
 
-  removeItem(key: StorageKey): void {
+  async removeItem(key: StorageKey): Promise<void> {
     if (key === 'signInSession') {
       sessionStorage.removeItem(this.storageKey);
 

--- a/packages/client/src/adapter.ts
+++ b/packages/client/src/adapter.ts
@@ -4,9 +4,9 @@ import { Nullable } from '@silverhand/essentials';
 export type StorageKey = 'idToken' | 'refreshToken' | 'accessToken' | 'signInSession';
 
 export interface Storage {
-  getItem(key: StorageKey): Nullable<string>;
-  setItem(key: StorageKey, value: string): void;
-  removeItem(key: StorageKey): void;
+  getItem(key: StorageKey): Promise<Nullable<string>>;
+  setItem(key: StorageKey, value: string): Promise<void>;
+  removeItem(key: StorageKey): Promise<void>;
 }
 
 export type Navigate = (url: string) => void;

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -16,15 +16,15 @@ export class MockedStorage implements Storage {
     }
   }
 
-  public getItem(key: string) {
+  public async getItem(key: string) {
     return this.storage[key] ?? null;
   }
 
-  public setItem(key: string, value: string): void {
+  public async setItem(key: string, value: string): Promise<void> {
     this.storage[key] = value;
   }
 
-  public removeItem(key: string): void {
+  public async removeItem(key: string): Promise<void> {
     /* eslint-disable @typescript-eslint/no-dynamic-delete */
     // eslint-disable-next-line @silverhand/fp/no-delete
     delete this.storage[key];
@@ -123,12 +123,12 @@ export class LogtoClientSignInSessionAccessor extends LogtoClient {
     return this.logtoConfig;
   }
 
-  public getSignInSessionItem(): Nullable<LogtoSignInSessionItem> {
-    return this.signInSession;
+  public async getSignInSessionItem(): Promise<Nullable<LogtoSignInSessionItem>> {
+    return this.getSignInSession();
   }
 
-  public setSignInSessionItem(item: Nullable<LogtoSignInSessionItem>) {
-    this.signInSession = item;
+  public async setSignInSessionItem(item: Nullable<LogtoSignInSessionItem>): Promise<void> {
+    await this.setSignInSession(item);
   }
 
   public getAccessTokenMap(): Map<string, AccessToken> {

--- a/packages/express-sample/package.json
+++ b/packages/express-sample/package.json
@@ -4,10 +4,14 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "ts-node src/app.ts"
+    "precommit": "lint-staged",
+    "start": "ts-node src/app.ts",
+    "check": "tsc --noEmit",
+    "build": "pnpm check",
+    "lint": "eslint --ext .ts src"
   },
   "dependencies": {
-    "@logto/express": "^1.0.0-beta.0",
+    "@logto/express": "^1.0.0-beta.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.1",
     "express-session": "^1.17.3"
@@ -24,15 +28,11 @@
     "postcss": "^8.4.6",
     "postcss-modules": "^4.3.0",
     "prettier": "^2.5.1",
-    "stylelint": "^14.8.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.5.5"
   },
   "eslintConfig": {
     "extends": "@silverhand"
-  },
-  "stylelint": {
-    "extends": "@silverhand/eslint-config/.stylelintrc"
   },
   "prettier": "@silverhand/eslint-config/.prettierrc"
 }

--- a/packages/express/src/storage.test.ts
+++ b/packages/express/src/storage.test.ts
@@ -18,30 +18,30 @@ describe('ExpressStorage', () => {
       const request = makeRequest();
       const storage = new ExpressStorage(request);
       await storage.setItem('idToken', 'value');
-      expect(storage.getItem('idToken')).toBe('value');
+      await expect(storage.getItem('idToken')).resolves.toBe('value');
     });
 
     it('should remove item', async () => {
       const request = makeRequest();
       const storage = new ExpressStorage(request);
       await storage.setItem('idToken', 'value');
-      storage.removeItem('idToken');
-      expect(storage.getItem('idToken')).toBeNull();
+      await storage.removeItem('idToken');
+      await expect(storage.getItem('idToken')).resolves.toBeNull();
     });
 
     it('should set and get item (signInSession)', async () => {
       const request = makeRequest();
       const storage = new ExpressStorage(request);
       await storage.setItem('signInSession', 'value');
-      expect(storage.getItem('signInSession')).toBe('value');
+      await expect(storage.getItem('signInSession')).resolves.toBe('value');
     });
 
     it('should remove item (signInSession)', async () => {
       const request = makeRequest();
       const storage = new ExpressStorage(request);
       await storage.setItem('signInSession', 'value');
-      storage.removeItem('signInSession');
-      expect(storage.getItem('signInSession')).toBeNull();
+      await storage.removeItem('signInSession');
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
     });
   });
 });

--- a/packages/express/src/storage.ts
+++ b/packages/express/src/storage.ts
@@ -9,7 +9,7 @@ export default class ExpressStorage implements Storage {
     this.request.session[key] = value;
   }
 
-  getItem(key: StorageKey) {
+  async getItem(key: StorageKey) {
     const value = this.request.session[key];
 
     if (value === undefined) {
@@ -19,7 +19,7 @@ export default class ExpressStorage implements Storage {
     return String(value);
   }
 
-  removeItem(key: StorageKey) {
+  async removeItem(key: StorageKey) {
     this.request.session[key] = undefined;
   }
 }

--- a/packages/next/src/storage.test.ts
+++ b/packages/next/src/storage.test.ts
@@ -17,30 +17,30 @@ describe('NextStorage', () => {
       const request = makeRequest();
       const storage = new NextStorage(request);
       await storage.setItem('idToken', 'value');
-      expect(storage.getItem('idToken')).toBe('value');
+      await expect(storage.getItem('idToken')).resolves.toBe('value');
     });
 
     it('should remove item', async () => {
       const request = makeRequest();
       const storage = new NextStorage(request);
       await storage.setItem('idToken', 'value');
-      storage.removeItem('idToken');
-      expect(storage.getItem('idToken')).toBeNull();
+      await storage.removeItem('idToken');
+      await expect(storage.getItem('idToken')).resolves.toBeNull();
     });
 
     it('should set and get item (signInSession)', async () => {
       const request = makeRequest();
       const storage = new NextStorage(request);
       await storage.setItem('signInSession', 'value');
-      expect(storage.getItem('signInSession')).toBe('value');
+      await expect(storage.getItem('signInSession')).resolves.toBe('value');
     });
 
     it('should remove item (signInSession)', async () => {
       const request = makeRequest();
       const storage = new NextStorage(request);
       await storage.setItem('signInSession', 'value');
-      storage.removeItem('signInSession');
-      expect(storage.getItem('signInSession')).toBeNull();
+      await storage.removeItem('signInSession');
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
     });
   });
 });

--- a/packages/next/src/storage.ts
+++ b/packages/next/src/storage.ts
@@ -11,7 +11,7 @@ export default class NextStorage implements Storage {
     this.sessionChanged = true;
   }
 
-  getItem(key: StorageKey) {
+  async getItem(key: StorageKey) {
     const value = this.request.session[key];
 
     if (value === undefined) {
@@ -21,7 +21,7 @@ export default class NextStorage implements Storage {
     return String(value);
   }
 
-  removeItem(key: StorageKey) {
+  async removeItem(key: StorageKey) {
     this.request.session[key] = undefined;
     this.sessionChanged = true;
   }

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -11,13 +11,14 @@ const storage = {
 };
 
 const getAccessToken = jest.fn(async () => true);
-const getIdTokenClaims = jest.fn(() => ({ sub: 'sub' }));
+const getIdTokenClaims = jest.fn(async () => ({ sub: 'sub' }));
+const isAuthenticated = jest.fn(async () => true);
 jest.mock('@logto/client', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     getAccessToken,
     getIdTokenClaims,
-    isAuthenticated: true,
+    isAuthenticated,
   })),
   createRequester: jest.fn(),
 }));

--- a/packages/react-sample/src/pages/Home/index.tsx
+++ b/packages/react-sample/src/pages/Home/index.tsx
@@ -10,10 +10,12 @@ const Home = () => {
   const [idTokenClaims, setIdTokenClaims] = useState<IdTokenClaims>();
 
   useEffect(() => {
-    if (isAuthenticated) {
-      const claims = getIdTokenClaims();
-      setIdTokenClaims(claims);
-    }
+    (async () => {
+      if (isAuthenticated) {
+        const claims = await getIdTokenClaims();
+        setIdTokenClaims(claims);
+      }
+    })();
   }, [getIdTokenClaims, isAuthenticated]);
 
   return (

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -5,6 +5,7 @@ import { ComponentType } from 'react';
 import { useLogto, useHandleSignInCallback } from '.';
 import { LogtoProvider } from '../provider';
 
+const isAuthenticated = jest.fn(() => false);
 const isSignInRedirected = jest.fn(() => false);
 const handleSignInCallback = jest.fn(async () => Promise.resolve());
 const getAccessToken = jest.fn(() => {
@@ -14,6 +15,7 @@ const getAccessToken = jest.fn(() => {
 jest.mock('@logto/browser', () => {
   return jest.fn().mockImplementation(() => {
     return {
+      isAuthenticated,
       isSignInRedirected,
       handleSignInCallback,
       getAccessToken,

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -8,7 +8,7 @@ type Logto = {
   isLoading: boolean;
   error?: Error;
   getAccessToken: (resource?: string) => Promise<string | undefined>;
-  getIdTokenClaims: () => IdTokenClaims | undefined;
+  getIdTokenClaims: () => Promise<IdTokenClaims | undefined>;
   signIn: (redirectUri: string) => Promise<void>;
   signOut: (postLogoutRedirectUri?: string) => Promise<void>;
 };
@@ -163,13 +163,13 @@ const useLogto = (): Logto => {
     [logtoClient, setLoadingState, handleError]
   );
 
-  const getIdTokenClaims = useCallback(() => {
+  const getIdTokenClaims = useCallback(async () => {
     if (!logtoClient) {
       return throwContextError();
     }
 
     try {
-      return logtoClient.getIdTokenClaims();
+      return await logtoClient.getIdTokenClaims();
     } catch {
       // Do nothing if any exception occurs. Caller will get undefined value.
     }

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,5 +1,5 @@
 import LogtoClient, { LogtoConfig } from '@logto/browser';
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { LogtoContext } from './context';
 
@@ -11,10 +11,17 @@ export type LogtoProviderProps = {
 export const LogtoProvider = ({ config, children }: LogtoProviderProps) => {
   const [loadingCount, setLoadingCount] = useState(0);
   const memorizedLogtoClient = useMemo(() => ({ logtoClient: new LogtoClient(config) }), [config]);
-  const [isAuthenticated, setIsAuthenticated] = useState(
-    memorizedLogtoClient.logtoClient.isAuthenticated
-  );
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [error, setError] = useState<Error>();
+
+  useEffect(() => {
+    (async () => {
+      const isAuthenticated = await memorizedLogtoClient.logtoClient.isAuthenticated();
+
+      setIsAuthenticated(isAuthenticated);
+    })();
+  }, [memorizedLogtoClient]);
+
   const memorizedContextValue = useMemo(
     () => ({
       ...memorizedLogtoClient,

--- a/packages/vue-sample/src/views/HomeView.vue
+++ b/packages/vue-sample/src/views/HomeView.vue
@@ -17,7 +17,7 @@ const onClickSignOut = () => {
 
 watchEffect(async () => {
   if (isAuthenticated.value) {
-    const claims = getIdTokenClaims();
+    const claims = await getIdTokenClaims();
     idTokenClaims.value = claims;
   }
 });

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,5 +1,5 @@
 import LogtoClient from '@logto/browser';
-import { computed, ComputedRef, reactive, Ref, toRefs, UnwrapRef } from 'vue';
+import { computed, ComputedRef, reactive, Ref, toRefs, UnwrapRef, watchEffect } from 'vue';
 
 type LogtoContextProperties = {
   logtoClient: LogtoClient | undefined;
@@ -24,7 +24,7 @@ export const createContext = (client: LogtoClient): Context => {
   const context = toRefs(
     reactive<LogtoContextProperties>({
       logtoClient: client,
-      isAuthenticated: client.isAuthenticated,
+      isAuthenticated: false,
       loadingCount: 0,
       error: undefined,
     })
@@ -56,6 +56,12 @@ export const createContext = (client: LogtoClient): Context => {
     isAuthenticated.value = _isAuthenticated;
   };
   /* eslint-enable @silverhand/fp/no-mutation */
+
+  watchEffect(async () => {
+    const isAuthenticated = await client.isAuthenticated();
+
+    setIsAuthenticated(isAuthenticated);
+  });
 
   return { ...context, isLoading, setError, setLoading, setIsAuthenticated };
 };

--- a/packages/vue/src/index.test.ts
+++ b/packages/vue/src/index.test.ts
@@ -6,6 +6,7 @@ import { contextInjectionKey, logtoInjectionKey } from './consts';
 import { createContext } from './context';
 import { createPluginMethods } from './plugin';
 
+const isAuthenticated = jest.fn(async () => false);
 const isSignInRedirected = jest.fn(() => false);
 const handleSignInCallback = jest.fn(async () => Promise.resolve());
 const getAccessToken = jest.fn(() => {
@@ -18,7 +19,7 @@ const injectMock = jest.fn<unknown, string[]>((): unknown => {
 jest.mock('@logto/browser', () => {
   return jest.fn().mockImplementation(() => {
     return {
-      isAuthenticated: false,
+      isAuthenticated,
       isSignInRedirected,
       handleSignInCallback,
       getAccessToken,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -23,7 +23,7 @@ type Logto = {
   isLoading: Readonly<Ref<boolean>>;
   error: Readonly<Ref<Error | undefined>>;
   getAccessToken: (resource?: string) => Promise<string | undefined>;
-  getIdTokenClaims: () => IdTokenClaims | undefined;
+  getIdTokenClaims: () => Promise<IdTokenClaims | undefined>;
   signIn: (redirectUri: string) => Promise<void>;
   signOut: (postLogoutRedirectUri?: string) => Promise<void>;
 };

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -55,13 +55,13 @@ export const createPluginMethods = (context: Context) => {
     }
   };
 
-  const getIdTokenClaims = () => {
+  const getIdTokenClaims = async () => {
     if (!logtoClient.value) {
       return throwContextError();
     }
 
     try {
-      return logtoClient.value.getIdTokenClaims();
+      return await logtoClient.value.getIdTokenClaims();
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while getting id token claims.');
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
 
   packages/express-sample:
     specifiers:
-      '@logto/express': ^1.0.0-beta.0
+      '@logto/express': ^1.0.0-beta.2
       '@silverhand/eslint-config': ^0.17.0
       '@silverhand/ts-config': ^0.14.0
       '@types/cookie-parser': ^1.4.3
@@ -233,7 +233,6 @@ importers:
       postcss: ^8.4.6
       postcss-modules: ^4.3.0
       prettier: ^2.5.1
-      stylelint: ^14.8.2
       ts-node: ^10.9.1
       typescript: ^4.5.5
     dependencies:
@@ -253,7 +252,6 @@ importers:
       postcss: 8.4.14
       postcss-modules: 4.3.1_postcss@8.4.14
       prettier: 2.5.1
-      stylelint: 14.8.2
       ts-node: 10.9.1_oiu2ewiupzyxivucxtfadbrvwm
       typescript: 4.7.2
 
@@ -1476,7 +1474,6 @@ packages:
       pacote: 13.4.1
       semver: 7.3.7
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1507,7 +1504,6 @@ packages:
       p-waterfall: 2.1.1
       semver: 7.3.7
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1648,7 +1644,6 @@ packages:
       whatwg-url: 8.7.0
       yargs-parser: 20.2.4
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1846,7 +1841,6 @@ packages:
       npm-registry-fetch: 9.0.0
       npmlog: 4.1.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1876,7 +1870,6 @@ packages:
       pify: 5.0.0
       read-package-json: 3.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1915,7 +1908,6 @@ packages:
       npmlog: 4.1.2
       tar: 6.1.11
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -2014,7 +2006,6 @@ packages:
       pacote: 13.4.1
       semver: 7.3.7
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -2060,7 +2051,6 @@ packages:
       '@npmcli/run-script': 3.0.2
       npmlog: 4.1.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -2162,7 +2152,6 @@ packages:
       slash: 3.0.0
       write-json-file: 4.3.0
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -2410,7 +2399,6 @@ packages:
       treeverse: 2.0.0
       walk-up-path: 1.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -2446,8 +2434,6 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.7
       which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -2478,7 +2464,6 @@ packages:
       pacote: 13.4.1
       semver: 7.3.7
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -2530,7 +2515,6 @@ packages:
       node-gyp: 9.0.0
       read-package-json-fast: 2.0.3
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -3638,7 +3622,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_zhymizk4kfitko2u2d4p3qwyee
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -3658,7 +3641,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_cazrl3eatzhkw4y7xb6glndqh4
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -3678,7 +3660,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_an3wuxxoixcpivwd2moqhhly5q
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -3698,7 +3679,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_zhymizk4kfitko2u2d4p3qwyee
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -3722,7 +3702,7 @@ packages:
       eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
       eslint-plugin-consistent-default-export-name: 0.0.7
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.9.0
-      eslint-plugin-import: 2.25.4_hkug4hnbgllydtpdygs6xvzedm
+      eslint-plugin-import: 2.25.4_eslint@8.9.0
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.9.0
       eslint-plugin-prettier: 4.0.0_t5rlqxhdzybjjhn5fth7z27jl4
@@ -3732,7 +3712,6 @@ packages:
       pkg-dir: 4.2.0
       prettier: 2.5.1
     transitivePeerDependencies:
-      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -3754,7 +3733,7 @@ packages:
       eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
       eslint-plugin-consistent-default-export-name: 0.0.7
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.9.0
-      eslint-plugin-import: 2.25.4_hkug4hnbgllydtpdygs6xvzedm
+      eslint-plugin-import: 2.25.4_eslint@8.9.0
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.9.0
       eslint-plugin-prettier: 4.0.0_t5rlqxhdzybjjhn5fth7z27jl4
@@ -3764,7 +3743,6 @@ packages:
       pkg-dir: 4.2.0
       prettier: 2.5.1
     transitivePeerDependencies:
-      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -3786,7 +3764,7 @@ packages:
       eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
       eslint-plugin-consistent-default-export-name: 0.0.7
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.9.0
-      eslint-plugin-import: 2.25.4_hkug4hnbgllydtpdygs6xvzedm
+      eslint-plugin-import: 2.25.4_eslint@8.9.0
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.9.0
       eslint-plugin-prettier: 4.0.0_t5rlqxhdzybjjhn5fth7z27jl4
@@ -3796,7 +3774,6 @@ packages:
       pkg-dir: 4.2.0
       prettier: 2.5.1
     transitivePeerDependencies:
-      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -5187,8 +5164,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5300,8 +5275,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cacache/16.1.0:
@@ -5326,8 +5299,6 @@ packages:
       ssri: 9.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /call-bind/1.0.2:
@@ -5918,21 +5889,11 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -6588,8 +6549,6 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-import-resolver-typescript/2.5.0_cmtdok55f7srt3k3ux6kqq5jcq:
@@ -6601,7 +6560,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.9.0
-      eslint-plugin-import: 2.25.4_hkug4hnbgllydtpdygs6xvzedm
+      eslint-plugin-import: 2.25.4_eslint@8.9.0
       glob: 7.2.0
       is-glob: 4.0.3
       resolve: 1.22.0
@@ -6610,31 +6569,12 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_e5wtvfn4rlk3af2y4axy7jmfea:
+  /eslint-module-utils/2.7.3:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.1_fhzmdq77bspfhxkfuzq4fbrdsy
       debug: 3.2.7
-      eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.5.0_cmtdok55f7srt3k3ux6kqq5jcq
       find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-consistent-default-export-name/0.0.7:
@@ -6669,24 +6609,19 @@ packages:
       ignore: 5.2.0
     dev: true
 
-  /eslint-plugin-import/2.25.4_hkug4hnbgllydtpdygs6xvzedm:
+  /eslint-plugin-import/2.25.4_eslint@8.9.0:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
-      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.1_fhzmdq77bspfhxkfuzq4fbrdsy
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.9.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_e5wtvfn4rlk3af2y4axy7jmfea
+      eslint-module-utils: 2.7.3
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
@@ -6694,10 +6629,6 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.12.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-no-use-extend-native/0.5.0:
@@ -7069,8 +7000,6 @@ packages:
       parseurl: 1.3.3
       safe-buffer: 5.2.1
       uid-safe: 2.1.5
-    transitivePeerDependencies:
-      - supports-color
 
   /express/4.18.1:
     resolution: {integrity: sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==}
@@ -7107,8 +7036,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /external-editor/3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -7203,8 +7130,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /find-up/2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -9008,7 +8933,6 @@ packages:
       import-local: 3.1.0
       npmlog: 4.1.2
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -9043,7 +8967,6 @@ packages:
       npm-package-arg: 8.1.5
       npm-registry-fetch: 11.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9057,7 +8980,6 @@ packages:
       semver: 7.3.7
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9331,7 +9253,6 @@ packages:
       socks-proxy-agent: 6.1.1
       ssri: 9.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9355,7 +9276,6 @@ packages:
       socks-proxy-agent: 5.0.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9380,7 +9300,6 @@ packages:
       socks-proxy-agent: 6.1.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9818,7 +9737,6 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9959,7 +9877,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9975,7 +9892,6 @@ packages:
       npm-package-arg: 9.0.2
       proc-log: 2.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -9992,7 +9908,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10300,7 +10215,6 @@ packages:
       ssri: 9.0.1
       tar: 6.1.11
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -10862,11 +10776,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -11418,8 +11327,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   /serve-static/1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
@@ -11429,8 +11336,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Since React Native storage solutions are all async and we need to write React Native SDK to extend from @logto/client , it is required to implement the Storage interface in React Native.

However, the existing functions (getItem, setItem, removeItem) in Storage interface are all synchronous, we can't implement the interface with an asynchronous storage solution.

Therefore, we need to make storage functions async in @logto/client in order to unblock React Native SDK development.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Build successfully
- [x] Sign-in and sign-out worked in all sample projects
- [x] Passed all test cases
