### PR TITLE
fix: add typeVersions field in package.json of Next SDK (#499)

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -5,6 +5,16 @@
   "main": "./lib/src/index.cjs",
   "module": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/src/index.d.ts"
+      ],
+      "edge": [
+        "./lib/edge/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "require": "./lib/src/index.cjs",


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix Cannot find module '@logto/next/edge' or its corresponding type declarations.ts (2307) (fixes #499)

Set `typesVersions` to ensure that the corresponding imported type declaration file is used correctly

ref:
https://github.com/vercel/satori/blob/341bfab3326da507accc550d0197ffed90d8e3ac/package.json
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
