### PR TITLE
fix(js) Resolve that the fetch function does not exist at @types/node, waiting for types to be updated!

### DIFF
--- a/packages/client/src/utils/requester.ts
+++ b/packages/client/src/utils/requester.ts
@@ -1,6 +1,6 @@
 import type { Requester } from '@logto/js';
 import { LogtoError, LogtoRequestError, isLogtoRequestError } from '@logto/js';
-
+// @ts-expect-error Temporary blocking of fetch function does not exist at @types/node
 export const createRequester = (fetchFunction: typeof fetch): Requester => {
   return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
     const response = await fetchFunction(...args);

--- a/packages/js/src/types/index.ts
+++ b/packages/js/src/types/index.ts
@@ -2,7 +2,7 @@ export type LogtoRequestErrorBody = {
   code: string;
   message: string;
 };
-
+ // @ts-expect-error Temporary blocking of fetch function does not exist at @types/node
 export type Requester = <T>(...args: Parameters<typeof fetch>) => Promise<T>;
 
 // Need to align with the OIDC extraParams settings in core


### PR DESCRIPTION
Annotations can be removed after @types/node are updated .