### PR TITLE
chore(react-sample): use createRoot instead of ReactDOM render

### DIFF
--- a/packages/react-sample/src/index.tsx
+++ b/packages/react-sample/src/index.tsx
@@ -1,6 +1,7 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
 
 const app = document.querySelector('#app');
-ReactDOM.render(<App />, app);
+const root = app && createRoot(app);
+root?.render(<App />);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use `createRoot` instead of `ReactDOM.render` as the latter is deprecated in React 18.
https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
React sample works

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
