### PR TITLE
fix(client): fix memoize cache key

### DIFF
--- a/.changeset/angry-beans-run.md
+++ b/.changeset/angry-beans-run.md
@@ -1,0 +1,7 @@
+---
+"@logto/client": patch
+---
+
+Fix the bug of granting mutiple organization tokens concurrently.
+
+This is a bug fix for the issue that the client is not able to grant multiple organization tokens concurrently. The issue is caused by the memoize function that caches the organization token request, which leads to the token request being memoized by incorrect key and not being able to be granted concurrently. This fix updates the memoize function to cache by the correct key.

--- a/packages/client/src/utils/memoize.ts
+++ b/packages/client/src/utils/memoize.ts
@@ -2,7 +2,7 @@ export function memoize<Args extends unknown[], Return>(run: (...args: Args) => 
   const promiseCache = new Map<unknown, Promise<Return>>();
 
   const memoized = async function (this: unknown, ...args: Args): Promise<Return> {
-    const promiseKey = args[0];
+    const promiseKey = JSON.stringify(args);
     const cachedPromise = promiseCache.get(promiseKey);
 
     if (cachedPromise) {


### PR DESCRIPTION
fixed #771

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix the bug of granting mutiple organization tokens concurrently.

The function `getAccessToken` is memoized by arguments, but the `memorize` function will only take the first argument as the cache key, change to take all arguments.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
