### PR TITLE
refactor(react)!: refactor LogtoContextProps and LogtoContext

### DIFF
--- a/.changeset/wicked-peas-destroy.md
+++ b/.changeset/wicked-peas-destroy.md
@@ -1,0 +1,11 @@
+---
+"@logto/react": major
+---
+
+refactor LogtoContextProps and LogtoContext
+
+This version marks as major because it changes the exported `LogtoContextProps` type. In most cases, this should not affect you.
+
+- Removed `loadingCount` and `setLoadingCount` from `LogtoContextProps`.
+- Added `isLoading` and `setIsLoading` to `LogtoContextProps`.
+- Export `LogtoContext`.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
     "@silverhand/ts-config-react": "^5.0.0",
     "@swc/core": "^1.3.50",
     "@swc/jest": "^0.2.24",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^14.2.1",
     "@types/jest": "^29.5.0",
     "@types/react": "^18.2.0",
     "eslint": "^8.44.0",

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -2,12 +2,29 @@ import type LogtoClient from '@logto/browser';
 import { createContext } from 'react';
 
 export type LogtoContextProps = {
+  /** The underlying LogtoClient instance (from `@logto/browser`). */
   logtoClient?: LogtoClient;
+  /** Whether the user is authenticated or not. */
   isAuthenticated: boolean;
+  /** Whether the context has any pending requests. It will be `true` if there is at least one request pending. */
   isLoading: boolean;
+  /** The error that occurred during the last request. If there was no error, this will be `undefined`. */
   error?: Error;
+  /** Sets the authentication state. */
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
+  /**
+   * Sets the loading state.
+   *
+   * @remarks
+   * Instead of directly setting the boolean value, this function will increment or decrement the
+   * loading count.
+   *
+   * - If the `state` is `true`, the loading count will be incremented by 1.
+   * - If the `state` is `false`, the loading count will be decremented by 1. If the loading count
+   *   is already 0, it will be set to 0.
+   */
   setIsLoading: (state: boolean) => void;
+  /** Sets the error state. To clear the error, set this to `undefined`. */
   setError: React.Dispatch<React.SetStateAction<Error | undefined>>;
 };
 
@@ -15,6 +32,12 @@ export const throwContextError = (): never => {
   throw new Error('Must be used inside <LogtoProvider> context.');
 };
 
