### PR TITLE
fix: prepack script

### DIFF
--- a/.changeset/violet-dryers-fetch.md
+++ b/.changeset/violet-dryers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@logto/js": patch
+---
+
+fix `prepack` script

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v3
 
-      - name: Build for testing scripts before release
-        run: pnpm -r --filter '!@logto/*-sample' build
-
       - name: Configure Git user
         run: |
           git config --global user.email bot@silverhand.io

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/client": "^2.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/js": "^2.0.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "node test.cjs && jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/node": "^2.0.0"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --env=jsdom && jest --silent",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@silverhand/essentials": "^2.6.2",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint --ext .ts src",
     "test": "node test.cjs && jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/node": "^2.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "node test.cjs && jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/client": "^2.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts --ext .tsx src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/browser": "^2.0.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/node": "^2.0.0"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ext .ts src",
     "test": "jest",
     "test:coverage": "jest --silent --coverage",
-    "prepack": "pnpm test"
+    "prepack": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@logto/browser": "^2.0.0"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add build in `prepack` script and remove build phase in publish workflow since pnpm will smartly detect and publish in the dependency order thus there is no need for manually build anymore
- force bump `@logto/js` version since the last version has no `lib` (didn't build in either `prepack` nor publish workflow)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- run `pnpm prepack` locally, the script running process is in the dependency order and parallel executing will work when possible.
- bump all sdk versions, dry run publish, work also as expected

<img width="917" alt="image" src="https://user-images.githubusercontent.com/14722250/234603231-dabdcf4c-ce42-49e6-882a-ab09f81fc33a.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
