### PR TITLE
fix(client): remove access token from storage after sign-out

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -202,6 +202,7 @@ describe('LogtoClient', () => {
       storage.reset({
         idToken: 'id_token_value',
         refreshToken: 'refresh_token_value',
+        accessToken: 'access_token_map_json_string',
       });
     });
 
@@ -212,12 +213,13 @@ describe('LogtoClient', () => {
       expect(requester).toHaveBeenCalledWith(revocationEndpoint, expect.anything());
     });
 
-    it('should clear id token and refresh token in local storage', async () => {
+    it('should clear id token, refresh token and access token from storage', async () => {
       const logtoClient = createClient(undefined, storage);
       await logtoClient.signOut(postSignOutRedirectUri);
 
       await expect(storage.getItem('idToken')).resolves.toBeNull();
       await expect(storage.getItem('refreshToken')).resolves.toBeNull();
+      await expect(storage.getItem('accessToken')).resolves.toBeNull();
     });
 
     it('should redirect to post sign-out URI after signing out', async () => {
@@ -244,6 +246,7 @@ describe('LogtoClient', () => {
       expect(failingRequester).toBeCalledTimes(1);
       await expect(storage.getItem('idToken')).resolves.toBeNull();
       await expect(storage.getItem('refreshToken')).resolves.toBeNull();
+      await expect(storage.getItem('accessToken')).resolves.toBeNull();
       expect(navigate).toHaveBeenCalledWith(`${endSessionEndpoint}?id_token_hint=id_token_value`);
     });
   });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -230,6 +230,7 @@ export default class LogtoClient {
     this.accessTokenMap.clear();
     await this.setRefreshToken(null);
     await this.setIdToken(null);
+    await this.adapter.storage.removeItem('accessToken');
 
     this.adapter.navigate(url);
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed a bug that `accessToken` is still in local storage after successfully signing out.
Updated test case to reflect this change.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed UTs
