### PR TITLE
refactor: implement `CookieStorage` for node sdk

### DIFF
--- a/.changeset/green-dingos-grin.md
+++ b/.changeset/green-dingos-grin.md
@@ -1,0 +1,7 @@
+---
+"@logto/node": minor
+---
+
+implement reusable `CookieStorage` for Node environment
+
+It can be used to store and retrieve encrypted cookies in Node.js environment for Logto.

--- a/.changeset/small-cows-act.md
+++ b/.changeset/small-cows-act.md
@@ -1,0 +1,5 @@
+---
+"@logto/node": patch
+---
+
+remove `node-fetch` from dependencies (native fetch is available from [Node.js v17.5.0](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch), we are targeting v20+)

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,9 @@ cache
 .*cache
 .DS_Store
 Thumbs.db
-*.env
+.env
+.env.*
+!.env.example
 .idea/
 *.pem
 .history

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -41,13 +41,14 @@
     "@logto/client": "workspace:^2.3.3",
     "@silverhand/essentials": "^2.8.7",
     "js-base64": "^3.7.4",
-    "node-fetch": "^2.6.7"
+    "p-queue": "^8.0.1"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^5.0.0",
     "@silverhand/ts-config": "^5.0.0",
     "@swc/core": "^1.3.7",
     "@swc/jest": "^0.2.24",
+    "@types/cookie": "^0.6.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.11.19",
     "eslint": "^8.44.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@logto/client": "workspace:^2.3.3",
     "@silverhand/essentials": "^2.8.7",
-    "js-base64": "^3.7.4",
-    "p-queue": "^8.0.1"
+    "js-base64": "^3.7.4"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^5.0.0",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,6 +1,5 @@
 import type { LogtoConfig, ClientAdapter, StandardLogtoClient, JwtVerifier } from '@logto/client';
 import { createRequester } from '@logto/client';
-import fetch from 'node-fetch';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../edge/generators.js';
 
@@ -9,6 +8,7 @@ import BaseClient from './client.js';
 export type { LogtoContext, GetContextParameters } from './types.js';
 
 export * from './utils/session.js';
