### PR TITLE
feat: add support for sign up flow in Remix

### DIFF
--- a/.changeset/mighty-feet-look.md
+++ b/.changeset/mighty-feet-look.md
@@ -1,0 +1,5 @@
+---
+"@logto/remix": minor
+---
+
+add sign up flow support

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -84,6 +84,10 @@ export const loader = logto.handleAuthRoutes({
     path: "/api/logto/sign-out",
     redirectBackTo: "/",
   },
+  "sign-up": {
+    path: "/api/logto/sign-up",
+    redirectBackTo: "/api/logto/callback",
+  },
 });
 ```
 

--- a/packages/remix/src/framework/mocks.ts
+++ b/packages/remix/src/framework/mocks.ts
@@ -36,11 +36,17 @@ export const handleSignOut = vi.fn(async () => ({
   navigateToUrl: '/success-handle-sign-out',
 }));
 
+export const handleSignUp = vi.fn(async () => ({
+  session,
+  navigateToUrl: '/success-handle-sign-up',
+}));
+
 export const createLogtoAdapter: CreateLogtoAdapter = vi.fn((session: Session) => {
   return {
     handleSignIn,
     handleSignInCallback,
     handleSignOut,
+    handleSignUp,
     getContext,
   };
 });

--- a/packages/remix/src/infrastructure/logto/handle-sign-up.ts
+++ b/packages/remix/src/infrastructure/logto/handle-sign-up.ts
@@ -1,0 +1,55 @@
+import type { Session } from '@remix-run/node';
+
+import type { CreateLogtoClient } from './create-client.js';
+import type { LogtoStorage } from './create-storage.js';
+
+type HandleSignUpRequest = {
+  readonly redirectUri: string;
+};
+
+type HandleSignUpResponse = {
+  readonly session: Session;
+  readonly navigateToUrl: string;
+};
+
+class HandleSignUpCommand {
+  public static readonly fromDependencies = (dependencies: { createClient: CreateLogtoClient }) =>
+    new HandleSignUpCommand({ createClient: dependencies.createClient });
+
+  private navigateToUrl = '/api/sign-up';
+
+  private constructor(
+    private readonly properties: {
+      readonly createClient: CreateLogtoClient;
+    }
+  ) {}
+
+  public async execute(request: HandleSignUpRequest) {
+    const { createClient } = this.properties;
+
+    const client = createClient((url) => {
+      this.navigateToUrl = url;
+    });
+
+    await client.signIn({ redirectUri: request.redirectUri, interactionMode: 'signUp' });
+
+    return {
+      navigateToUrl: this.navigateToUrl,
+    };
+  }
+}
+
+export const makeHandleSignUp =
+  (deps: { storage: LogtoStorage; createClient: CreateLogtoClient }) =>
+  async (request: HandleSignUpRequest): Promise<HandleSignUpResponse> => {
+    const { storage, createClient } = deps;
+
+    const command = HandleSignUpCommand.fromDependencies({ createClient });
+
+    const { navigateToUrl } = await command.execute(request);
+
+    return {
+      session: storage.session,
+      navigateToUrl,
+    };
+  };

--- a/packages/remix/src/infrastructure/logto/index.ts
+++ b/packages/remix/src/infrastructure/logto/index.ts
@@ -7,6 +7,7 @@ import { makeGetContext } from './get-context.js';
 import { makeHandleSignInCallback } from './handle-sign-in-callback.js';
 import { makeHandleSignIn } from './handle-sign-in.js';
 import { makeHandleSignOut } from './handle-sign-out.js';
+import { makeHandleSignUp } from './handle-sign-up.js';
 
 type MakeLogtoAdapterConfiguration = LogtoConfig;
 
@@ -18,6 +19,7 @@ export const makeLogtoAdapter = (config: MakeLogtoAdapterConfiguration) => (sess
     handleSignIn: makeHandleSignIn({ storage, createClient }),
     handleSignInCallback: makeHandleSignInCallback({ storage, createClient }),
     handleSignOut: makeHandleSignOut({ createClient }),
+    handleSignUp: makeHandleSignUp({ storage, createClient }),
     getContext: makeGetContext({ storage, createClient }),
   };
 };

--- a/packages/remix/src/useCases/handleAuthRoutes/index.ts
+++ b/packages/remix/src/useCases/handleAuthRoutes/index.ts
@@ -4,6 +4,7 @@ import type { CreateLogtoAdapter } from '../../infrastructure/logto/index.js';
 import { makeHandleSignIn } from '../handleSignIn/index.js';
 import { makeHandleSignInCallback } from '../handleSignInCallback/index.js';
 import { makeHandleSignOut } from '../handleSignOut/index.js';
+import { makeHandleSignUp } from '../handleSignUp/index.js';
 
 import { HandleAuthRoutesError } from './HandleAuthRoutesError.js';
 
@@ -12,7 +13,7 @@ type AuthRouteConfig = {
   readonly redirectBackTo: string;
 };
 
-type PossibleRouteTypes = 'sign-in' | 'sign-in-callback' | 'sign-out';
+type PossibleRouteTypes = 'sign-in' | 'sign-in-callback' | 'sign-out' | 'sign-up';
 
 type HandleAuthRoutesDto = Record<PossibleRouteTypes, AuthRouteConfig>;
 
@@ -58,6 +59,17 @@ export const makeHandleAuthRoutes =
 
       case 'sign-in-callback': {
         const handler = makeHandleSignInCallback(
+          {
+            redirectBackTo: `${baseUrl}${config.redirectBackTo}`,
+          },
+          { sessionStorage, createLogtoAdapter }
+        );
+
+        return handler(request);
+      }
+
+      case 'sign-up': {
+        const handler = makeHandleSignUp(
           {
             redirectBackTo: `${baseUrl}${config.redirectBackTo}`,
           },

--- a/packages/remix/src/useCases/handleSignUp/HandleSignUpController.spec.ts
+++ b/packages/remix/src/useCases/handleSignUp/HandleSignUpController.spec.ts
@@ -1,0 +1,20 @@
+import { createLogtoAdapter, sessionStorage } from '../../framework/mocks.js';
+
+import { HandleSignUpController } from './HandleSignUpController.js';
+import { makeHandleSignUpUseCase } from './HandleSignUpUseCase.js';
+
+describe('useCases:handleSignUp:HandleSignUpController', () => {
+  it('can be created', () => {
+    const useCase = makeHandleSignUpUseCase({
+      createLogtoAdapter,
+      sessionStorage,
+    });
+
+    const controller = HandleSignUpController.fromDto({
+      useCase,
+      redirectUri: '/',
+    });
+
+    expect(controller.constructor.name).toBe('HandleSignUpController');
+  });
+});

--- a/packages/remix/src/useCases/handleSignUp/HandleSignUpController.ts
+++ b/packages/remix/src/useCases/handleSignUp/HandleSignUpController.ts
@@ -1,0 +1,44 @@
+import type { TypedResponse } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+
+import { getCookieHeaderFromRequest } from '../../framework/get-cookie-header-from-request.js';
+
+import type { HandleSignUpUseCase } from './HandleSignUpUseCase.js';
+
+type HandleSignUpControllerDto = {
+  readonly redirectUri: string;
+  readonly useCase: HandleSignUpUseCase;
+};
+
+export class HandleSignUpController {
+  public static readonly fromDto = (dto: HandleSignUpControllerDto) =>
+    new HandleSignUpController({
+      useCase: dto.useCase,
+      redirectUri: dto.redirectUri,
+    });
+
+  private readonly useCase = this.properties.useCase;
+  private readonly redirectUri = this.properties.redirectUri;
+  private constructor(
+    private readonly properties: {
+      redirectUri: string;
+      useCase: HandleSignUpUseCase;
+    }
+  ) {}
+
+  public readonly execute = async (request: Request): Promise<TypedResponse<never>> => {
+    const cookieHeader = getCookieHeaderFromRequest(request);
+    const { redirectUri } = this;
+
+    const result = await this.useCase({
+      cookieHeader: cookieHeader ?? undefined,
+      redirectUri,
+    });
+
+    return redirect(result.navigateToUrl, {
+      headers: {
+        'Set-Cookie': result.cookieHeader,
+      },
+    });
+  };
+}

--- a/packages/remix/src/useCases/handleSignUp/HandleSignUpUseCase.spec.ts
+++ b/packages/remix/src/useCases/handleSignUp/HandleSignUpUseCase.spec.ts
@@ -1,0 +1,23 @@
+import { createLogtoAdapter, sessionStorage, handleSignUp } from '../../framework/mocks.js';
+
+import { makeHandleSignUpUseCase } from './HandleSignUpUseCase.js';
+
+describe('useCases:handleSignUp:HandleSignUpUseCase', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('can make a use case executer', async () => {
+    const execute = makeHandleSignUpUseCase({
+      createLogtoAdapter,
+      sessionStorage,
+    });
+
+    await execute({
+      cookieHeader: 'abcd',
+      redirectUri: '/',
+    });
+
+    expect(handleSignUp).toBeCalledTimes(1);
+  });
+});

--- a/packages/remix/src/useCases/handleSignUp/HandleSignUpUseCase.ts
+++ b/packages/remix/src/useCases/handleSignUp/HandleSignUpUseCase.ts
@@ -1,0 +1,36 @@
+import type { SessionStorage } from '@remix-run/node';
+
+import type { CreateLogtoAdapter } from '../../infrastructure/logto/index.js';
+
+type SignUpRequest = {
+  readonly cookieHeader: string | undefined;
+  readonly redirectUri: string;
+};
+
+type SignUpResponse = {
+  readonly cookieHeader: string;
+  readonly navigateToUrl: string;
+};
+
+export const makeHandleSignUpUseCase =
+  (deps: { createLogtoAdapter: CreateLogtoAdapter; sessionStorage: SessionStorage }) =>
+  async (request: SignUpRequest): Promise<SignUpResponse> => {
+    const { sessionStorage, createLogtoAdapter } = deps;
+
+    const session = await sessionStorage.getSession(request.cookieHeader);
+
+    const logto = createLogtoAdapter(session);
+
+    const response = await logto.handleSignUp({
+      redirectUri: request.redirectUri,
+    });
+
+    const cookieHeader = await sessionStorage.commitSession(response.session);
+
+    return {
+      cookieHeader,
+      navigateToUrl: response.navigateToUrl,
+    };
+  };
+
+export type HandleSignUpUseCase = ReturnType<typeof makeHandleSignUpUseCase>;

--- a/packages/remix/src/useCases/handleSignUp/index.ts
+++ b/packages/remix/src/useCases/handleSignUp/index.ts
@@ -1,0 +1,32 @@
+import type { SessionStorage } from '@remix-run/node';
+
+import type { CreateLogtoAdapter } from '../../infrastructure/logto/index.js';
+
+import { HandleSignUpController } from './HandleSignUpController.js';
+import { makeHandleSignUpUseCase } from './HandleSignUpUseCase.js';
+
+type HandleSignUpDto = {
+  readonly redirectBackTo: string;
+};
+
+type HandleSignUpDeps = {
+  readonly createLogtoAdapter: CreateLogtoAdapter;
+  readonly sessionStorage: SessionStorage;
+};
+
+export const makeHandleSignUp =
+  (dto: HandleSignUpDto, deps: HandleSignUpDeps) => async (request: Request) => {
+    const { createLogtoAdapter, sessionStorage } = deps;
+
+    const useCase = makeHandleSignUpUseCase({
+      createLogtoAdapter,
+      sessionStorage,
+    });
+
+    const controller = HandleSignUpController.fromDto({
+      useCase,
+      redirectUri: dto.redirectBackTo,
+    });
+
+    return controller.execute(request);
+  };


### PR DESCRIPTION
## Summary
Add a sign up flow for Remix: https://github.com/logto-io/js/issues/722


<!-- MANDATORY -->
## Testing
I published an NPM package and using it in production: https://www.npmjs.com/package/@samos123/logto-remix

You can try it with:
```
npm install @samos123/logto-remix@2.1.10-sam1
```

Then use the following for auth routes:
```
import { logto } from "~/services/authentication";

export const loader = logto.handleAuthRoutes({
  "sign-in": {
    path: "/api/logto/sign-in",
    redirectBackTo: "/api/logto/callback", // The redirect URI just entered
  },
  "sign-in-callback": {
    path: "/api/logto/callback",
    redirectBackTo: "/",
  },
  "sign-out": {
    path: "/api/logto/sign-out",
    redirectBackTo: "/",
  },
  "sign-up": {
    path: "/api/logto/sign-up",
    redirectBackTo: "/api/logto/callback", // The redirect URI just entered
  },
});
```


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments