### PR TITLE
refactor: fix types

### DIFF
--- a/.changeset/blue-dolls-turn.md
+++ b/.changeset/blue-dolls-turn.md
@@ -1,0 +1,5 @@
+---
+"@logto/js": patch
+---
+
+remove unsupported direct sign-in methods

--- a/.changeset/chilly-pets-walk.md
+++ b/.changeset/chilly-pets-walk.md
@@ -1,0 +1,7 @@
+---
+"@logto/react": patch
+---
+
+fix `signIn()` type
+
+Now it can correctly infer the overload signatures.

--- a/.changeset/clean-games-lie.md
+++ b/.changeset/clean-games-lie.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+add `signIn(redirectUri: string)` as a normal signature

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -222,6 +222,19 @@ export class StandardLogtoClient {
    */
   async signIn(options: SignInOptions): Promise<void>;
   /**
+   * Start the sign-in flow with the specified options.
+   *
+   * The redirect URI is required and it must be registered in the Logto Console.
+   *
+   * The user will be redirected to that URI after the sign-in flow is completed,
+   * and the client will be able to get the authorization code from the URI.
+   * To fetch the tokens from the authorization code, use {@link handleSignInCallback}
+   * after the user is redirected in the callback URI.
+   *
+   * @param redirectUri See {@link SignInOptions.redirectUri}.
+   */
+  async signIn(redirectUri: SignInOptions['redirectUri']): Promise<void>;
+  /**
    *
    * Start the sign-in flow with the specified redirect URI. The URI must be
    * registered in the Logto Console.
@@ -239,6 +252,7 @@ export class StandardLogtoClient {
   async signIn(
     redirectUri: SignInOptions['redirectUri'],
     interactionMode?: SignInOptions['interactionMode'],
+    // eslint-disable-next-line @typescript-eslint/unified-signatures -- We will deprecate this signature soon.
     loginHint?: SignInOptions['loginHint']
   ): Promise<void>;
   async signIn(

--- a/packages/js/src/core/sign-in.test.ts
+++ b/packages/js/src/core/sign-in.test.ts
@@ -106,13 +106,13 @@ describe('generateSignInUri', () => {
       codeChallenge,
       state,
       directSignIn: {
-        method: 'email',
-        target: 'foo@bar.com',
+        method: 'social',
+        target: 'google',
       },
     });
 
     expect(signInUri).toEqual(
-      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&direct_sign_in=email%3Afoo%40bar.com'
+      'https://logto.dev/oidc/sign-in?client_id=clientId&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=codeChallenge&code_challenge_method=S256&state=state&response_type=code&prompt=consent&scope=openid+offline_access+profile&direct_sign_in=social%3Agoogle'
     );
   });
 });

--- a/packages/js/src/core/sign-in.ts
+++ b/packages/js/src/core/sign-in.ts
@@ -10,13 +10,11 @@ export type DirectSignInOptions = {
   /**
    * The method to be used for the direct sign-in.
    */
-  method: 'social' | 'email' | 'sms';
+  method: 'social';
   /**
    * The target to be used for the direct sign-in.
    *
    * - For `method: 'social'`, it should be the social connector target.
-   * - For `method: 'email'`, it should be the email address.
-   * - For `method: 'sms'`, it should be the phone number.
    */
   target: string;
 };

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -260,4 +260,22 @@ describe('useLogto', () => {
       expect(result.current.isLoading).toBe(true);
     });
   });
+
+  it('should be able to call the inner LogtoClient method overload signature', async () => {
+    const { result } = renderHook(useLogto, {
+      wrapper: createHookWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.signIn({ redirectUri: 'foo' });
+    });
+
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalledTimes(1);
+      expect(signIn).toHaveBeenCalledWith({ redirectUri: 'foo' });
+      expect(result.current.error).toBeUndefined();
+      // `signIn` disables resetting loading state
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
 });

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -24,11 +24,12 @@ type Logto = {
     | 'getOrganizationTokenClaims'
     | 'getIdToken'
     | 'getIdTokenClaims'
-    | 'signIn'
     | 'signOut'
     | 'fetchUserInfo'
   >
->;
+> &
+  // Manually pick the method with overloads since TypeScript cannot infer the correct type.
+  Pick<LogtoClient, 'signIn'>;
 
 const useErrorHandler = () => {
   const { setError } = useContext(LogtoContext);
@@ -133,7 +134,8 @@ const useLogto = (): Logto => {
       getOrganizationTokenClaims: proxy(client.getOrganizationTokenClaims.bind(client)),
       getIdToken: proxy(client.getIdToken.bind(client)),
       getIdTokenClaims: proxy(client.getIdTokenClaims.bind(client)),
-      signIn: proxy(client.signIn.bind(client), false),
+      // eslint-disable-next-line no-restricted-syntax -- TypeScript cannot infer the correct type.
+      signIn: proxy(client.signIn.bind(client), false) as LogtoClient['signIn'],
       // We deliberately do NOT set isAuthenticated to false in the function below, because the app state
       // may change immediately even before navigating to the oidc end session endpoint, which might cause
       // rendering problems.


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- overload signature cannot be picked up in react, this pull request fixes it.
- remove unsupported direct sign-in methods

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- added unit test
- correctly infer the type

<img width="507" alt="image" src="https://github.com/logto-io/js/assets/14722250/9cc647fa-ca23-4729-a80a-8159c53a19f3">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
