### PR TITLE
chore: update default scopes and IdTokenClaim definition

### DIFF
--- a/packages/browser-sample/src/index.js
+++ b/packages/browser-sample/src/index.js
@@ -1,4 +1,4 @@
-import LogtoClient from '@logto/browser';
+import LogtoClient, { UserScope } from '@logto/browser';
 
 import { endpoint, appId } from './consts';
 import Callback from './pages/Callback';
@@ -6,7 +6,11 @@ import Home from './pages/Home';
 
 import './index.scss';
 
-const logtoClient = new LogtoClient({ endpoint, appId });
+const logtoClient = new LogtoClient({
+  endpoint,
+  appId,
+  scopes: [UserScope.Email, UserScope.Phone, UserScope.CustomData, UserScope.Identities],
+});
 const app = document.querySelector('#app');
 
 // Could replace this with a formal router solution

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -10,7 +10,16 @@ export type {
   LogtoClientErrorCode,
   UserInfoResponse,
 } from '@logto/client';
-export { LogtoError, OidcError, Prompt, LogtoRequestError, LogtoClientError } from '@logto/client';
+
+export {
+  LogtoError,
+  OidcError,
+  Prompt,
+  LogtoRequestError,
+  LogtoClientError,
+  ReservedScope,
+  UserScope,
+} from '@logto/client';
 
 const navigate = (url: string) => {
   window.location.assign(url);

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,6 +29,7 @@
     "prepack": "pnpm test"
   },
   "dependencies": {
+    "@logto/core-kit": "1.0.0-beta.13",
     "@logto/js": "^1.0.0-beta.6",
     "@silverhand/essentials": "^1.2.1",
     "camelcase-keys": "^7.0.1",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { ReservedScope } from '@logto/core-kit';
 import {
   CodeTokenResponse,
   decodeIdToken,
@@ -14,7 +15,7 @@ import {
   UserInfoResponse,
   verifyAndParseCodeFromCallbackUri,
   verifyIdToken,
-  withReservedScopes,
+  withDefaultScopes,
 } from '@logto/js';
 import { Nullable } from '@silverhand/essentials';
 import { createRemoteJWKSet } from 'jose';
@@ -38,6 +39,7 @@ export * from './errors';
 export type { Storage, StorageKey, ClientAdapter } from './adapter';
 export { createRequester } from './utils';
 export * from './types';
+export { ReservedScope, UserScope } from '@logto/core-kit';
 
 export default class LogtoClient {
   protected readonly logtoConfig: LogtoConfig;
@@ -52,7 +54,7 @@ export default class LogtoClient {
     this.logtoConfig = {
       ...logtoConfig,
       prompt: logtoConfig.prompt ?? Prompt.Consent,
-      scopes: withReservedScopes(logtoConfig.scopes).split(' '),
+      scopes: withDefaultScopes(logtoConfig.scopes).split(' '),
     };
     this.adapter = adapter;
 
@@ -301,7 +303,7 @@ export default class LogtoClient {
             tokenEndpoint,
             refreshToken: currentRefreshToken,
             resource,
-            scopes: resource ? ['offline_access'] : undefined, // Force remove openid scope from the request
+            scopes: resource ? [ReservedScope.OfflineAccess] : undefined, // Force remove openid scope from the request
           },
           this.adapter.requester
         );

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -7,6 +7,8 @@ import { LogtoExpressError } from './errors';
 import ExpressStorage from './storage';
 import { LogtoExpressConfig } from './types';
 
+export { ReservedScope, UserScope } from '@logto/node';
+
 export type { LogtoContext } from '@logto/node';
 export type { LogtoExpressConfig } from './types';
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -29,6 +29,7 @@
     "prepack": "pnpm test"
   },
   "dependencies": {
+    "@logto/core-kit": "1.0.0-beta.13",
     "@silverhand/essentials": "^1.2.1",
     "camelcase-keys": "^7.0.1",
     "jose": "^4.3.8",

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -1,3 +1,5 @@
+import { UserScope } from '@logto/core-kit';
+
 import { Prompt } from '../consts';
 import { generateSignInUri } from './sign-in';
 
@@ -28,12 +30,12 @@ describe('generateSignInUri', () => {
       redirectUri,
       codeChallenge,
       state,
-      scopes: ['scope1', 'scope2'],
+      scopes: [UserScope.Email, UserScope.Phone],
       resources: ['resource1', 'resource2'],
       prompt: Prompt.Login,
     });
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=login&scope=openid+offline_access+profile+scope1+scope2&resource=resource1&resource=resource2'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=login&scope=openid+offline_access+profile+email+phone&resource=resource1&resource=resource2'
     );
   });
 });

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -1,5 +1,5 @@
 import { Prompt, QueryKey } from '../consts';
