### PR TITLE
refactor: align the error exports in all js SDKs

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -23,6 +23,7 @@ export {
   LogtoError,
   LogtoRequestError,
   LogtoClientError,
+  OidcError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -21,10 +21,9 @@ export type {
 
 export {
   LogtoError,
-  OidcError,
-  Prompt,
   LogtoRequestError,
   LogtoClientError,
+  Prompt,
   ReservedScope,
   UserScope,
 } from '@logto/client';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,14 +36,7 @@ import { memoize } from './utils/memoize.js';
 import { once } from './utils/once.js';
 
 export type { IdTokenClaims, LogtoErrorCode, UserInfoResponse, InteractionMode } from '@logto/js';
-export {
-  LogtoError,
-  OidcError,
-  Prompt,
-  LogtoRequestError,
-  ReservedScope,
-  UserScope,
-} from '@logto/js';
+export { LogtoError, LogtoRequestError, Prompt, ReservedScope, UserScope } from '@logto/js';
 export * from './errors.js';
 export type { Storage, StorageKey, ClientAdapter } from './adapter/index.js';
 export { PersistKey, CacheKey } from './adapter/index.js';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,7 +36,14 @@ import { memoize } from './utils/memoize.js';
 import { once } from './utils/once.js';
 
 export type { IdTokenClaims, LogtoErrorCode, UserInfoResponse, InteractionMode } from '@logto/js';
-export { LogtoError, LogtoRequestError, Prompt, ReservedScope, UserScope } from '@logto/js';
+export {
+  LogtoError,
+  LogtoRequestError,
+  OidcError,
+  Prompt,
+  ReservedScope,
+  UserScope,
+} from '@logto/js';
 export * from './errors.js';
 export type { Storage, StorageKey, ClientAdapter } from './adapter/index.js';
 export { PersistKey, CacheKey } from './adapter/index.js';

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -8,9 +8,15 @@ import { LogtoExpressError } from './errors.js';
 import ExpressStorage from './storage.js';
 import type { LogtoExpressConfig } from './types.js';
 
-export { ReservedScope, UserScope } from '@logto/node';
+export {
+  ReservedScope,
+  UserScope,
+  LogtoError,
+  LogtoClientError,
+  LogtoRequestError,
+} from '@logto/node';
 
-export type { LogtoContext, InteractionMode } from '@logto/node';
+export type { LogtoContext, InteractionMode, LogtoErrorCode } from '@logto/node';
 export type { LogtoExpressConfig } from './types.js';
 
 export type Middleware = (

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -13,9 +13,15 @@ import LogtoNextBaseClient from './client.js';
 import { createSession } from './session.js';
 import type { LogtoNextConfig } from './types.js';
 
-export { ReservedScope, UserScope } from '@logto/node';
+export {
+  ReservedScope,
+  UserScope,
+  LogtoError,
+  LogtoClientError,
+  LogtoRequestError,
+} from '@logto/node';
 
-export type { LogtoContext, InteractionMode } from '@logto/node';
+export type { LogtoContext, InteractionMode, LogtoErrorCode } from '@logto/node';
 
 export default class LogtoClient extends LogtoNextBaseClient {
   constructor(config: LogtoNextConfig) {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -17,10 +17,9 @@ export type {
 
 export {
   LogtoError,
-  OidcError,
-  Prompt,
   LogtoRequestError,
   LogtoClientError,
+  Prompt,
   ReservedScope,
   UserScope,
 } from '@logto/client';

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -19,6 +19,7 @@ export {
   LogtoError,
   LogtoRequestError,
   LogtoClientError,
+  OidcError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -21,6 +21,7 @@ export {
   LogtoError,
   LogtoRequestError,
   LogtoClientError,
+  OidcError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,10 +19,9 @@ export type {
 
 export {
   LogtoError,
-  OidcError,
-  Prompt,
   LogtoRequestError,
   LogtoClientError,
+  Prompt,
   ReservedScope,
   UserScope,
   PersistKey,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,7 +12,7 @@ export type {
 export {
   LogtoError,
   LogtoClientError,
-  OidcError,
+  LogtoRequestError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,6 +13,7 @@ export {
   LogtoError,
   LogtoClientError,
   LogtoRequestError,
+  OidcError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -21,6 +21,7 @@ export {
   LogtoError,
   LogtoClientError,
   LogtoRequestError,
+  OidcError,
   Prompt,
   ReservedScope,
   UserScope,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -20,7 +20,7 @@ export type {
 export {
   LogtoError,
   LogtoClientError,
-  OidcError,
+  LogtoRequestError,
   Prompt,
   ReservedScope,
   UserScope,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Align the error exports in all js SDKs.

- Remove the export of `OidcError`. As currently it is only used internally and wrapped up by the `LogtoError` 
- Add the exports of `LogtoRequestError` to react and vue SDK
- Add all the missing error exports of Node SDKs. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
