### PR TITLE
refactor(client): remove refresh token concurrent request protection

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -279,19 +279,9 @@ describe('LogtoClient', () => {
     });
 
     it('should return access token by valid refresh token', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-let
-      let count = 0;
-
       requester.mockClear().mockImplementation(async () => {
-        // eslint-disable-next-line @silverhand/fp/no-mutation
-        count += 1;
-        await new Promise((resolve) => {
-          setTimeout(resolve, 0);
-        });
-
         return {
-          accessToken: count === 1 ? 'access_token_value' : 'nope',
-          refreshToken: count === 1 ? 'new_refresh_token_value' : 'nope',
+          accessToken: 'access_token_value',
           expiresIn: 3600,
         };
       });
@@ -303,17 +293,10 @@ describe('LogtoClient', () => {
           refreshToken: 'refresh_token_value',
         })
       );
-      const [accessToken_1, accessToken_2] = await Promise.all([
-        logtoClient.getAccessToken(),
-        logtoClient.getAccessToken(),
-      ]);
+      const accessToken = await logtoClient.getAccessToken();
 
       expect(requester).toHaveBeenCalledWith(tokenEndpoint, expect.anything());
-      expect(accessToken_1).toEqual('access_token_value');
-      expect(accessToken_2).toEqual('access_token_value');
-
-      const refreshToken = await logtoClient.getRefreshToken();
-      expect(refreshToken).toEqual('new_refresh_token_value');
+      expect(accessToken).toEqual('access_token_value');
     });
 
     it('should delete expired access token once', async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { ReservedScope } from '@logto/core-kit';
 import {
   CodeTokenResponse,
@@ -47,8 +46,6 @@ export default class LogtoClient {
   protected readonly adapter: ClientAdapter;
   protected readonly accessTokenMap = new Map<string, AccessToken>();
 
-  private readonly getAccessTokenPromiseMap = new Map<string, Promise<string>>();
-
   constructor(logtoConfig: LogtoConfig, adapter: ClientAdapter) {
     this.logtoConfig = {
       ...logtoConfig,
@@ -72,7 +69,6 @@ export default class LogtoClient {
     return this.adapter.storage.getItem('idToken');
   }
 
-  // eslint-disable-next-line complexity
   async getAccessToken(resource?: string): Promise<string> {
     if (!(await this.getIdToken())) {
       throw new LogtoClientError('not_authenticated');
@@ -92,26 +88,8 @@ export default class LogtoClient {
 
     /**
      * Need to fetch a new access token using refresh token.
-     * Reuse the cached promise if exists.
      */
-    const cachedPromise = this.getAccessTokenPromiseMap.get(accessTokenKey);
-
-    if (cachedPromise) {
-      return cachedPromise;
-    }
-
-    /**
-     * Create a new promise and cache in map to avoid race condition.
-     * Since we enable "refresh token rotation" by default,
-     * it will be problematic when calling multiple `getAccessToken()` closely.
-     */
-    const promise = this.getAccessTokenByRefreshToken(resource);
-    this.getAccessTokenPromiseMap.set(accessTokenKey, promise);
-
-    const token = await promise;
-    this.getAccessTokenPromiseMap.delete(accessTokenKey);
-
-    return token;
+    return this.getAccessTokenByRefreshToken(resource);
   }
 
   async getIdTokenClaims(): Promise<IdTokenClaims> {
@@ -399,4 +377,3 @@ export default class LogtoClient {
     } catch {}
   }
 }
-/* eslint-enable max-lines */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
remove refresh token concurrent request protection. For now, we protect it on the server side.

reference: https://github.com/logto-io/kotlin/pull/203

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs
