### PR TITLE
feat(client): support specifying prompt on sign-in

### DIFF
--- a/.changeset/curvy-ghosts-talk.md
+++ b/.changeset/curvy-ghosts-talk.md
@@ -1,0 +1,7 @@
+---
+"@logto/client": patch
+---
+
+add prompt parameter to sign in function.
+
+This change adds a prompt parameter to the signIn function in the @logto/client package. This parameter allows you to specify the prompt parameter in the `signIn()` method, with which the developer can override the prompt value pre-defined in the Logto configs.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -47,6 +47,11 @@ export type SignInOptions = {
    * sign-in callback. If not specified, the user will stay on the `redirectUri` page.
    */
   postRedirectUri?: string | URL;
+  /**
+   * The prompt parameter to be used for the authorization request.
+   * Note: If specified, it will override the prompt value in Logto configs.
+   */
+  prompt?: SignInUriParameters['prompt'];
 } & Pick<
   SignInUriParameters,
   'interactionMode' | 'firstScreen' | 'loginHint' | 'directSignIn' | 'extraParams'
@@ -268,6 +273,7 @@ export class StandardLogtoClient {
       loginHint,
       directSignIn,
       extraParams,
+      prompt,
     } = typeof options === 'string' || options instanceof URL
       ? {
           redirectUri: options,
@@ -277,11 +283,12 @@ export class StandardLogtoClient {
           loginHint: hint,
           directSignIn: undefined,
           extraParams: undefined,
+          prompt: undefined,
         }
       : options;
     const redirectUri = redirectUriUrl.toString();
     const postRedirectUri = postRedirectUriUrl?.toString();
-    const { appId: clientId, prompt, resources, scopes } = this.logtoConfig;
+    const { appId: clientId, prompt: promptViaConfig, resources, scopes } = this.logtoConfig;
     const { authorizationEndpoint } = await this.getOidcConfig();
     const [codeVerifier, state] = await Promise.all([
       this.adapter.generateCodeVerifier(),
@@ -297,7 +304,7 @@ export class StandardLogtoClient {
       state,
       scopes,
       resources,
-      prompt,
+      prompt: prompt ?? promptViaConfig,
       firstScreen,
       interactionMode,
       loginHint,

--- a/packages/client/src/index.sign-in.test.ts
+++ b/packages/client/src/index.sign-in.test.ts
@@ -139,6 +139,15 @@ describe('LogtoClient', () => {
         for: 'sign-in',
       });
     });
+
+    it('should take the prompt from the function argument over config', async () => {
+      const logtoClient = createClient(Prompt.Consent);
+      await logtoClient.signIn({ redirectUri, prompt: Prompt.Login });
+      expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithLoginPrompt, {
+        redirectUri,
+        for: 'sign-in',
+      });
+    });
   });
 
   describe('isSignInRedirected', () => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support dynamically specifying `Prompt` on `signIn()` function. And the SDK should take the prompt from sign in function over the one pre-configured in logto configs.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
