### PR TITLE
refactor(js,client,node): use btoa to replace buffer

### DIFF
--- a/.changeset/gold-snails-exercise.md
+++ b/.changeset/gold-snails-exercise.md
@@ -1,0 +1,5 @@
+---
+"@logto/node": patch
+---
+
+Fix the Buffer error in edge runtime

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -67,7 +67,7 @@ export * from './types/index.js';
  */
 export default class LogtoClient {
   readonly logtoConfig: LogtoConfig;
-  readonly getOidcConfig = memoize(this.#getOidcConfig);
+  readonly getOidcConfig: () => Promise<OidcConfigResponse> = memoize(this.#getOidcConfig);
   /**
    * Get the access token from the storage with refresh strategy.
    *

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -1,4 +1,4 @@
-import { generateSignInUri, Prompt } from '@logto/js';
+import { generateSignInUri, type OidcConfigResponse, Prompt } from '@logto/js';
 import { conditional, type Nullable } from '@silverhand/essentials';
 
 import type { Storage } from './adapter/index.js';
@@ -139,7 +139,7 @@ export const createClient = (
  * Make protected fields accessible for test
  */
 export class LogtoClientWithAccessors extends LogtoClient {
-  public async runGetOidcConfig() {
+  public async runGetOidcConfig(): Promise<OidcConfigResponse> {
     return this.getOidcConfig();
   }
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -30,7 +30,7 @@
     "prepack": "pnpm build && pnpm test"
   },
   "dependencies": {
-    "@silverhand/essentials": "^2.6.2",
+    "@silverhand/essentials": "^2.8.6",
     "camelcase-keys": "^7.0.1",
     "jose": "^5.0.0"
   },

--- a/packages/node/edge/index.ts
+++ b/packages/node/edge/index.ts
@@ -17,14 +17,13 @@ export default class LogtoClient extends BaseClient {
           ? async (...args: Parameters<typeof fetch>) => {
               const [input, init] = args;
 
+              // Encode to base64 using btoa
+              const base64Credentials = btoa(`${config.appId}:${config.appSecret ?? ''}`);
+
               return fetch(input, {
                 ...init,
                 headers: {
-                  Authorization: `Basic ${Buffer.from(
-                    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                    `${config.appId}:${config.appSecret}`,
-                    'utf8'
-                  ).toString('base64')}`,
+                  Authorization: `Basic ${base64Credentials}`,
                   ...init?.headers,
                 },
               });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,8 +381,8 @@ importers:
   packages/js:
     dependencies:
       '@silverhand/essentials':
-        specifier: ^2.6.2
-        version: 2.6.2
+        specifier: ^2.8.6
+        version: 2.8.6
       camelcase-keys:
         specifier: ^7.0.1
         version: 7.0.2
@@ -3689,10 +3689,10 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@8.50.0)
       eslint-config-xo: 0.43.1(eslint@8.50.0)
       eslint-config-xo-typescript: 0.57.0(@typescript-eslint/eslint-plugin@5.61.0)(@typescript-eslint/parser@5.61.0)(eslint@8.50.0)(typescript@5.3.2)
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.28.1)(eslint@8.50.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.27.5)(eslint@8.50.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.50.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0(eslint@8.50.0)
       eslint-plugin-prettier: 5.0.0-alpha.2(eslint-config-prettier@8.8.0)(eslint@8.50.0)(prettier@3.0.0)
@@ -3737,6 +3737,11 @@ packages:
 
   /@silverhand/essentials@2.6.2:
     resolution: {integrity: sha512-1b5u2BGEa14V3o8XzaE7eL+nuwmQe8c1wqSMcGvq+KAusPPZo9tV4glbfF16Xi/ohv37vUpBGJ2DNf4CfuxBLw==}
+    engines: {node: ^16.13.0 || ^18.12.0 || ^19.2.0, pnpm: ^8.0.0}
+    dev: false
+
+  /@silverhand/essentials@2.8.6:
+    resolution: {integrity: sha512-qNyc6CvZRngP66hTA8sbpXGsiu9j6Hu62jCy7LV3tJiytg/hmxJB5oM9k5tpaUa9kHwYJ2X9CManX7SYYNrzHg==}
     engines: {node: ^16.13.0 || ^18.12.0 || ^19.2.0, pnpm: ^8.0.0}
     dev: false
 
@@ -6852,7 +6857,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.28.1)(eslint@8.50.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.27.5)(eslint@8.50.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -6863,7 +6868,7 @@ packages:
       enhanced-resolve: 5.13.0
       eslint: 8.50.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
       is-core-module: 2.13.0
@@ -6955,7 +6960,7 @@ packages:
       debug: 3.2.7
       eslint: 8.50.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.28.1)(eslint@8.50.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.61.0)(eslint-plugin-import@2.27.5)(eslint@8.50.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7075,8 +7080,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0):
-    resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.50.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -7087,7 +7092,6 @@ packages:
     dependencies:
       '@typescript-eslint/parser': 5.61.0(eslint@8.50.0)(typescript@5.3.2)
       array-includes: 3.1.6
-      array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
@@ -7099,11 +7103,10 @@ packages:
       is-core-module: 2.13.0
       is-glob: 4.0.3
       minimatch: 3.1.2
-      object.fromentries: 2.0.6
-      object.groupby: 1.0.1
       object.values: 1.1.6
+      resolve: 1.22.1
       semver: 6.3.1
-      tsconfig-paths: 3.14.2
+      tsconfig-paths: 3.14.1
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Use `btoa` function in NodeJS environment. Although this is deprecated, but it still works. 

`Buffer` is not available in some edge runtime, for example, in Cloudflare Pages, it should be imported through:

```
import { Buffer } from 'node:buffer";
```

But this import will fail in browser environment.

Also updated the package `@silverhand/essentials`, see https://github.com/silverhand-io/essentials/pull/58

The new version of `@silverhand/essentials` causes some issues with types, to bypass these, use explicit type annotations.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Pass existing tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
