### PR TITLE
fix: bump to essentials v1.2.1 to use utf-8 on decoding base64

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@logto/client": "^1.0.0-beta.5",
-    "@silverhand/essentials": "^1.2.0",
+    "@silverhand/essentials": "^1.2.1",
     "js-base64": "^3.7.2"
   },
   "devDependencies": {

--- a/packages/browser/src/utils/generators.test.ts
+++ b/packages/browser/src/utils/generators.test.ts
@@ -1,4 +1,4 @@
-import { UrlSafeBase64 } from '@silverhand/essentials';
+import { urlSafeBase64 } from '@silverhand/essentials';
 import { toUint8Array } from 'js-base64';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators';
@@ -12,7 +12,7 @@ describe('generateState', () => {
 
   test('should be url-safe', () => {
     const state = generateState();
-    expect(UrlSafeBase64.isSafe(state)).toBeTruthy();
+    expect(urlSafeBase64.isSafe(state)).toBeTruthy();
   });
 
   test('raw random data length should be length 64', () => {
@@ -30,7 +30,7 @@ describe('generateCodeVerifier', () => {
 
   test('should be url-safe', () => {
     const codeVerifier = generateCodeVerifier();
-    expect(UrlSafeBase64.isSafe(codeVerifier)).toBeTruthy();
+    expect(urlSafeBase64.isSafe(codeVerifier)).toBeTruthy();
   });
 
   test('raw random data length should be length 64', () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@logto/js": "^1.0.0-beta.5",
-    "@silverhand/essentials": "^1.2.0",
+    "@silverhand/essentials": "^1.2.1",
     "camelcase-keys": "^7.0.1",
     "jose": "^4.3.8",
     "lodash.get": "^4.4.2",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -29,7 +29,7 @@
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@silverhand/essentials": "^1.2.0",
+    "@silverhand/essentials": "^1.2.1",
     "camelcase-keys": "^7.0.1",
     "jose": "^4.3.8",
     "lodash.get": "^4.4.2",

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -214,7 +214,7 @@ describe('verifyIdToken', () => {
 describe('decodeIdToken', () => {
   test('decoding valid JWT should return claims', async () => {
     const { privateKey } = await generateKeyPair('RS256');
-    const jwt = await new SignJWT({ name: null, avatar: undefined, role_names: ['admin'] })
+    const jwt = await new SignJWT({ name: '测试用户', avatar: undefined, role_names: ['admin'] })
       .setProtectedHeader({ alg: 'RS256' })
       .setIssuer('foo')
       .setSubject('bar')
@@ -229,7 +229,7 @@ describe('decodeIdToken', () => {
       aud: 'qux',
       exp: 2000,
       iat: 1000,
-      name: null,
+      name: '测试用户',
       role_names: ['admin'],
     });
   });

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -1,4 +1,4 @@
-import { UrlSafeBase64 } from '@silverhand/essentials';
+import { urlSafeBase64 } from '@silverhand/essentials';
 import { jwtVerify, JWTVerifyGetKey } from 'jose';
 import * as s from 'superstruct';
 
@@ -44,7 +44,7 @@ export const decodeIdToken = (token: string): IdTokenClaims => {
     throw new LogtoError('id_token.invalid_token');
   }
 
-  const json = UrlSafeBase64.decode(encodedPayload);
+  const json = urlSafeBase64.decode(encodedPayload);
   const idTokenClaims: unknown = JSON.parse(json);
   s.assert(idTokenClaims, IdTokenClaimsSchema);
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@logto/client": "^1.0.0-beta.5",
-    "@silverhand/essentials": "^1.2.0",
+    "@silverhand/essentials": "^1.2.1",
     "js-base64": "^3.7.2",
     "node-fetch": "^2.6.7"
   },

--- a/packages/node/src/utils/generators.test.ts
+++ b/packages/node/src/utils/generators.test.ts
@@ -1,4 +1,4 @@
-import { UrlSafeBase64 } from '@silverhand/essentials';
+import { urlSafeBase64 } from '@silverhand/essentials';
 import { toUint8Array } from 'js-base64';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators';
@@ -12,7 +12,7 @@ describe('generateState', () => {
 
   test('should be url-safe', () => {
     const state = generateState();
-    expect(UrlSafeBase64.isSafe(state)).toBeTruthy();
+    expect(urlSafeBase64.isSafe(state)).toBeTruthy();
   });
 
   test('raw random data length should be length 64', () => {
@@ -30,7 +30,7 @@ describe('generateCodeVerifier', () => {
 
   test('should be url-safe', () => {
     const codeVerifier = generateCodeVerifier();
-    expect(UrlSafeBase64.isSafe(codeVerifier)).toBeTruthy();
+    expect(urlSafeBase64.isSafe(codeVerifier)).toBeTruthy();
   });
 
   test('raw random data length should be length 64', () => {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@logto/browser": "^1.0.0-beta.5",
-    "@silverhand/essentials": "^1.2.0"
+    "@silverhand/essentials": "^1.2.1"
   },
   "devDependencies": {
     "@jest/types": "^27.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
-      '@silverhand/essentials': ^1.2.0
+      '@silverhand/essentials': ^1.2.1
       '@silverhand/ts-config': ^1.0.0
       '@types/jest': ^27.4.0
       eslint: ^8.23.0
@@ -43,7 +43,7 @@ importers:
       typescript: 4.7.4
     dependencies:
       '@logto/client': link:../client
-      '@silverhand/essentials': 1.2.0
+      '@silverhand/essentials': 1.2.1
       js-base64: 3.7.2
     devDependencies:
       '@jest/types': 27.5.1
@@ -106,7 +106,7 @@ importers:
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
-      '@silverhand/essentials': ^1.2.0
+      '@silverhand/essentials': ^1.2.1
       '@silverhand/ts-config': ^1.0.0
       '@types/jest': ^27.4.1
       '@types/lodash.get': ^4.4.6
@@ -130,7 +130,7 @@ importers:
       typescript: 4.7.4
     dependencies:
       '@logto/js': link:../js
-      '@silverhand/essentials': 1.2.0
+      '@silverhand/essentials': 1.2.1
       camelcase-keys: 7.0.2
       jose: 4.5.1
       lodash.get: 4.4.2
@@ -262,7 +262,7 @@ importers:
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
-      '@silverhand/essentials': ^1.2.0
+      '@silverhand/essentials': ^1.2.1
       '@silverhand/ts-config': ^1.0.0
       '@types/jest': ^27.4.1
       '@types/lodash.get': ^4.4.6
@@ -283,7 +283,7 @@ importers:
       type-fest: ^2.10.0
       typescript: 4.7.4
     dependencies:
-      '@silverhand/essentials': 1.2.0
+      '@silverhand/essentials': 1.2.1
       camelcase-keys: 7.0.2
       jose: 4.5.1
       lodash.get: 4.4.2
@@ -412,7 +412,7 @@ importers:
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
-      '@silverhand/essentials': ^1.2.0
+      '@silverhand/essentials': ^1.2.1
       '@silverhand/ts-config': ^1.0.0
       '@types/jest': ^27.4.0
       eslint: ^8.23.0
@@ -428,7 +428,7 @@ importers:
       typescript: 4.7.4
     dependencies:
       '@logto/client': link:../client
-      '@silverhand/essentials': 1.2.0
+      '@silverhand/essentials': 1.2.1
       js-base64: 3.7.2
       node-fetch: 2.6.7
     devDependencies:
@@ -458,7 +458,7 @@ importers:
       '@parcel/transformer-typescript-types': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
       '@silverhand/eslint-config-react': ^1.0.0
-      '@silverhand/essentials': ^1.2.0
+      '@silverhand/essentials': ^1.2.1
       '@silverhand/ts-config': ^1.0.0
       '@silverhand/ts-config-react': ^1.0.0
       '@testing-library/react-hooks': ^8.0.0
@@ -476,7 +476,7 @@ importers:
       typescript: 4.7.4
     dependencies:
       '@logto/browser': link:../browser
-      '@silverhand/essentials': 1.2.0
+      '@silverhand/essentials': 1.2.1
     devDependencies:
       '@jest/types': 27.5.1
       '@parcel/core': 2.7.0
@@ -3687,8 +3687,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@silverhand/essentials/1.2.0:
-    resolution: {integrity: sha512-AEkWX0667febPV4wTjGbM8wIKWCnJqlXSLXUTaVRdQJmuc87WGbjP7WTPn6tJ8o9cb5i4LpYTIE3ptz90nRvCg==}
+  /@silverhand/essentials/1.2.1:
+    resolution: {integrity: sha512-4wOM/yYEbcDH6Nwv/PdPjH+kbw8ixqGGVpD+CaWf+ay8+fYtmdNnr5aheqBwLV1ipHAjpXoh9x6Bqm9x68bGfA==}
     engines: {node: '>=14.15.0', pnpm: '>=6'}
     dependencies:
       lodash.orderby: 4.6.0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Bump @silverhand/essentials toolkit to v1.2.1 to use utf-8 character set when encoding and decoding base64 strings, in order to avoid ending up with garbled text with CJK characters

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested revised and passed successfully
