### PR TITLE
refactor(js, client): refresh token should be optional in RefreshToke…

### DIFF
--- a/.changeset/quiet-ducks-roll.md
+++ b/.changeset/quiet-ducks-roll.md
@@ -1,0 +1,6 @@
+---
+"@logto/client": patch
+"@logto/js": patch
+---
+
+update "RefreshTokenTokenResponse" type in core JS SDK and set "refresh_token" field as optional

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -395,7 +395,10 @@ export default class LogtoClient {
     });
 
     await this.saveAccessTokenMap();
-    await this.setRefreshToken(refreshToken);
+
+    if (refreshToken) {
+      await this.setRefreshToken(refreshToken);
+    }
 
     if (idToken) {
       await this.verifyIdToken(idToken);

--- a/packages/js/src/core/fetch-token.ts
+++ b/packages/js/src/core/fetch-token.ts
@@ -33,7 +33,7 @@ export type CodeTokenResponse = KeysToCamelCase<SnakeCaseCodeTokenResponse>;
 
 type SnakeCaseRefreshTokenTokenResponse = {
   access_token: string;
-  refresh_token: string;
+  refresh_token?: string;
   id_token?: string;
   scope: string;
   expires_in: number;


### PR DESCRIPTION
…nTokenResponse type

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
According to [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-6), the auth server MAY issue a refresh token, not always.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
~~- [ ] integration tests~~
- [x] Updated SDK convention docs

OR

~~- [ ] This PR is not applicable for the checklist~~
