### PR TITLE
feat(client,node): add organizationId param to getAccessTokenClaims

### DIFF
--- a/.changeset/fresh-impalas-glow.md
+++ b/.changeset/fresh-impalas-glow.md
@@ -1,0 +1,8 @@
+---
+"@logto/client": minor
+"@logto/node": minor
+---
+
+Add organizationId param to getAccessTokenClaims function.
+
+You can now pass an organizationId to the getAccessTokenClaims function, and this will be passed down to the getAccessToken function. This allows you to get the access token claims with scopes inherited from the specific organization.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -184,9 +184,14 @@ export class StandardLogtoClient {
    * @param resource The resource that the access token is granted for. If not
    * specified, the access token will be used for OpenID Connect or the default
    * resource, as specified in the Logto Console.
+   * @param organizationId The ID of the organization, if specified, will narrow
+   * down the scopes inherited from organizations to only that organization.
    */
-  async getAccessTokenClaims(resource?: string): Promise<AccessTokenClaims> {
-    const accessToken = await this.getAccessToken(resource);
+  async getAccessTokenClaims(
+    resource?: string,
+    organizationId?: string
+  ): Promise<AccessTokenClaims> {
+    const accessToken = await this.getAccessToken(resource, organizationId);
 
     return decodeAccessToken(accessToken);
   }

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -48,7 +48,9 @@ export default class LogtoNodeBaseClient extends BaseClient {
           accessToken: await trySafe(async () =>
             this.getAccessToken(resource, accessTokenOrganizationId)
           ),
-          accessTokenClaims: await trySafe(async () => this.getAccessTokenClaims(resource)),
+          accessTokenClaims: await trySafe(async () =>
+            this.getAccessTokenClaims(resource, accessTokenOrganizationId)
+          ),
         }
       : { accessToken: undefined, accessTokenClaims: undefined };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add organizationId param to getAccessTokenClaims function.

Users can now pass an organizationId to the getAccessTokenClaims function, and this will be passed down to the getAccessToken function. This allows you to get the access token claims with scopes inherited from the specific organization.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
