### PR TITLE
fix(next-sample): use location assign for sign in redirect

### DIFF
--- a/packages/next-sample/pages/index.tsx
+++ b/packages/next-sample/pages/index.tsx
@@ -73,9 +73,21 @@ const Home = () => {
       </header>
       <nav>
         {data?.isAuthenticated ? (
-          <Link href="/api/logto/sign-out">Sign Out</Link>
+          <button
+            onClick={() => {
+              window.location.assign('/api/logto/sign-out');
+            }}
+          >
+            Sign Out
+          </button>
         ) : (
-          <Link href="/api/logto/sign-in">Sign In</Link>
+          <button
+            onClick={() => {
+              window.location.assign('/api/logto/sign-in');
+            }}
+          >
+            Sign In
+          </button>
         )}
       </nav>
       {claims}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
According to [NextJs official doc](https://nextjs.org/docs/api-reference/next/link), client-side transitions between routes can be enabled via the `Link` component.

In this case, "sign in" is not an internal route, it'll cause CORS issue because NextJS will perform some "pre-render".

Use `location.assign` instead.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
