### PR TITLE
refactor(js): increase ID token issued-at-time tolerance (iat) to 5 mins

### DIFF
--- a/.changeset/good-radios-brake.md
+++ b/.changeset/good-radios-brake.md
@@ -1,0 +1,5 @@
+---
+"@logto/js": patch
+---
+
+Increase ID token issued-at-time tolerance (iat) to 5 minutes

--- a/packages/js/src/utils/id-token.test.ts
+++ b/packages/js/src/utils/id-token.test.ts
@@ -166,7 +166,7 @@ describe('verifyIdToken', () => {
       .setSubject('bar')
       .setAudience('qux')
       .setExpirationTime('2h')
-      .setIssuedAt(Date.now() / 1000 - 180)
+      .setIssuedAt(Date.now() / 1000 - 301)
       .sign(privateKey);
 
     const jwks = createDefaultJwks();

--- a/packages/js/src/utils/id-token.ts
+++ b/packages/js/src/utils/id-token.ts
@@ -6,7 +6,7 @@ import { jwtVerify } from 'jose';
 import { isArbitraryObject } from './arbitrary-object.js';
 import { LogtoError } from './errors.js';
 
-const issuedAtTimeTolerance = 60;
+const issuedAtTimeTolerance = 300; // 5 minutes
 
 export type IdTokenClaims = {
   /** Issuer of this token. */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Increase ID token issued-at-time tolerance (iat claim) to 5 minutes. This change helps mitigate the potential "Invalid issued at time in the ID token" failure when the client system time is not synced with the world time.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