-import { withReservedScopes } from '../utils';
+import { withDefaultScopes } from '../utils';
 
 const codeChallengeMethod = 'S256';
 const responseType = 'code';
@@ -33,7 +33,7 @@ export const generateSignInUri = ({
     [QueryKey.State]: state,
     [QueryKey.ResponseType]: responseType,
     [QueryKey.Prompt]: prompt ?? Prompt.Consent,
-    [QueryKey.Scope]: withReservedScopes(scopes),
+    [QueryKey.Scope]: withDefaultScopes(scopes),
   });
 
   for (const resource of resources ?? []) {

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -18,7 +18,11 @@ const IdTokenClaimsSchema = s.type({
   at_hash: s.nullable(s.optional(s.string())),
   name: s.nullable(s.optional(s.string())),
   username: s.nullable(s.optional(s.string())),
-  avatar: s.nullable(s.optional(s.string())),
+  picture: s.nullable(s.optional(s.string())),
+  email: s.nullable(s.optional(s.string())),
+  email_verified: s.nullable(s.optional(s.boolean())),
+  phone_number: s.nullable(s.optional(s.string())),
+  phone_number_verified: s.nullable(s.optional(s.boolean())),
   role_names: s.nullable(s.optional(s.array(s.string()))),
 });
 

--- a/packages/js/src/utils/scopes.test.ts
+++ b/packages/js/src/utils/scopes.test.ts
@@ -1,39 +1,44 @@
-import { withReservedScopes } from './scopes';
+import { ReservedScope, UserScope } from '@logto/core-kit';
 
-const email = 'email';
-const name = 'name';
-const offlineAccess = 'offline_access';
-const openid = 'openid';
-const profile = 'profile';
-const reservedScopes = [openid, offlineAccess, profile];
-const reservedScopesString = reservedScopes.join(' ');
+import { withDefaultScopes } from './scopes';
+
+const offlineAccess = ReservedScope.OfflineAccess;
+const openid = ReservedScope.OpenId;
+const profile = UserScope.Profile;
+const email = UserScope.Email;
+const phone = UserScope.Phone;
+const defaultScopes = [openid, offlineAccess, profile];
+const defaultScopesString = defaultScopes.join(' ');
+const userScopes = Object.values(UserScope);
+const userScopesString = userScopes.join(' ');
+const reservedScopeString = Object.values(ReservedScope).join(' ');
 
 describe('withReservedScopes', () => {
   test('with undefined param', () => {
-    expect(withReservedScopes()).toEqual(reservedScopesString);
+    expect(withDefaultScopes()).toEqual(defaultScopesString);
   });
 
   test('with nothing', () => {
-    expect(withReservedScopes([])).toEqual(reservedScopesString);
+    expect(withDefaultScopes([])).toEqual(defaultScopesString);
   });
 
-  test('with all reserved scopes, openid and offline_access', () => {
-    expect(withReservedScopes([openid, offlineAccess])).toEqual(reservedScopesString);
+  test('with default scope "profile"', () => {
+    expect(withDefaultScopes([profile])).toEqual(defaultScopesString);
   });
 
-  test('with openid (without reserved offline_access)', () => {
-    expect(withReservedScopes([openid])).toEqual(reservedScopesString);
+  test('with all default scopes', () => {
+    expect(withDefaultScopes([openid, offlineAccess, profile])).toEqual(defaultScopesString);
   });
 
-  test('with openid name (without reserved offline_access)', () => {
-    expect(withReservedScopes([name, openid])).toEqual(`${reservedScopesString} ${name}`);
+  test('with "profile" and "email"', () => {
+    expect(withDefaultScopes([profile, email])).toEqual(`${defaultScopesString} ${email}`);
   });
 
-  test('with offline_access email (without reserved openid)', () => {
-    expect(withReservedScopes([email, offlineAccess])).toEqual(`${reservedScopesString} ${email}`);
+  test('with "email" and "phone"', () => {
+    expect(withDefaultScopes([email, phone])).toEqual(`${defaultScopesString} ${email} ${phone}`);
   });
 
-  test('with name email (without all reserved scopes)', () => {
-    expect(withReservedScopes([name, email])).toEqual(`${reservedScopesString} ${name} ${email}`);
+  test('with all user scopes', () => {
+    expect(withDefaultScopes(userScopes)).toEqual(`${reservedScopeString} ${userScopesString}`);
   });
 });

--- a/packages/js/src/utils/scopes.ts
+++ b/packages/js/src/utils/scopes.ts
@@ -1,9 +1,12 @@
+import { ReservedScope, UserScope } from '@logto/core-kit';
+
 /**
  * @param originalScopes
- * @return scopes should contain all reserved scopes ( Logto requires `openid` and `offline_access` )
+ * @return scopes should contain all default scopes (`openid`, `offline_access` and `profile`)
  */
-export const withReservedScopes = (originalScopes?: string[]): string => {
-  const uniqueScopes = new Set(['openid', 'offline_access', 'profile', ...(originalScopes ?? [])]);
+export const withDefaultScopes = (originalScopes?: string[]): string => {
+  const reservedScopes = Object.values(ReservedScope);
+  const uniqueScopes = new Set([...reservedScopes, UserScope.Profile, ...(originalScopes ?? [])]);
 
   return Array.from(uniqueScopes).join(' ');
 };

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -7,6 +7,8 @@ import { GetServerSidePropsContext, GetServerSidePropsResult, NextApiHandler } f
 import NextStorage from './storage';
 import { LogtoNextConfig, WithLogtoConfig } from './types';
 
+export { ReservedScope, UserScope } from '@logto/node';
+
 export type { LogtoContext } from '@logto/node';
 
 export default class LogtoClient {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -14,7 +14,16 @@ export type {
   Storage,
   StorageKey,
 } from '@logto/client';
-export { LogtoError, OidcError, Prompt, LogtoRequestError, LogtoClientError } from '@logto/client';
+
+export {
+  LogtoError,
+  OidcError,
+  Prompt,
+  LogtoRequestError,
+  LogtoClientError,
+  ReservedScope,
+  UserScope,
+} from '@logto/client';
 
 export default class LogtoClient extends BaseClient {
   constructor(config: LogtoConfig, adapter: Pick<ClientAdapter, 'navigate' | 'storage'>) {

--- a/packages/react-sample/src/App.tsx
+++ b/packages/react-sample/src/App.tsx
@@ -1,4 +1,4 @@
-import { LogtoProvider, LogtoConfig } from '@logto/react';
+import { LogtoProvider, LogtoConfig, UserScope } from '@logto/react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import RequireAuth from './RequireAuth';
@@ -13,6 +13,7 @@ export const App = () => {
   const config: LogtoConfig = {
     appId,
     endpoint,
+    scopes: [UserScope.Email, UserScope.Phone, UserScope.CustomData, UserScope.Identities],
   };
 
   return (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,7 +8,14 @@ export type {
   LogtoClientErrorCode,
 } from '@logto/browser';
 
-export { LogtoError, LogtoClientError, OidcError, Prompt } from '@logto/browser';
+export {
+  LogtoError,
+  LogtoClientError,
+  OidcError,
+  Prompt,
+  ReservedScope,
+  UserScope,
+} from '@logto/browser';
 
 export * from './provider';
 

--- a/packages/vue-sample/src/main.ts
+++ b/packages/vue-sample/src/main.ts
@@ -1,12 +1,21 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
-import { createLogto } from "@logto/vue";
+import { createLogto, UserScope } from "@logto/vue";
 import { appId, endpoint } from "./consts";
 
 const app = createApp(App);
 
-app.use(createLogto, { appId, endpoint });
+app.use(createLogto, {
+  appId,
+  endpoint,
+  scopes: [
+    UserScope.Email,
+    UserScope.Phone,
+    UserScope.CustomData,
+    UserScope.Identities,
+  ],
+});
 app.use(router);
 
 app.mount("#app");

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -13,7 +13,14 @@ export type {
   LogtoClientErrorCode,
 } from '@logto/browser';
 
-export { LogtoError, LogtoClientError, OidcError, Prompt } from '@logto/browser';
+export {
+  LogtoError,
+  LogtoClientError,
+  OidcError,
+  Prompt,
+  ReservedScope,
+  UserScope,
+} from '@logto/browser';
 
 type LogtoVuePlugin = {
   install: (app: App, config: LogtoConfig) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,7 @@ importers:
   packages/client:
     specifiers:
       '@jest/types': ^27.5.1
+      '@logto/core-kit': 1.0.0-beta.13
       '@logto/js': ^1.0.0-beta.6
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
@@ -129,6 +130,7 @@ importers:
       type-fest: ^2.10.0
       typescript: 4.7.4
     dependencies:
+      '@logto/core-kit': 1.0.0-beta.13
       '@logto/js': link:../js
       '@silverhand/essentials': 1.2.1
       camelcase-keys: 7.0.2
@@ -258,6 +260,7 @@ importers:
   packages/js:
     specifiers:
       '@jest/types': ^27.5.1
+      '@logto/core-kit': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -283,6 +286,7 @@ importers:
       type-fest: ^2.10.0
       typescript: 4.7.4
     dependencies:
+      '@logto/core-kit': 1.0.0-beta.13
       '@silverhand/essentials': 1.2.1
       camelcase-keys: 7.0.2
       jose: 4.5.1
@@ -2269,6 +2273,15 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@logto/core-kit/1.0.0-beta.13:
+    resolution: {integrity: sha512-3Ugvpu2VHfBziEOZ07v+JpwQSoU71pO60dIeN2w3SHVgr0G6TV0FC/0NxJqEOGEEh6rEvcikVocwZJBJ+P6CoA==}
+    engines: {node: ^16.0.0}
+    dependencies:
+      color: 4.2.3
+      nanoid: 3.3.4
+      zod: 3.19.1
+    dev: false
 
   /@mischnic/json-sourcemap/0.1.0:
     resolution: {integrity: sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==}
@@ -5307,7 +5320,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -5315,12 +5327,26 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
+
+  /color-string/1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: false
 
   /color-support/1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
     dev: true
+
+  /color/4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+    dev: false
 
   /colord/2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -7789,6 +7815,10 @@ packages:
   /is-arrayish/0.2.1:
     resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
     dev: true
+
+  /is-arrayish/0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
 
   /is-bigint/1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -11329,6 +11359,12 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
+  /simple-swizzle/0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+    dependencies:
+      is-arrayish: 0.3.2
+    dev: false
+
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -12823,3 +12859,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod/3.19.1:
+    resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}
+    dev: false


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* JS SDKs export `ReservedScope` and `UserScope` from @logto/core-kit
* By default, the SDK provides `openid`, `offline_access` and `profile` scopes
* Update the type definition of `IdTokenClaim`, change "avatar" to "picture", and add email and phone_number properties

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in browser sample, react sample and vue sample projects, `fetchUserInfo` API can return corresponding user data structure by given different scopes. Working fine.
- [x] Tested in the above sample projects, that ID token claims are also affected by given scopes.
