### PR TITLE
chore: add nullable to UserInfoResponse type properties

### DIFF
--- a/packages/js/src/core/user-info.ts
+++ b/packages/js/src/core/user-info.ts
@@ -1,3 +1,5 @@
+import { Nullable } from '@silverhand/essentials';
+
 import { Requester } from '../types';
 
 type Identity = {
@@ -7,15 +9,15 @@ type Identity = {
 
 export type UserInfoResponse = {
   sub: string;
-  name?: string;
-  username?: string;
-  picture?: string;
-  email?: string;
+  name?: Nullable<string>;
+  username?: Nullable<string>;
+  picture?: Nullable<string>;
+  email?: Nullable<string>;
   email_verified?: boolean;
-  phone_number?: string;
+  phone_number?: Nullable<string>;
   phone_number_verified?: boolean;
-  custom_data?: unknown;
-  identities?: Record<string, Identity>;
+  custom_data?: unknown; // Not null in DB.
+  identities?: Record<string, Identity>; // Not null in DB.
 };
 
 export const fetchUserInfo = async (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix `UserInfoResponse` type in JS SDKs. Make most of the fields `Nullable`, which reflects the real field type in DB

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
