### PR TITLE
feat(js): add secureRoutes support to buildAngularAuthConfig util

### DIFF
--- a/.changeset/stupid-kiwis-sip.md
+++ b/.changeset/stupid-kiwis-sip.md
@@ -1,0 +1,5 @@
+---
+"@logto/js": patch
+---
+
+support `secureRoutes` config in `buildAngularAuthConfig` util.

--- a/packages/js/src/utils/angular.ts
+++ b/packages/js/src/utils/angular.ts
@@ -5,7 +5,7 @@ import { Prompt } from '../consts/index.js';
 import { withDefaultScopes } from './scopes.js';
 
 /** The Logto configuration object for Angular apps. */
-export type LogtoAngularConfig = {
+export type LogtoAngularConfig = OpenIdConfiguration & {
   /**
    * The endpoint for the Logto server, you can get it from the integration guide
    * or the team settings page of the Logto Console.
@@ -81,11 +81,13 @@ export const buildAngularAuthConfig = (logtoConfig: LogtoAngularConfig): OpenIdC
     redirectUri: redirectUrl,
     postLogoutRedirectUri,
     prompt = Prompt.Consent,
+    ...otherConfigs
   } = logtoConfig;
   const scope = withDefaultScopes(scopes);
   const customParameters = resource ? { resource } : undefined;
 
   return {
+    ...otherConfigs,
     authority: new URL('/oidc', endpoint).href,
     redirectUrl,
     postLogoutRedirectUri,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add support to `secureRoutes` config in `buildAngularAuthConfig` util, so that `angular-auth-oidc-client` will automatically add access tokens to request header for these routes.

Feature requested by community:
https://discord.com/channels/965845662535147551/1215176080680550461

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
We can do this now:
<img width="568" alt="image" src="https://github.com/logto-io/js/assets/12833674/99377f8e-a811-4325-8d59-356f6d104d8b">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`

~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
