### PR TITLE
fix: use `.mjs` for ESM files

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/module.js"
+    "import": "./lib/module.mjs"
   },
-  "module": "./lib/module.js",
+  "module": "./lib/module.mjs",
   "types": "./lib/index.d.ts",
   "files": [
     "lib"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Node will treat `.js` files [as CommonJS](https://nodejs.org/api/packages.html#determining-module-system) without `"type": "module"` in the `package.json`, need to use `.mjs` for ESM outputs.
Fixes #428 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before

#### Original
<img width="428" alt="image" src="https://user-images.githubusercontent.com/14722250/200572429-9380a104-d6fb-4a36-8569-e50ce97269f9.png">

#### Only change `@logto/node` to use `.mjs`
<img width="671" alt="image" src="https://user-images.githubusercontent.com/14722250/200572738-cb99f0e2-b9b8-40cd-b0d1-c1970c9e7be2.png">

### After

<img width="206" alt="image" src="https://user-images.githubusercontent.com/14722250/200572788-364547d3-9f5b-4a14-8193-8f04644eeb77.png">
