### PR TITLE
feat(js,client): support login_hint param on sign-in

### DIFF
--- a/.changeset/strange-chairs-appear.md
+++ b/.changeset/strange-chairs-appear.md
@@ -1,0 +1,6 @@
+---
+"@logto/client": patch
+"@logto/js": patch
+---
+
+support login_hint param on sign-in.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -57,6 +57,10 @@ export type SignInOptions = {
    * @see {@link InteractionMode}
    */
   interactionMode?: InteractionMode;
+  /**
+   * Login hint indicates the current user (usually an email address).
+   */
+  loginHint?: string;
 };
 
 /**
@@ -230,18 +234,26 @@ export class StandardLogtoClient {
    */
   async signIn(
     redirectUri: SignInOptions['redirectUri'],
-    interactionMode?: SignInOptions['interactionMode']
+    interactionMode?: SignInOptions['interactionMode'],
+    loginHint?: SignInOptions['loginHint']
   ): Promise<void>;
   async signIn(
     options: SignInOptions | string | URL,
-    mode?: SignInOptions['interactionMode']
+    mode?: SignInOptions['interactionMode'],
+    hint?: SignInOptions['loginHint']
   ): Promise<void> {
     const {
       redirectUri: redirectUriUrl,
       postRedirectUri: postRedirectUriUrl,
       interactionMode,
+      loginHint,
     } = typeof options === 'string' || options instanceof URL
-      ? { redirectUri: options, postRedirectUri: undefined, interactionMode: mode }
+      ? {
+          redirectUri: options,
+          postRedirectUri: undefined,
+          interactionMode: mode,
+          loginHint: hint,
+        }
       : options;
     const redirectUri = redirectUriUrl.toString();
     const postRedirectUri = postRedirectUriUrl?.toString();
@@ -263,6 +275,7 @@ export class StandardLogtoClient {
       resources,
       prompt,
       interactionMode,
+      loginHint,
     });
 
     await Promise.all([

--- a/packages/client/src/index.sign-in.test.ts
+++ b/packages/client/src/index.sign-in.test.ts
@@ -23,6 +23,8 @@ import {
   tokenEndpoint,
   createAdapters,
   mockedSignUpUri,
+  mockedUserHint,
+  mockedSignInUriWithLoginHint,
 } from './mock.js';
 
 jest.mock('@logto/js', () => ({
@@ -83,6 +85,12 @@ describe('LogtoClient', () => {
       const logtoClient = createClient();
       await logtoClient.signIn(redirectUri);
       expect(navigate).toHaveBeenCalledWith(mockedSignInUri, { redirectUri, for: 'sign-in' });
+    });
+
+    it('should redirect to signInUri with login_hint param after calling signIn with user hint', async () => {
+      const logtoClient = createClient();
+      await logtoClient.signIn(redirectUri, undefined, mockedUserHint);
+      expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithLoginHint);
     });
 
     it('should redirect to signInUri with interactionMode params after calling signIn with signUp mode', async () => {

--- a/packages/client/src/index.sign-in.test.ts
+++ b/packages/client/src/index.sign-in.test.ts
@@ -90,7 +90,10 @@ describe('LogtoClient', () => {
     it('should redirect to signInUri with login_hint param after calling signIn with user hint', async () => {
       const logtoClient = createClient();
       await logtoClient.signIn(redirectUri, undefined, mockedUserHint);
-      expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithLoginHint);
+      expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithLoginHint, {
+        redirectUri,
+        for: 'sign-in',
+      });
     });
 
     it('should redirect to signInUri with interactionMode params after calling signIn with signUp mode', async () => {

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -51,6 +51,7 @@ export const postSignOutRedirectUri = 'http://localhost:3000';
 export const mockCodeChallenge = 'code_challenge_value';
 export const mockedCodeVerifier = 'code_verifier_value';
 export const mockedState = 'state_value';
+export const mockedUserHint = 'johndoe@example.com';
 
 export const mockedSignInUri = generateSignInUri({
   authorizationEndpoint,
@@ -76,6 +77,15 @@ export const mockedSignUpUri = generateSignInUri({
   codeChallenge: mockCodeChallenge,
   state: mockedState,
   interactionMode: 'signUp',
+});
+
+export const mockedSignInUriWithLoginHint = generateSignInUri({
+  authorizationEndpoint,
+  clientId: appId,
+  redirectUri,
+  codeChallenge: mockCodeChallenge,
+  state: mockedState,
+  loginHint: mockedUserHint,
 });
 
 export const accessToken = 'access_token_value';

--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -20,6 +20,7 @@ export enum QueryKey {
   GrantType = 'grant_type',
   IdToken = 'id_token',
   IdTokenHint = 'id_token_hint',
+  LoginHint = 'login_hint',
   PostLogoutRedirectUri = 'post_logout_redirect_uri',
   Prompt = 'prompt',
   RedirectUri = 'redirect_uri',

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -66,4 +66,19 @@ describe('generateSignInUri', () => {
       'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&interaction_mode=signUp'
     );
   });
+
+  test('with loginHint', () => {
+    const signInUri = generateSignInUri({
+      authorizationEndpoint,
+      clientId,
+      redirectUri,
+      codeChallenge,
+      state,
+      loginHint: 'johndoe@example.com',
+    });
+
+    expect(signInUri).toEqual(
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&login_hint=johndoe%40example.com'
+    );
+  });
 });

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -15,6 +15,7 @@ export type SignInUriParameters = {
   resources?: string[];
   prompt?: Prompt | Prompt[];
   interactionMode?: InteractionMode;
+  loginHint?: string;
 };
 
 const buildPrompt = (prompt?: Prompt | Prompt[]) => {
@@ -35,6 +36,7 @@ export const generateSignInUri = ({
   resources,
   prompt,
   interactionMode,
+  loginHint,
 }: SignInUriParameters) => {
   const urlSearchParameters = new URLSearchParams({
     [QueryKey.ClientId]: clientId,
@@ -46,6 +48,10 @@ export const generateSignInUri = ({
     [QueryKey.Prompt]: buildPrompt(prompt),
     [QueryKey.Scope]: withDefaultScopes(scopes),
   });
+
+  if (loginHint) {
+    urlSearchParameters.append(QueryKey.LoginHint, loginHint);
+  }
 
   for (const resource of resources ?? []) {
     urlSearchParameters.append(QueryKey.Resource, resource);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support `login_hint` param on sign-in.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested with React sample project, and the `login_hint` param was appended in the sign-in URL properly when navigating to Logto sign-in experience page.

<img width="630" alt="image" src="https://github.com/logto-io/js/assets/12833674/8b3a7983-feca-4715-9932-49b5951b9367">

<img width="1019" alt="image" src="https://github.com/logto-io/js/assets/12833674/ea75e8a2-5883-40c4-8b2f-c86f04bddbb6">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests

~~- [ ] integration tests'~~

- [x] necessary TSDoc comments
