### PR TITLE
fix: fix prepack command for module package

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -26,9 +26,10 @@
     "check": "tsc --noEmit",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
-    "test": "node test.cjs && jest",
+    "test": "jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test && pnpm build",
+    "postpack": "node test.cjs"
   },
   "dependencies": {
     "@logto/node": "^2.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -32,9 +32,10 @@
     "check": "tsc --noEmit",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
-    "test": "node test.cjs && jest",
+    "test": "jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm build && pnpm test",
+    "postpack": "node test.cjs"
   },
   "dependencies": {
     "@logto/node": "^2.1.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,9 +32,10 @@
     "check": "tsc --noEmit",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
-    "test": "node test.cjs && jest",
+    "test": "jest",
     "test:coverage": "node test.cjs && jest --silent --coverage",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test && pnpm build",
+    "postpack": "node test.cjs"
   },
   "dependencies": {
     "@logto/client": "^2.1.0",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
CJS sanity checks need to perform after the package is built. So move them to `postpack`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
