### PR TITLE
fix(svelte): add svelte export key in package.json

### DIFF
--- a/.changeset/shiny-camels-sin.md
+++ b/.changeset/shiny-camels-sin.md
@@ -1,0 +1,7 @@
+---
+"@logto/sveltekit": patch
+---
+
+add `svelte` export tag in package.json
+
+This will provide a hint for `vite-plugin-svelte` to handle `Svelte` libraries in SSR properly.

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -9,7 +9,8 @@
     "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js",
-    "default": "./lib/index.js"
+    "default": "./lib/index.js",
+    "svelte": "./lib/index.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add svelte export key in package.json.

This will address `svelte/kit`  redirect  not working bug.  [ref](https://github.com/sveltejs/vite-plugin-svelte/issues/293)



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