+export * from './utils/cookie-storage.js';
 
 export type {
   IdTokenClaims,

--- a/packages/node/src/utils/cookie-storage.test.ts
+++ b/packages/node/src/utils/cookie-storage.test.ts
@@ -1,5 +1,4 @@
 import { PersistKey, unwrapSession, wrapSession } from '@logto/node';
-import { type RequestEvent } from '@sveltejs/kit';
 
 import { CookieStorage } from './cookie-storage.js';
 
@@ -18,33 +17,27 @@ class TestCookieStorage extends CookieStorage {
 
 const encryptionKey = 'foo';
 
-const createMockEvent = (
-  initialCookies: Record<string, string> = {},
-  url = 'http://localhost/',
-  headers = new Map()
-): RequestEvent => {
+const createCookieConfig = (encryptionKey: string, initialCookies: Record<string, string> = {}) => {
   const cookies = new Map(Object.entries(initialCookies));
-
   return {
-    // @ts-expect-error
-    cookies: {
-      get: (name: string) => cookies.get(name),
-      getAll: () => [...cookies.entries()].map(([name, value]) => ({ name, value })),
-      set: (name: string, value: string) => cookies.set(name, value),
-      delete: (name: string) => cookies.delete(name),
-    },
-    request: {
-      url,
-      // @ts-expect-error
-      headers,
-    },
+    encryptionKey,
+    getCookie: (name: string) => cookies.get(name),
+    setCookie: (name: string, value: string) => cookies.set(name, value),
   };
 };
+
+const createPartialRequest = (url = 'http://localhost/', headers = new Headers()) => ({
+  headers,
+  url,
+});
 
 describe('CookieStorage', () => {
   it('should be able to produce correct configs', () => {
     expect(
-      new TestCookieStorage({ requestEvent: createMockEvent(), encryptionKey }).getCookieOptions()
+      new TestCookieStorage(
+        createCookieConfig(encryptionKey),
+        createPartialRequest()
+      ).getCookieOptions()
     ).toEqual({
       httpOnly: true,
       path: '/',
@@ -54,10 +47,10 @@ describe('CookieStorage', () => {
     });
 
     expect(
-      new TestCookieStorage({
-        requestEvent: createMockEvent({}, 'https://localhost/'),
-        encryptionKey,
-      }).getCookieOptions()
+      new TestCookieStorage(
+        createCookieConfig(encryptionKey),
+        createPartialRequest('https://localhost/')
+      ).getCookieOptions()
     ).toEqual({
       httpOnly: true,
       path: '/',
@@ -67,10 +60,10 @@ describe('CookieStorage', () => {
     });
 
     expect(
-      new TestCookieStorage({
-        requestEvent: createMockEvent({}, undefined, new Map([['x-forwarded-proto', 'https']])),
-        encryptionKey,
-      }).getCookieOptions()
+      new TestCookieStorage(
+        createCookieConfig(encryptionKey),
+        createPartialRequest(undefined, new Headers({ 'x-forwarded-proto': 'https' }))
+      ).getCookieOptions()
     ).toEqual({
       httpOnly: true,
       path: '/',
@@ -81,10 +74,12 @@ describe('CookieStorage', () => {
   });
 
   it('should be able to load and save data', async () => {
-    const requestEvent = createMockEvent({
-      logtoCookies: await wrapSession({ [PersistKey.AccessToken]: 'bar' }, encryptionKey),
-    });
-    const storage = new TestCookieStorage({ requestEvent, encryptionKey });
+    const storage = new TestCookieStorage(
+      createCookieConfig(encryptionKey, {
+        logtoCookies: await wrapSession({ [PersistKey.AccessToken]: 'bar' }, encryptionKey),
+      }),
+      createPartialRequest()
+    );
     await storage.init();
     expect(storage.data).toEqual({ [PersistKey.AccessToken]: 'bar' });
     expect(await storage.getItem(PersistKey.AccessToken)).toEqual('bar');
@@ -92,22 +87,27 @@ describe('CookieStorage', () => {
 
     await storage.setItem(PersistKey.AccessToken, 'baz');
     expect(storage.data).toEqual({ [PersistKey.AccessToken]: 'baz' });
-    expect(await unwrapSession(requestEvent.cookies.get('logtoCookies')!, encryptionKey)).toEqual({
+    expect(await unwrapSession(storage.config.getCookie('logtoCookies')!, encryptionKey)).toEqual({
       [PersistKey.AccessToken]: 'baz',
     });
   });
 
   it('should be able to remove data', async () => {
-    const requestEvent = createMockEvent({
-      foo: await wrapSession({ [PersistKey.AccessToken]: 'bar' }, encryptionKey),
-    });
-    const storage = new TestCookieStorage({ requestEvent, encryptionKey, cookieKey: 'foo' });
+    const storage = new TestCookieStorage(
+      {
+        ...createCookieConfig(encryptionKey, {
+          foo: await wrapSession({ [PersistKey.AccessToken]: 'bar' }, encryptionKey),
+        }),
+        cookieKey: 'foo',
+      },
+      createPartialRequest()
+    );
     await storage.init();
     expect(storage.data).toEqual({ [PersistKey.AccessToken]: 'bar' });
 
     await storage.removeItem(PersistKey.AccessToken);
     expect(storage.data).toEqual({});
-    expect(await unwrapSession(requestEvent.cookies.get('foo')!, encryptionKey)).toEqual({});
+    expect(await unwrapSession(storage.config.getCookie('foo')!, encryptionKey)).toEqual({});
   });
 });
 
@@ -144,8 +144,8 @@ describe('CookieStorage concurrency', () => {
   ])('should have the expected result [%#]', async (StorageClass) => {
     const randomDelay = async <T>(function_: () => Promise<T>): Promise<T> =>
       delay(function_, Math.random() * 5);
-    const requestEvent = createMockEvent({});
-    const storage = new StorageClass({ requestEvent, encryptionKey });
+
+    const storage = new StorageClass(createCookieConfig(encryptionKey), createPartialRequest());
     await storage.init();
     expect(storage.data).toEqual({});
 
@@ -164,7 +164,7 @@ describe('CookieStorage concurrency', () => {
     };
     expect(storage.data).toEqual(result);
 
-    const unwrapped = await unwrapSession(requestEvent.cookies.get('logtoCookies')!, encryptionKey);
+    const unwrapped = await unwrapSession(storage.config.getCookie('logtoCookies')!, encryptionKey);
 
     if (StorageClass === NoQueueTestCookieStorage) {
       expect(unwrapped).not.toEqual(result);

--- a/packages/node/src/utils/cookie-storage.test.ts
+++ b/packages/node/src/utils/cookie-storage.test.ts
@@ -1,6 +1,7 @@
-import { PersistKey, unwrapSession, wrapSession } from '@logto/node';
+import { PersistKey } from '@logto/client/shim';
 
 import { CookieStorage } from './cookie-storage.js';
+import { unwrapSession, wrapSession } from './session.js';
 
 const delay = async <T>(function_: () => Promise<T>, ms: number): Promise<T> =>
   new Promise((resolve) => {

--- a/packages/node/src/utils/cookie-storage.ts
+++ b/packages/node/src/utils/cookie-storage.ts
@@ -1,7 +1,7 @@
 import { type PersistKey, type Storage } from '@logto/client';
 import type { CookieSerializeOptions } from 'cookie';
-import PQueue from 'p-queue';
 
+import { PromiseQueue } from './promise-queue.js';
 import { wrapSession, unwrapSession, type SessionData } from './session.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -48,7 +48,7 @@ export class CookieStorage implements Storage<PersistKey> {
   }
 
   protected sessionData: SessionData = {};
-  protected saveQueue: PQueue = new PQueue({ concurrency: 1 });
+  protected saveQueue = new PromiseQueue();
   #isSecure: boolean;
 
   constructor(
@@ -87,7 +87,7 @@ export class CookieStorage implements Storage<PersistKey> {
   }
 
   protected async save() {
-    return this.saveQueue.add(async () => this.write());
+    return this.saveQueue.enqueue(async () => this.write());
   }
 
   protected async write(data = this.sessionData) {

--- a/packages/node/src/utils/cookie-storage.ts
+++ b/packages/node/src/utils/cookie-storage.ts
@@ -1,19 +1,28 @@
-import type { PersistKey, SessionData, Storage } from '@logto/node';
-import { wrapSession, unwrapSession } from '@logto/node';
-import type { Cookies, RequestEvent } from '@sveltejs/kit';
+import { type PersistKey, type Storage } from '@logto/client';
 import type { CookieSerializeOptions } from 'cookie';
 import PQueue from 'p-queue';
+
+import { wrapSession, unwrapSession, type SessionData } from './session.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type Nullable<T> = T | null;
 
 export type CookieConfig = {
-  /** The request event from SvelteKit. */
-  requestEvent: RequestEvent;
   /** The encryption key to encrypt the session data. It should be a random string. */
   encryptionKey: string;
   /** The name of the cookie key. Default to `logtoCookies`. */
   cookieKey?: string;
+  getCookie: (name: string) => string | undefined;
+  setCookie: (
+    name: string,
+    value: string,
+    options: CookieSerializeOptions & { path: string }
+  ) => void;
+};
+
+export type PartialRequest = {
+  headers: Headers;
+  url: string;
 };
 
 /**
@@ -41,18 +50,25 @@ export class CookieStorage implements Storage<PersistKey> {
   protected sessionData: SessionData = {};
   protected saveQueue: PQueue = new PQueue({ concurrency: 1 });
   #isSecure: boolean;
-  #cookies: Cookies;
 
-  constructor(public config: CookieConfig) {
-    const { request, cookies } = config.requestEvent;
+  constructor(
+    public config: CookieConfig,
+    request: PartialRequest
+  ) {
+    if (!config.encryptionKey) {
+      throw new TypeError('The `encryptionKey` string is required for `CookieStorage`');
+    }
+
     this.#isSecure =
       request.headers.get('x-forwarded-proto') === 'https' || request.url.startsWith('https');
-    this.#cookies = cookies;
   }
 
   async init() {
     const { encryptionKey } = this.config;
-    this.sessionData = await unwrapSession(this.#cookies.get(this.cookieKey) ?? '', encryptionKey);
+    this.sessionData = await unwrapSession(
+      this.config.getCookie(this.cookieKey) ?? '',
+      encryptionKey
+    );
   }
 
   async getItem(key: PersistKey): Promise<Nullable<string>> {
@@ -76,6 +92,10 @@ export class CookieStorage implements Storage<PersistKey> {
 
   protected async write(data = this.sessionData) {
     const { encryptionKey } = this.config;
-    this.#cookies.set(this.cookieKey, await wrapSession(data, encryptionKey), this.cookieOptions);
+    this.config.setCookie(
+      this.cookieKey,
+      await wrapSession(data, encryptionKey),
+      this.cookieOptions
+    );
   }
 }

--- a/packages/node/src/utils/promise-queue.test.ts
+++ b/packages/node/src/utils/promise-queue.test.ts
@@ -1,0 +1,57 @@
+import { PromiseQueue } from './promise-queue.js';
+
+/* eslint-disable @silverhand/fp/no-mutating-methods */
+describe('PromiseQueue', () => {
+  it('should process tasks sequentially in the order they are enqueued', async () => {
+    const queue = new PromiseQueue();
+    const results: number[] = [];
+
+    const task = (value: number) => async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+      results.push(value);
+    };
+
+    await Promise.all([queue.enqueue(task(1)), queue.enqueue(task(2)), queue.enqueue(task(3))]);
+
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it('should process tasks sequentially in the order they are enqueued even if the tasks are rejected', async () => {
+    const queue = new PromiseQueue();
+    const results: number[] = [];
+    const errors: unknown[] = [];
+
+    const task = (value: number) => async () => {
+      try {
+        await new Promise((resolve, reject) => {
+          setTimeout(() => {
+            if (value === 2) {
+              reject(new Error('Task 2 failed'));
+            } else {
+              resolve(null);
+            }
+          }, 1);
+        });
+
+        results.push(value);
+      } catch (error) {
+        errors.push(error);
+      }
+    };
+
+    await Promise.all([
+      queue.enqueue(task(1)),
+      queue.enqueue(task(2)),
+      queue.enqueue(task(3)),
+      queue.enqueue(task(4)),
+    ]);
+
+    expect(results).toEqual([1, 3, 4]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect((errors[0] as Error).message).toBe('Task 2 failed');
+  });
+});
+/* eslint-enable @silverhand/fp/no-mutating-methods */

--- a/packages/node/src/utils/promise-queue.ts
+++ b/packages/node/src/utils/promise-queue.ts
@@ -1,0 +1,45 @@
+/**
+ * A simple promise queue that processes tasks sequentially in the order they are enqueued.
+ */
+export class PromiseQueue {
+  private readonly queue: Array<() => Promise<unknown>> = [];
+  private processing = false;
+
+  async enqueue<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      // Wrap the task along with its resolve and reject callbacks
+      const wrappedTask = async () => {
+        try {
+          resolve(await task());
+        } catch (error) {
+          reject(error);
+        }
+      };
+
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      this.queue.push(wrappedTask);
+
+      if (!this.processing) {
+        void this.processQueue();
+      }
+    });
+  }
+
+  private async processQueue() {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      const task = this.queue.shift();
+      if (task) {
+        // eslint-disable-next-line no-await-in-loop
+        await task();
+      }
+    }
+
+    this.processing = false;
+  }
+}

--- a/packages/node/src/utils/session.test.ts
+++ b/packages/node/src/utils/session.test.ts
@@ -1,4 +1,4 @@
-import { PersistKey } from '@logto/node';
+import { PersistKey } from '@logto/client/shim';
 
 import { unwrapSession, wrapSession } from './session.js';
 

--- a/packages/sveltekit-sample/package.json
+++ b/packages/sveltekit-sample/package.json
@@ -26,7 +26,7 @@
 		"svelte-check": "^3.6.0",
 		"tslib": "^2.4.1",
 		"typescript": "^5.3.3",
-		"vite": "^5.0.3"
+		"vite": "^5.1.1"
 	},
 	"eslintConfig": {
 		"extends": "@silverhand"

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -55,7 +55,6 @@
     "@sveltejs/kit": "^2.0.0"
   },
   "dependencies": {
-    "@logto/node": "workspace:^",
-    "p-queue": "^8.0.1"
+    "@logto/node": "workspace:^"
   }
 }

--- a/packages/vue-sample/package.json
+++ b/packages/vue-sample/package.json
@@ -28,7 +28,7 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12",
+    "vite": "^5.1.1",
     "vue-tsc": "^1.8.26"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,9 +700,6 @@ importers:
       js-base64:
         specifier: ^3.7.4
         version: 3.7.4
-      p-queue:
-        specifier: ^8.0.1
-        version: 8.0.1
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^5.0.0
@@ -8829,6 +8826,7 @@ packages:
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+    dev: true
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -11790,19 +11788,6 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
     dev: true
-
-  /p-queue@8.0.1:
-    resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
-    engines: {node: '>=18'}
-    dependencies:
-      eventemitter3: 5.0.1
-      p-timeout: 6.1.2
-    dev: false
-
-  /p-timeout@6.1.2:
-    resolution: {integrity: sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==}
-    engines: {node: '>=14.16'}
-    dev: false
 
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,9 +700,9 @@ importers:
       js-base64:
         specifier: ^3.7.4
         version: 3.7.4
-      node-fetch:
-        specifier: ^2.6.7
-        version: 2.6.7
+      p-queue:
+        specifier: ^8.0.1
+        version: 8.0.1
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^5.0.0
@@ -716,6 +716,9 @@ importers:
       '@swc/jest':
         specifier: ^0.2.24
         version: 0.2.24(@swc/core@1.3.7)
+      '@types/cookie':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.0
@@ -1008,9 +1011,6 @@ importers:
       '@logto/node':
         specifier: workspace:^
         version: link:../node
-      p-queue:
-        specifier: ^8.0.1
-        version: 8.0.1
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^5.0.0
@@ -1065,10 +1065,10 @@ importers:
         version: 3.1.1(@sveltejs/kit@2.5.0)
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.0.12)
+        version: 2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.1.1)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.2(svelte@4.2.11)(vite@5.0.12)
+        version: 3.0.2(svelte@4.2.11)(vite@5.1.1)
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1094,8 +1094,8 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.3
-        version: 5.0.12(@types/node@20.11.6)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.6)
 
   packages/vue:
     dependencies:
@@ -1169,7 +1169,7 @@ importers:
         version: 20.11.19
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.0(vite@5.0.12)(vue@3.3.13)
+        version: 5.0.0(vite@5.1.1)(vue@3.3.13)
       '@vue/eslint-config-prettier':
         specifier: ^8.0.0
         version: 8.0.0(eslint@8.44.0)(prettier@3.0.0)
@@ -1195,8 +1195,8 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.19)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.19)
       vue-tsc:
         specifier: ^1.8.26
         version: 1.8.26(typescript@5.3.3)
@@ -4345,35 +4345,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.1.1)
       import-meta-resolve: 4.0.0
-    dev: true
-
-  /@sveltejs/kit@2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.0.12):
-    resolution: {integrity: sha512-1uyXvzC2Lu1FZa30T4y5jUAC21R309ZMRG0TPt+PPPbNUoDpy8zSmSNVWYaBWxYDqLGQ5oPNWvjvvF2IjJ1jmA==}
-    engines: {node: '>=18.13'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.3
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.11)(vite@5.0.12)
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-      devalue: 4.3.2
-      esm-env: 1.0.0
-      import-meta-resolve: 4.0.0
-      kleur: 4.1.5
-      magic-string: 0.30.5
-      mrmime: 2.0.0
-      sade: 1.8.1
-      set-cookie-parser: 2.6.0
-      sirv: 2.0.4
-      svelte: 4.2.11
-      tiny-glob: 0.2.9
-      vite: 5.0.12(@types/node@20.11.6)
     dev: true
 
   /@sveltejs/kit@2.5.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.1.1):
@@ -4403,22 +4376,6 @@ packages:
       vite: 5.1.1(@types/node@20.11.19)
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.0.12):
-    resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.11)(vite@5.0.12)
-      debug: 4.3.4
-      svelte: 4.2.11
-      vite: 5.0.12(@types/node@20.11.6)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.1.1):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
@@ -4431,26 +4388,6 @@ packages:
       debug: 4.3.4
       svelte: 4.2.11
       vite: 5.1.1(@types/node@20.11.19)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@4.2.11)(vite@5.0.12):
-    resolution: {integrity: sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.0.12)
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.5
-      svelte: 4.2.11
-      svelte-hmr: 0.15.3(svelte@4.2.11)
-      vite: 5.0.12(@types/node@20.11.6)
-      vitefu: 0.2.5(vite@5.0.12)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5787,14 +5724,14 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@vitejs/plugin-vue@5.0.0(vite@5.0.12)(vue@3.3.13):
+  /@vitejs/plugin-vue@5.0.0(vite@5.1.1)(vue@3.3.13):
     resolution: {integrity: sha512-7x5e8X4J1Wi4NxudGjJBd2OFerAi/0nzF80ojCzvfj347WVr0YSn82C8BSsgwSHzlk9Kw5xnZfj0/7RLnNwP5w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.12(@types/node@20.11.19)
+      vite: 5.1.1(@types/node@20.11.19)
       vue: 3.3.13(typescript@5.3.3)
     dev: true
 
@@ -11569,6 +11506,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
 
   /node-gyp-build-optional-packages@5.0.6:
     resolution: {integrity: sha512-2ZJErHG4du9G3/8IWl/l9Bp5BBFy63rno5GVmjQijvTuUZKsl6g8RB4KH/x3NLcV5ZBb4GsXmAuTYr6dRml3Gw==}
@@ -13732,6 +13670,7 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
 
   /tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
@@ -14025,78 +13964,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@5.0.12(@types/node@20.11.19):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.19
-      esbuild: 0.19.10
-      postcss: 8.4.32
-      rollup: 4.9.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@5.0.12(@types/node@20.11.6):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.6
-      esbuild: 0.19.10
-      postcss: 8.4.32
-      rollup: 4.9.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@5.1.1(@types/node@20.11.19):
     resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -14133,15 +14000,40 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitefu@0.2.5(vite@5.0.12):
-    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
+  /vite@5.1.1(@types/node@20.11.6):
+    resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
     peerDependenciesMeta:
-      vite:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@20.11.6)
+      '@types/node': 20.11.6
+      esbuild: 0.19.10
+      postcss: 8.4.35
+      rollup: 4.9.1
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /vitefu@0.2.5(vite@5.1.1):
@@ -14289,6 +14181,7 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
 
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -14320,6 +14213,7 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    dev: true
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- implement reusable `CookieStorage` for Node environment (extracted from `@logto/sveltekit`)
- remove `node-fetch` from `@logto/node` (Node comes with native fetch from 17)
- minor package metadata updates
- implement a simple Promise queue as `p-queue` is ESM only but we still target CJS

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
unit tests + local sign-in/out

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
