### PR TITLE
fix: remove id token check for sign out

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -185,12 +185,6 @@ export default class LogtoClient {
   }
 
   async signOut(postLogoutRedirectUri?: string) {
-    const idToken = await this.getIdToken();
-
-    if (!idToken) {
-      throw new LogtoClientError('not_authenticated');
-    }
-
     const { appId: clientId } = this.logtoConfig;
     const { endSessionEndpoint, revocationEndpoint } = await this.getOidcConfig();
     const refreshToken = await this.getRefreshToken();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove "idToken" check for "sign out":

The problem is that, if the "idToken" is already expired, the sign out process will fail, then the user is not able to sign out and sign in again.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
