### PR TITLE
feat(client): remove scope for access token grant

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,3 @@
-import { ReservedScope } from '@logto/core-kit';
 import {
   CodeTokenResponse,
   decodeIdToken,
@@ -278,7 +277,6 @@ export default class LogtoClient {
             tokenEndpoint,
             refreshToken: currentRefreshToken,
             resource,
-            scopes: resource ? [ReservedScope.OfflineAccess] : undefined, // Force remove openid scope from the request
           },
           this.adapter.requester
         );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove the parameter `scope` for `getAccessTokenByRefreshToken`. Then the OP server will automaticly attach all the available scopes (in refresh token) to this access token.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested
