### PR TITLE
fix(vue,vue-sample): remove the mis-use of watchEffect

### DIFF
--- a/packages/vue-sample/src/views/HomeView.vue
+++ b/packages/vue-sample/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useLogto, type UserInfoResponse } from "@logto/vue";
 import { RouterLink } from "vue-router";
-import { ref, watchEffect } from "vue";
+import { ref } from "vue";
 import { baseUrl, redirectUrl } from "../consts";
 
 const { isAuthenticated, fetchUserInfo, signIn, signOut } = useLogto();
@@ -15,12 +15,12 @@ const onClickSignOut = () => {
   void signOut(baseUrl);
 };
 
-watchEffect(async () => {
-  if (isAuthenticated.value) {
-    const userInfo = await fetchUserInfo();
-    user.value = userInfo;
-  }
-});
+if (isAuthenticated.value) {
+  (async () => {
+    const info = await fetchUserInfo();
+    user.value = info;
+  })();
+}
 </script>
 
 <template>

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,6 +1,6 @@
 import type LogtoClient from '@logto/browser';
 import type { ComputedRef, Ref, UnwrapRef } from 'vue';
-import { computed, reactive, toRefs, watchEffect } from 'vue';
+import { computed, reactive, toRefs } from 'vue';
 
 type LogtoContextProperties = {
   logtoClient: LogtoClient | undefined;
@@ -58,12 +58,12 @@ export const createContext = (client: LogtoClient): Context => {
   };
   /* eslint-enable @silverhand/fp/no-mutation */
 
-  watchEffect(async () => {
+  (async () => {
     const isAuthenticated = await client.isAuthenticated();
 
     setIsAuthenticated(isAuthenticated);
     setLoading(false);
-  });
+  })();
 
   return { ...context, isLoading, setError, setLoading, setIsAuthenticated };
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the mis-use of `watchEffect` in Vue SDK and Vue sample. The occurance in SDK was not necessary but didn't do any harm, however the other occurance in the sample code DID cause an infinite loop.
(fixes #450)

Add unit test case to ensure this SDK change won't cause infinite loop.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and the infinite loop no longer exists

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] unit tests
