### PR TITLE
fix(react,vue): potential infinite loop when handleSignInCallback fails

### DIFF
--- a/.changeset/new-adults-happen.md
+++ b/.changeset/new-adults-happen.md
@@ -1,0 +1,6 @@
+---
+"@logto/react": patch
+"@logto/vue": patch
+---
+
+Fixed a potential infinite loop in React and Vue SDKs in some edge cases

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "changeset": "changeset",
-    "prepare": "if test \"$NODE_ENV\" != \"production\" ; then husky install ; fi"
+    "prepare": "if test \"$NODE_ENV\" != \"production\" ; then husky install ; fi",
+    "build": "pnpm -r build",
+    "test": "pnpm -r test"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.1",

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -84,10 +84,10 @@ const useHandleSignInCallback = (callback?: () => void) => {
   useEffect(() => {
     const currentPageUrl = window.location.href;
 
-    if (!isAuthenticated && logtoClient?.isSignInRedirected(currentPageUrl) && !isLoading) {
+    if (!isAuthenticated && logtoClient?.isSignInRedirected(currentPageUrl)) {
       void handleSignInCallback(currentPageUrl);
     }
-  }, [handleSignInCallback, isAuthenticated, isLoading, logtoClient]);
+  }, [handleSignInCallback, isAuthenticated, logtoClient]);
 
   return {
     isLoading,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -137,11 +137,7 @@ export const useHandleSignInCallback = (callback?: () => void) => {
   watchEffect(() => {
     const currentPageUrl = window.location.href;
 
-    if (
-      !isAuthenticated.value &&
-      logtoClient.value?.isSignInRedirected(currentPageUrl) &&
-      !isLoading.value
-    ) {
+    if (!isAuthenticated.value && logtoClient.value?.isSignInRedirected(currentPageUrl)) {
       void handleSignInCallback(currentPageUrl, callback);
     }
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a potential infinite loop when `handleSignInCallback` fails in some edge cases. Initially reported in #501 
fixes #501 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit tested added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