+/**
+ * The context for the LogtoProvider.
+ *
+ * @remarks
+ * Instead of using this context directly, in most cases you should use the `useLogto` hook.
+ */
 export const LogtoContext = createContext<LogtoContextProps>({
   logtoClient: undefined,
   isAuthenticated: false,

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -4,10 +4,10 @@ import { createContext } from 'react';
 export type LogtoContextProps = {
   logtoClient?: LogtoClient;
   isAuthenticated: boolean;
-  loadingCount: number;
+  isLoading: boolean;
   error?: Error;
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
-  setLoadingCount: React.Dispatch<React.SetStateAction<number>>;
+  setIsLoading: (state: boolean) => void;
   setError: React.Dispatch<React.SetStateAction<Error | undefined>>;
 };
 
@@ -18,9 +18,9 @@ export const throwContextError = (): never => {
 export const LogtoContext = createContext<LogtoContextProps>({
   logtoClient: undefined,
   isAuthenticated: false,
-  loadingCount: 0,
+  isLoading: false,
   error: undefined,
   setIsAuthenticated: throwContextError,
-  setLoadingCount: throwContextError,
+  setIsLoading: throwContextError,
   setError: throwContextError,
 });

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -53,13 +53,13 @@ const HasError = ({ children }: { children?: ReactNode }) => {
 };
 
 const AlwaysLoading = ({ children }: { children?: ReactNode }) => {
-  const { loadingCount, setLoadingCount } = useContext(LogtoContext);
+  const { isLoading, setIsLoading } = useContext(LogtoContext);
   useEffect(() => {
-    setLoadingCount((count) => count + 2); // Ensure loadingCount is greater than 1
-  }, [setLoadingCount]);
+    setIsLoading(true); // Simulate always loading
+  }, [setIsLoading]);
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <>{loadingCount > 0 ? children : null}</>;
+  return <>{children}</>;
 };
 
 describe('useLogto', () => {
@@ -171,14 +171,7 @@ describe('useLogto', () => {
   it('should not call `handleSignInCallback` when it is loading', async () => {
     isSignInRedirected.mockResolvedValueOnce(true);
 
-    // eslint-disable-next-line unicorn/consistent-function-scoping -- Use for this test only
-    const useWrapped = () => {
-      const { loadingCount } = useContext(LogtoContext);
-      useHandleSignInCallback();
-      return { loadingCount };
-    };
-
-    const { result } = renderHook(useWrapped, {
+    const { result } = renderHook(useHandleSignInCallback, {
       wrapper: ({ children }) => (
         <LogtoProvider config={{ endpoint, appId }}>
           <AlwaysLoading>{children}</AlwaysLoading>
@@ -187,8 +180,9 @@ describe('useLogto', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.loadingCount).toBeGreaterThan(1);
+      expect(result.current.isLoading).toBe(true);
     });
+
     // Give some time for side effects to be triggered
     await new Promise((resolve) => {
       setTimeout(resolve, 1);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export type { LogtoContextProps } from './context.js';
+export type { LogtoContextProps, LogtoContext } from './context.js';
 
 export type {
   LogtoConfig,

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,5 +1,5 @@
 import LogtoClient, { type LogtoConfig } from '@logto/browser';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState, useCallback } from 'react';
 
 import { LogtoContext } from './context.js';
 
@@ -27,6 +27,18 @@ export const LogtoProvider = ({
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [error, setError] = useState<Error>();
 
+  const isLoading = useMemo(() => loadingCount > 0, [loadingCount]);
+  const setIsLoading = useCallback(
+    (state: boolean) => {
+      if (state) {
+        setLoadingCount((count) => count + 1);
+      } else {
+        setLoadingCount((count) => Math.max(0, count - 1));
+      }
+    },
+    [setLoadingCount]
+  );
+
   useEffect(() => {
     (async () => {
       const isAuthenticated = await memorizedLogtoClient.logtoClient.isAuthenticated();
@@ -41,12 +53,12 @@ export const LogtoProvider = ({
       ...memorizedLogtoClient,
       isAuthenticated,
       setIsAuthenticated,
-      loadingCount,
-      setLoadingCount,
+      isLoading,
+      setIsLoading,
       error,
       setError,
     }),
-    [memorizedLogtoClient, isAuthenticated, loadingCount, error]
+    [memorizedLogtoClient, isAuthenticated, isLoading, setIsLoading, error]
   );
 
   return <LogtoContext.Provider value={memorizedContextValue}>{children}</LogtoContext.Provider>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,8 +824,8 @@ importers:
         specifier: ^0.2.24
         version: 0.2.24(@swc/core@1.3.50)
       '@testing-library/react':
-        specifier: ^14.0.0
-        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^14.2.1
+        version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.0
@@ -4243,8 +4243,8 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/react@14.0.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==}
+  /@testing-library/react@14.2.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^18.0.0
@@ -4252,7 +4252,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@testing-library/dom': 9.2.0
-      '@types/react-dom': 18.2.18
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
@@ -4543,6 +4543,12 @@ packages:
       '@types/react': 18.2.45
     dev: true
 
+  /@types/react-dom@18.2.19:
+    resolution: {integrity: sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==}
+    dependencies:
+      '@types/react': 18.2.56
+    dev: true
+
   /@types/react-router-dom@5.3.3:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
@@ -4576,6 +4582,14 @@ packages:
 
   /@types/react@18.2.45:
     resolution: {integrity: sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==}
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.1.3
+    dev: true
+
+  /@types/react@18.2.56:
+    resolution: {integrity: sha512-NpwHDMkS/EFZF2dONFQHgkPRwhvgq/OAvIaGQzxGSBmaeR++kTg6njr15Vatz0/2VcCEwJQFi6Jf4Q0qBu0rLA==}
     dependencies:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- remove `useLoadingState`, leave the logic inside the context since they are generic.
- export more useful `isLoading` and `setIsLoading` from Logto context.
- export `LogtoContext` from the package

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested in Logto demo app. works as expected.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
