### PR TITLE
feat: support additional sign-in params

### DIFF
--- a/.changeset/silly-grapes-fold.md
+++ b/.changeset/silly-grapes-fold.md
@@ -1,0 +1,6 @@
+---
+"@logto/client": minor
+"@logto/js": minor
+---
+
+support `firstScreen`, `directSignIn`, and `extraParams` for sign-in

--- a/packages/js/src/consts/index.ts
+++ b/packages/js/src/consts/index.ts
@@ -34,6 +34,8 @@ export enum QueryKey {
   InteractionMode = 'interaction_mode',
   /** The query key for specifying the organization ID. */
   OrganizationId = 'organization_id',
+  FirstScreen = 'first_screen',
+  DirectSignIn = 'direct_sign_in',
 }
 
 /** The prompt parameter to be used for the authorization request. */

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -81,4 +81,38 @@ describe('generateSignInUri', () => {
       'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&login_hint=johndoe%40example.com'
     );
   });
+
+  test('with firstScreen and interactionMode', () => {
+    const signInUri = generateSignInUri({
+      authorizationEndpoint,
+      clientId,
+      redirectUri,
+      codeChallenge,
+      state,
+      firstScreen: 'register',
+      interactionMode: 'signIn',
+    });
+
+    expect(signInUri).toEqual(
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&first_screen=register'
+    );
+  });
+
+  test('with directSignIn', () => {
+    const signInUri = generateSignInUri({
+      authorizationEndpoint,
+      clientId,
+      redirectUri,
+      codeChallenge,
+      state,
+      directSignIn: {
+        method: 'email',
+        target: 'foo@bar.com',
+      },
+    });
+
+    expect(signInUri).toEqual(
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&direct_sign_in=email%3Afoo%40bar.com'
+    );
+  });
 });

--- a/packages/js/src/types/index.ts
+++ b/packages/js/src/types/index.ts
@@ -16,5 +16,13 @@ export type Requester = <T>(...args: Parameters<typeof fetch>) => Promise<T>;
  *
  * - `signIn`: The authorization request will be initiated with a sign-in page.
  * - `signUp`: The authorization request will be initiated with a sign-up page.
+ *
+ * @deprecated Use {@link FirstScreen} instead.
  */
 export type InteractionMode = 'signIn' | 'signUp';
+
+/**
+ * The first screen to be shown in the sign-in experience. Note it's not a part of the OIDC
+ * standard, but a Logto-specific extension.
+ */
+export type FirstScreen = 'signIn' | 'register';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- support `firstScreen`, `directSignIn`, and `extraParams` for sign-in
- deprecate `interactionMode`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added test cases

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
