### PR TITLE
feat(sveltekit): add support for custom storage and getUserInfo error handling

### DIFF
--- a/.changeset/afraid-tables-explain.md
+++ b/.changeset/afraid-tables-explain.md
@@ -1,0 +1,9 @@
+---
+"@logto/sveltekit": minor
+---
+
+introduce custom local storage support and error handling for getUserInfo
+
+1. 1. Introduce a new `storage` option in `hookConfig` that allows a custom local storage to be passed into `logtoClient`. This will supersede the default `CookieStorage` for storing session and token data. If a custom `storage` is provided, the `cookieConfig` settings can be disregarded.
+
+2. Incorporate a new `onGetUserInfoError` callback in `hookConfig` for custom error handling when `getUserInfo` or `getIdTokenClaims` operations fail. By default, a 500 server error will be thrown.

--- a/.changeset/afraid-tables-explain.md
+++ b/.changeset/afraid-tables-explain.md
@@ -4,6 +4,6 @@
 
 introduce custom local storage support and error handling for getUserInfo
 
-1. 1. Introduce a new `storage` option in `hookConfig` that allows a custom local storage to be passed into `logtoClient`. This will supersede the default `CookieStorage` for storing session and token data. If a custom `storage` is provided, the `cookieConfig` settings can be disregarded.
+1. Introduce a new `storage` option in `hookConfig` that allows a custom local storage to be passed into `logtoClient`. This will supersede the default `CookieStorage` for storing session and token data. If a custom `storage` is provided, the `cookieConfig` settings can be disregarded.
 
 2. Incorporate a new `onGetUserInfoError` callback in `hookConfig` for custom error handling when `getUserInfo` or `getIdTokenClaims` operations fail. By default, a 500 server error will be thrown.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
introduce custom local storage support and error handling for getUserInfo

1. Introduce a new `storage` option in `hookConfig` that allows a custom local storage to be passed into `logtoClient`. This will supersede the default `CookieStorage` for storing session and token data. If a custom `storage` is provided, the `cookieConfig` settings can be disregarded.

2. Add a new `onGetUserInfoError` callback in `hookConfig` for custom error handling when `getUserInfo` or `getIdTokenClaims` operations fail. By default, a 500 server error will be thrown.



This PR will address the following feedbacks from the Logto community:
- Large cookie exception if a large number of tokens are cached. 
- Unable to catch the error thrown by the `getUserInfo` flow in the `handleLogto` method. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test lcoally


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
