### PR TITLE
fix(vue): prevent potential issue from handling sign-in callback

### DIFF
--- a/.changeset/small-eyes-flow.md
+++ b/.changeset/small-eyes-flow.md
@@ -1,0 +1,6 @@
+---
+"@logto/react": patch
+"@logto/vue": patch
+---
+
+Fix potential issue on handling sign-in callback in React and Vue SDKs

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -137,7 +137,11 @@ export const useHandleSignInCallback = (callback?: () => void) => {
   watchEffect(() => {
     const currentPageUrl = window.location.href;
 
-    if (!isAuthenticated.value && logtoClient.value?.isSignInRedirected(currentPageUrl)) {
+    if (
+      !isAuthenticated.value &&
+      logtoClient.value?.isSignInRedirected(currentPageUrl) &&
+      !isLoading.value
+    ) {
       void handleSignInCallback(currentPageUrl, callback);
     }
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We identified an issue with `handleSignInCallback` in React SDK, which causes a sign-in failure due to multiple callback calls within a short period of time. This issue might also exist in Vue SDK, hence this PR is trying to fix it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- UT passed
- Tested sign-in and sign-out flows in Vue sample, still works properly

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] `.changeset`
- [x] unit tests
