### PR TITLE
fix(next): fix get context params

### DIFF
--- a/.changeset/angry-glasses-cough.md
+++ b/.changeset/angry-glasses-cough.md
@@ -1,0 +1,5 @@
+---
+"@logto/next": patch
+---
+
+Fix Next.js edge SDK's getContext, pass config to get access token

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ cache
 .history
 .vercel
 .next
+*.local

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -95,7 +95,7 @@ export default class LogtoClient extends BaseClient {
 
   getLogtoContext = async (request: NextRequest, config: GetContextParameters = {}) => {
     const { nodeClient } = await this.createNodeClientFromEdgeRequest(request);
-    const context = await nodeClient.getContext();
+    const context = await nodeClient.getContext(config);
 
     return context;
   };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

For Next.js Edge SDK, fix the bug: handle "config" param of `getLogtoContext` function.

This is a quick fix, will add unit tests for Edge SDK later in LOG-7370.

This PR fixes https://github.com/logto-io/logto/issues/4603

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with sample.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
