### PR TITLE
refactor(client): reuse getAccessToken promise

### DIFF
--- a/.changeset/fifty-paws-switch.md
+++ b/.changeset/fifty-paws-switch.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+reuse `getAccessToken()` Promise when there's an ongoing one to avoid multiple calls to the server


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
reuse `getAccessToken()` Promise when there's an ongoing one to avoid multiple calls to the server

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added unit tests, also tested locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
