### PR TITLE
fix(remix): use the correct sign-out redirect URL 

### DIFF
--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
@@ -38,7 +38,7 @@ export class HandleSignOutController {
       redirectUri: this.redirectUri,
     });
 
-    return redirect(this.redirectUri, {
+    return redirect(result.navigateToUrl, {
       headers: {
         'Set-Cookie': result.cookieHeader,
       },


### PR DESCRIPTION
## Summary

There was a problem with the `sign-out` in the Remix SDK where after performing the `sign-out`, the user was able to perform a `sign-in` without executing the actual authentication flow:

[Screen_recording_2022-10-19_23.50.18.webm](https://user-images.githubusercontent.com/224910/196992055-8f067240-cd0a-4da5-b090-9bccd170ea46.webm)

## Testing

You can use the example app which currently lives in this [repo](https://github.com/openformation/logto-remix/tree/main/example).
