### PR TITLE
refactor: fix pnpm installation issue for angular sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules
 /packages/*/out-tsc
 /packages/*/bazel-out
 
+# sample lockfile
+/packages/*-sample/pnpm-lock.yaml
+
 # logs
 logs
 *.log

--- a/packages/angular-sample/README.md
+++ b/packages/angular-sample/README.md
@@ -7,8 +7,15 @@ A sample Angular application that demonstrates how to integrate Logto with `angu
 
 For more information about `angular-auth-oidc-client`, see its [repository](https://github.com/damienbod/angular-auth-oidc-client) and official [documentation](https://angular-auth-oidc-client.com/).
 
-> *[!Note]
-> This project is excluded from the workspace. To run the sample, you need to manually install project dependencies.
+## Install dependencies
+
+This project is excluded from the workspace. To run the sample, you need to manually install project dependencies.
+
+For PNPM users, run:
+
+```sh
+pnpm install --ignore-workspace
+```
 
 ---
 

--- a/packages/angular-sample/package.json
+++ b/packages/angular-sample/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-server": "^17.2.0",
     "@angular/router": "^17.2.0",
     "@angular/ssr": "^17.2.0",
-    "@logto/js": "workspace:^",
+    "@logto/js": "link:../js",
     "angular-auth-oidc-client": "^17.0.0",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
since we removed Angular sample from the workspace, the `workspace:` protocol is no longer valid. update the protocol and readme accordingly

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
`pnpm i --ignore-workspace` installed packages and created `pnpm-lock.yaml` in the Angular sample project folder

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
