### PR TITLE
chore: update `package.json`

### DIFF
--- a/packages/browser-sample/package.json
+++ b/packages/browser-sample/package.json
@@ -11,7 +11,7 @@
     "stylelint": "stylelint \"src/**/*.scss\""
   },
   "dependencies": {
-    "@logto/browser": "^1.0.0-beta.13"
+    "@logto/browser": "1.0.0-beta.13"
   },
   "devDependencies": {
     "@parcel/core": "^2.7.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/client": "^1.0.0-beta.13",
+    "@logto/client": "1.0.0-beta.13",
     "@silverhand/essentials": "^1.2.1",
     "js-base64": "^3.7.2"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent --coverage",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@logto/core-kit": "1.0.0-beta.20",
-    "@logto/js": "^1.0.0-beta.13",
+    "@logto/js": "1.0.0-beta.13",
     "@silverhand/essentials": "^1.2.1",
     "camelcase-keys": "^7.0.1",
     "jose": "^4.3.8",

--- a/packages/express-sample/package.json
+++ b/packages/express-sample/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .ts src"
   },
   "dependencies": {
-    "@logto/express": "^1.0.0-beta.13",
+    "@logto/express": "1.0.0-beta.13",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.1",
     "express-session": "^1.17.3"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/node": "^1.0.0-beta.13"
+    "@logto/node": "1.0.0-beta.13"
   },
   "devDependencies": {
     "@jest/types": "^27.5.1",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -22,7 +22,7 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent --coverage",

--- a/packages/next-sample/package.json
+++ b/packages/next-sample/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@logto/next": "^1.0.0-beta.13",
+    "@logto/next": "1.0.0-beta.13",
     "next": "^13.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/node": "^1.0.0-beta.13",
+    "@logto/node": "1.0.0-beta.13",
     "iron-session": "^6.1.3"
   },
   "devDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/client": "^1.0.0-beta.13",
+    "@logto/client": "1.0.0-beta.13",
     "@silverhand/essentials": "^1.2.1",
     "js-base64": "^3.7.2",
     "node-fetch": "^2.6.7"

