### PR TITLE
fix(next): refresh cookie ttl when access token change

### DIFF
--- a/.changeset/shy-monkeys-tease.md
+++ b/.changeset/shy-monkeys-tease.md
@@ -1,0 +1,5 @@
+---
+"@logto/next": patch
+---
+
+The page router SDK will now update cookie when access token changed

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -95,6 +95,7 @@ export default class LogtoClient extends BaseClient {
   getLogtoContext = async (request: NextRequest, config: GetContextParameters = {}) => {
     const { nodeClient } = await this.createNodeClientFromEdgeRequest(request);
     const context = await nodeClient.getContext(config);
+    await this.storage?.save();
 
     return context;
   };

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -118,6 +118,7 @@ export default class LogtoClient extends LogtoNextBaseClient {
     async (request, response) => {
       const nodeClient = await this.createNodeClientFromNextApi(request, response);
       const user = await nodeClient.getContext(config);
+      await this.storage?.save();
 
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods
       Object.defineProperty(request, 'user', { enumerable: true, get: () => user });
@@ -135,6 +136,7 @@ export default class LogtoClient extends LogtoNextBaseClient {
     async (context: GetServerSidePropsContext) => {
       const nodeClient = await this.createNodeClientFromNextApi(context.req, context.res);
       const user = await nodeClient.getContext(configs);
+      await this.storage?.save();
 
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods
       Object.defineProperty(context.req, 'user', { enumerable: true, get: () => user });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

When access token changed (new one issued), the session will change with new token map as well, need to set new cookie by calling "storage.save()".

No need to change "server actions" SDK because the cookie is not managed inside the SDK, and the server action can not always call "setCookie".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, after 1 hour when access token expires, "set-cookie" is found in response header.

<img width="639" alt="截屏2024-02-20 下午4 59 15" src="https://github.com/logto-io/js/assets/5717882/e1146ee7-e2a1-4fae-9594-180355334278">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
