### PR TITLE
fix(next): set cookie samesite when the config is secure

### DIFF
--- a/.changeset/polite-masks-judge.md
+++ b/.changeset/polite-masks-judge.md
@@ -1,0 +1,5 @@
+---
+"@logto/next": patch
+---
+
+In Next.js SDK, if cookie secure config is set to true, will add "SameSite=Lax"

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -117,6 +117,7 @@ export default class LogtoClient extends BaseClient {
           responseCookies.set(cookieName, value, {
             maxAge: 14 * 3600 * 24,
             secure: this.config.cookieSecure,
+            sameSite: this.config.cookieSecure ? 'lax' : undefined,
           });
         }
       )

--- a/packages/next/server-actions/cookie.ts
+++ b/packages/next/server-actions/cookie.ts
@@ -10,5 +10,6 @@ export const setCookies = async (newCookie: string, config: LogtoNextConfig): Pr
   cookies().set(`logto:${config.appId}`, newCookie, {
     maxAge: 14 * 3600 * 24,
     secure: config.cookieSecure,
+    sameSite: config.cookieSecure ? 'lax' : undefined,
   });
 };

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -165,7 +165,7 @@ export default class LogtoClient extends LogtoNextBaseClient {
           response.setHeader(
             'Set-Cookie',
             `${cookieName}=${value}; Path=/; Max-Age=${maxAge}; ${
-              secure ? 'Secure; SameSite=None' : ''
+              secure ? 'Secure; SameSite=Lax' : ''
             }`
           );
         }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In Next.js SDK, if cookie secure config is set to true, will add "SameSite=Lax".

There is "CookieStorage" in this project, but it turned out to be not easy to refactor. Created an issue to track, will refactor later.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