--- a/packages/react-sample/package.json
+++ b/packages/react-sample/package.json
@@ -12,7 +12,7 @@
     "stylelint": "stylelint \"src/**/*.scss\""
   },
   "dependencies": {
-    "@logto/react": "^1.0.0-beta.13",
+    "@logto/react": "1.0.0-beta.13",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts --ext .tsx src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/browser": "^1.0.0-beta.13",
+    "@logto/browser": "1.0.0-beta.13",
     "@silverhand/essentials": "^1.2.1"
   },
   "devDependencies": {

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/node": "^1.0.0-beta.13"
+    "@logto/node": "1.0.0-beta.13"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/packages/vue-sample/package.json
+++ b/packages/vue-sample/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .vue,.ts src"
   },
   "dependencies": {
-    "@logto/vue": "^1.0.0-beta.13",
+    "@logto/vue": "1.0.0-beta.13",
     "vue": "^3.2.35",
     "vue-router": "^4.0.14"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,14 +22,14 @@
     "dev:tsc": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
-    "build": "rm -rf lib/ && pnpm check && parcel build",
+    "build": "rm -rf lib/ && pnpm check && parcel build && cp lib/index.d.ts lib/module.d.mts",
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
     "prepack": "pnpm test"
   },
   "dependencies": {
-    "@logto/browser": "^1.0.0-beta.13"
+    "@logto/browser": "1.0.0-beta.13"
   },
   "devDependencies": {
     "@jest/types": "^27.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
   packages/browser:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/client': ^1.0.0-beta.13
+      '@logto/client': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -67,7 +67,7 @@ importers:
 
   packages/browser-sample:
     specifiers:
-      '@logto/browser': ^1.0.0-beta.13
+      '@logto/browser': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/transformer-sass': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
@@ -102,7 +102,7 @@ importers:
     specifiers:
       '@jest/types': ^27.5.1
       '@logto/core-kit': 1.0.0-beta.20
-      '@logto/js': ^1.0.0-beta.13
+      '@logto/js': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -162,7 +162,7 @@ importers:
   packages/express:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/node': ^1.0.0-beta.13
+      '@logto/node': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -218,7 +218,7 @@ importers:
 
   packages/express-sample:
     specifiers:
-      '@logto/express': ^1.0.0-beta.13
+      '@logto/express': 1.0.0-beta.13
       '@silverhand/eslint-config': ^1.0.0
       '@silverhand/ts-config': ^1.0.0
       '@types/cookie-parser': ^1.4.3
@@ -313,7 +313,7 @@ importers:
   packages/next:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/node': ^1.0.0-beta.13
+      '@logto/node': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -363,7 +363,7 @@ importers:
 
   packages/next-sample:
     specifiers:
-      '@logto/next': ^1.0.0-beta.13
+      '@logto/next': 1.0.0-beta.13
       '@silverhand/eslint-config': ^1.0.0
       '@silverhand/eslint-config-react': ^1.0.0
       '@silverhand/ts-config': ^1.0.0
@@ -407,7 +407,7 @@ importers:
   packages/node:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/client': ^1.0.0-beta.13
+      '@logto/client': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -452,7 +452,7 @@ importers:
   packages/react:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/browser': ^1.0.0-beta.13
+      '@logto/browser': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -502,7 +502,7 @@ importers:
 
   packages/react-sample:
     specifiers:
-      '@logto/react': ^1.0.0-beta.13
+      '@logto/react': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/transformer-sass': ^2.7.0
       '@silverhand/eslint-config': ^1.0.0
@@ -552,7 +552,7 @@ importers:
       '@commitlint/cli': ^17.1.2
       '@commitlint/config-conventional': ^17.1.0
       '@jest/types': ^27.5.1
-      '@logto/node': ^1.0.0-beta.13
+      '@logto/node': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -607,7 +607,7 @@ importers:
   packages/vue:
     specifiers:
       '@jest/types': ^27.5.1
-      '@logto/browser': ^1.0.0-beta.13
+      '@logto/browser': 1.0.0-beta.13
       '@parcel/core': ^2.7.0
       '@parcel/packager-ts': ^2.7.0
       '@parcel/transformer-typescript-types': ^2.7.0
@@ -647,7 +647,7 @@ importers:
 
   packages/vue-sample:
     specifiers:
-      '@logto/vue': ^1.0.0-beta.13
+      '@logto/vue': 1.0.0-beta.13
       '@rushstack/eslint-patch': ^1.1.0
       '@types/node': ^16.11.27
       '@vitejs/plugin-vue': ^3.0.0
@@ -4196,6 +4196,7 @@ packages:
       stylelint-config-xo-scss: 0.15.0_dv74vz3kd2jzw73aeftwn7eaye
     transitivePeerDependencies:
       - eslint
+      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -4216,6 +4217,7 @@ packages:
       stylelint-config-xo-scss: 0.15.0_fuey67s7n6jf446omnzhgthpnu
     transitivePeerDependencies:
       - eslint
+      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -4239,7 +4241,7 @@ packages:
       eslint-import-resolver-typescript: 3.5.1_faomjyrlgqmwswvqymymzkxcqi
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.23.0
-      eslint-plugin-import: 2.26.0_eslint@8.23.0
+      eslint-plugin-import: 2.26.0_ikxfxf6lcdzwf3sfhs76tj4x7m
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.23.0
       eslint-plugin-prettier: 4.2.1_tgumt6uwl2md3n6uqnggd6wvce
@@ -4249,6 +4251,7 @@ packages:
       eslint-plugin-unused-imports: 2.0.0_zko7vy5ljylfnjbd43q67qnl6a
       prettier: 2.7.1
     transitivePeerDependencies:
+      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -5964,6 +5967,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -7473,14 +7478,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
-    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      debug: 3.2.7
-      find-up: 2.1.0
-    dev: true
-
   /eslint-module-utils/2.7.3_7liths4w263er5tix7tpkwznyq:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
@@ -7536,28 +7533,6 @@ packages:
       escape-string-regexp: 1.0.5
       eslint: 8.23.0
       ignore: 5.2.0
-    dev: true
-
-  /eslint-plugin-import/2.26.0_eslint@8.23.0:
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    dependencies:
-      array-includes: 3.1.4
-      array.prototype.flat: 1.2.5
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.23.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
-      has: 1.0.3
-      is-core-module: 2.9.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.5
-      resolve: 1.22.1
-      tsconfig-paths: 3.14.1
     dev: true
 
   /eslint-plugin-import/2.26.0_ikxfxf6lcdzwf3sfhs76tj4x7m:
@@ -8001,6 +7976,8 @@ packages:
       parseurl: 1.3.3
       safe-buffer: 5.2.1
       uid-safe: 2.1.5
+    transitivePeerDependencies:
+      - supports-color
 
   /express/4.18.1:
     resolution: {integrity: sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==}
@@ -8037,6 +8014,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /external-editor/3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -8132,6 +8111,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /find-up/2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -13076,6 +13057,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   /serve-static/1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add one last step to the build script to copy the type declaration for matching the `.mjs` file.
  - TypeScript needs a `.mts` file in the dependency to correctly import types when "moduleResolution" is "nodenext".
  - https://github.com/microsoft/TypeScript/issues/47848 https://github.com/microsoft/TypeScript/issues/49189
- Lock workspace dependency versions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

tested in core, both ESM and CJS typing/building work as expected