### PR TITLE
feat(node): add access token organization id param to getContext

### DIFF
--- a/.changeset/spotty-readers-rule.md
+++ b/.changeset/spotty-readers-rule.md
@@ -1,0 +1,7 @@
+---
+"@logto/node": minor
+---
+
+Add `organizationId` to `getContext` function.
+
+This will allow the users to get access token with "organization_id" claim, which supports organization API resources.

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -31,6 +31,7 @@ export default class LogtoNodeBaseClient extends BaseClient {
     resource,
     fetchUserInfo,
     getOrganizationToken,
+    organizationId,
   }: GetContextParameters = {}): Promise<LogtoContext> => {
     const isAuthenticated = await this.isAuthenticated();
 
@@ -44,7 +45,7 @@ export default class LogtoNodeBaseClient extends BaseClient {
 
     const { accessToken, accessTokenClaims } = getAccessToken
       ? {
-          accessToken: await trySafe(async () => this.getAccessToken(resource)),
+          accessToken: await trySafe(async () => this.getAccessToken(resource, organizationId)),
           accessTokenClaims: await trySafe(async () => this.getAccessTokenClaims(resource)),
         }
       : { accessToken: undefined, accessTokenClaims: undefined };

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -50,7 +50,21 @@ describe('LogtoClient', () => {
       ).resolves.toEqual({
         isAuthenticated: false,
       });
-      expect(getAccessToken).toHaveBeenCalledWith('resource');
+      expect(getAccessToken).toHaveBeenCalledWith('resource', undefined);
+    });
+
+    it('should get access token with organization id', async () => {
+      const client = new LogtoClient({ endpoint, appId }, { navigate, storage });
+      await expect(
+        client.getContext({
+          getAccessToken: true,
+          resource: 'resource',
+          organizationId: 'org1',
+        })
+      ).resolves.toMatchObject({
+        isAuthenticated: true,
+      });
+      expect(getAccessToken).toHaveBeenCalledWith('resource', 'org1');
     });
 
     it('should get organization tokens', async () => {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -20,6 +20,8 @@ export type LogtoContext = {
 export type GetContextParameters = {
   fetchUserInfo?: boolean;
   getAccessToken?: boolean;
+  /** The optional `organization_id` param for granting access token. */
+  organizationId?: string;
   resource?: string;
   getOrganizationToken?: boolean;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add `accessTokenOrgnizationId` param to `getContext`, allowing users to set `orgniazation_id` when granting access token.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
