### PR TITLE
refactor(js,core): decode resource dynamically from access token on saving tokens

### DIFF
--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -7,9 +7,9 @@ const logtoClientErrorCodes = Object.freeze({
     not_found: 'Sign-in session not found.',
   },
   not_authenticated: 'Not authenticated.',
-  get_access_token_by_refresh_token_failed: 'Failed to get access token by refresh token.',
-  fetch_user_info_failed: 'Unable to fetch user info. The access token may be invalid.',
   invalid_id_token: 'Invalid id token.',
+  refresh_token_not_found: 'Refresh token not found.',
+  access_token_not_found: 'Access token not found.',
 });
 
 export type LogtoClientErrorCode = NormalizeKeyPaths<typeof logtoClientErrorCodes>;

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,9 +1,21 @@
 import { discoveryPath } from '@logto/js';
+import { decodeJwt } from 'jose';
 
 export * from './requester';
 
 export const buildAccessTokenKey = (resource = '', scopes: string[] = []): string =>
   `${scopes.slice().sort().join(' ')}@${resource}`;
+
+export const decodeResourceFromAccessToken = (accessToken: string): string => {
+  try {
+    const audience = decodeJwt(accessToken).aud ?? '';
+    const [resource = ''] = typeof audience === 'string' ? [audience] : audience;
+
+    return resource;
+  } catch {
+    return '';
+  }
+};
 
 export const getDiscoveryEndpoint = (endpoint: string): string =>
   new URL(discoveryPath, endpoint).toString();

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -5,8 +5,7 @@ import { isArbitraryObject } from './arbitrary-object';
 
 const logtoErrorCodes = Object.freeze({
   id_token: {
-    invalid_iat: 'Invalid issued at time in the ID token',
-    invalid_token: 'Invalid ID token',
+    invalid_iat: 'Invalid token iat (issued-at-time)',
   },
   callback_uri_verification: {
     redirect_uri_mismatched: 'The callback URI mismatches the redirect URI.',

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -269,9 +269,7 @@ describe('decodeIdToken', () => {
   });
 
   test('decoding invalid JWT string should throw Error', async () => {
-    expect(() => decodeIdToken('invalid-JWT')).toMatchError(
-      new LogtoError('id_token.invalid_token')
-    );
+    expect(() => decodeIdToken('invalid-JWT')).toThrowError();
   });
 
   test('decoding valid JWT without issuer should throw TypeError', async () => {

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -1,5 +1,5 @@
-import { Nullable, urlSafeBase64 } from '@silverhand/essentials';
-import { jwtVerify, JWTVerifyGetKey } from 'jose';
+import { Nullable } from '@silverhand/essentials';
+import { decodeJwt, jwtVerify, JWTVerifyGetKey } from 'jose';
 
 import { isArbitraryObject } from './arbitrary-object';
 import { LogtoError } from './errors';
@@ -96,14 +96,7 @@ export const verifyIdToken = async (
 };
 
 export const decodeIdToken = (token: string): IdTokenClaims => {
-  const { 1: encodedPayload } = token.split('.');
-
-  if (!encodedPayload) {
-    throw new LogtoError('id_token.invalid_token');
-  }
-
-  const json = urlSafeBase64.decode(encodedPayload);
-  const idTokenClaims: unknown = JSON.parse(json);
+  const idTokenClaims = decodeJwt(token);
   assertIdTokenClaims(idTokenClaims);
 
   return idTokenClaims;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Dynamically decode resource indicator from access token when persisting it in storage
* Use `decodeJwt` from `jose` library to decode claims from id token and access token

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Passed all unit tests
