### PR TITLE
fix: skip access token decode for opaque token

### DIFF
--- a/.changeset/slow-cooks-destroy.md
+++ b/.changeset/slow-cooks-destroy.md
@@ -1,0 +1,8 @@
+---
+"@logto/js": patch
+"@logto/express": patch
+"@logto/next": patch
+"@logto/node": patch
+---
+
+Skip token decode for opaque access token

--- a/packages/js/src/utils/access-token.test.ts
+++ b/packages/js/src/utils/access-token.test.ts
@@ -1,7 +1,6 @@
 import { generateKeyPair, SignJWT } from 'jose';
 
 import { decodeAccessToken } from './access-token.js';
-import { LogtoError } from './errors.js';
 
 describe('decodeAccessToken', () => {
   test('decoding valid JWT should return claims', async () => {
@@ -60,9 +59,8 @@ describe('decodeAccessToken', () => {
     });
   });
 
-  test('decoding invalid JWT string should throw Error', async () => {
-    expect(() => decodeAccessToken('invalid-JWT')).toMatchError(
-      new LogtoError('access_token.invalid_token')
-    );
+  test('decoding invalid JWT string should return empty claims', async () => {
+    const claims = decodeAccessToken('invalid-JWT');
+    expect(claims).toEqual({});
   });
 });

--- a/packages/js/src/utils/access-token.ts
+++ b/packages/js/src/utils/access-token.ts
@@ -3,7 +3,6 @@
 import { urlSafeBase64 } from '@silverhand/essentials';
 
 import { isArbitraryObject } from './arbitrary-object.js';
-import { LogtoError } from './errors.js';
 
 // Claims may vary, based on the custom OIDC config
 export type AccessTokenClaims = {
@@ -47,7 +46,8 @@ export const decodeAccessToken = (accessToken: string): AccessTokenClaims => {
   const { 1: encodedPayload } = accessToken.split('.');
 
   if (!encodedPayload) {
-    throw new LogtoError('access_token.invalid_token');
+    // Non-JWT format token string
+    return {};
   }
 
   const json = urlSafeBase64.decode(encodedPayload);

--- a/packages/js/src/utils/errors.ts
+++ b/packages/js/src/utils/errors.ts
@@ -11,7 +11,6 @@ const logtoErrorCodes = Object.freeze({
   'callback_uri_verification.missing_code': 'Missing code in the callback URI',
   crypto_subtle_unavailable: 'Crypto.subtle is unavailable in insecure contexts (non-HTTPS).',
   unexpected_response_error: 'Unexpected response error from the server.',
-  'access_token.invalid_token': 'Invalid access token',
 });
 
 export type LogtoErrorCode = keyof typeof logtoErrorCodes;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
skip access token decode for opaque token, opaque token has "empty claims", should not throw an error.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested with express sample

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
