### PR TITLE
fix(next-sample): revise nextjs sample profile-ssr page redirect location

### DIFF
--- a/packages/next-sample/pages/profile-ssr.tsx
+++ b/packages/next-sample/pages/profile-ssr.tsx
@@ -53,7 +53,7 @@ export const getServerSideProps = logtoClient.withLogtoSsr(async function ({ req
   const { claims, isAuthenticated } = user;
 
   if (!isAuthenticated) {
-    res.setHeader('location', '/api/logto/login');
+    res.setHeader('location', '/api/logto/sign-in');
     // eslint-disable-next-line @silverhand/fp/no-mutation
     res.statusCode = 302;
     res.end();


### PR DESCRIPTION
The correct redirect location should be `'/api/logto/sign-in'` instead of `'/api/logto/login'`.

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

I am not sure whether `export default logtoClient.handleAuthRoutes()` has changed route definition, the correct sign in route should be `/sign-in` instead of `/login`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Ref: https://github.com/logto-io/logto/blob/f539b0851d42eba974032582a8094a540c9f1246/packages/console/src/assets/docs/guides/web-next/README.mdx#L97

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [ ] ~~integration tests~~
- [ ] ~~necessary TSDoc comments~~
