### PR TITLE
fix(nuxt): import `defineEventHandler` from h3

### DIFF
--- a/.changeset/afraid-socks-lie.md
+++ b/.changeset/afraid-socks-lie.md
@@ -1,0 +1,5 @@
+---
+"@logto/nuxt": patch
+---
+
+fix `defineEventHandler is not defined` error`

--- a/packages/nuxt/src/runtime/server/event-handler.ts
+++ b/packages/nuxt/src/runtime/server/event-handler.ts
@@ -1,4 +1,5 @@
 import LogtoClient, { CookieStorage } from '@logto/node';
+import { defineEventHandler } from 'h3';
 
 import { defaults } from '../utils/constants';
 import { type LogtoRuntimeConfig } from '../utils/types';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
explicitly import `defineEventHandler` from h3 to fix the runtime error. fix #647.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
after update, the nuxt project can build successfully

<img width="562" alt="image" src="https://github.com/logto-io/js/assets/14722250/257c2541-025c-4104-a717-13fc8976a36b">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
