### PR TITLE
fix(react,vue): do not set loading to false after calling signIn

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -114,8 +114,6 @@ const useLogto = (): Logto => {
         await logtoClient.signIn(redirectUri);
       } catch (error: unknown) {
         handleError(error, 'Unexpected error occurred while signing in.');
-      } finally {
-        setLoadingState(false);
       }
     },
     [logtoClient, setLoadingState, handleError]

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -14,8 +14,6 @@ export const createPluginMethods = (context: Context) => {
       await logtoClient.value.signIn(redirectUri);
     } catch (error: unknown) {
       setError(error, 'Unexpected error occurred while signing in.');
-    } finally {
-      setLoading(false);
     }
   };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove `setLoadingState(false)` after calling `signIn()` from React and Vue SDKs, in order to remove a potential infinite loop and sign-in failure.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in React sample project with the protected-resource route and auto-triggered sign-in
- [x] Tested in Vue sample project with the protected-resource route.
