### PR TITLE
fix: add missing sign out page route for next.js app dir sample

### DIFF
--- a/packages/next-app-dir-sample/app/api/logto/sign-out/route.ts
+++ b/packages/next-app-dir-sample/app/api/logto/sign-out/route.ts
@@ -1,0 +1,9 @@
+import { type NextRequest } from 'next/server';
+
+import { logtoClient } from '../../../../libraries/logto-edge';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  return logtoClient.handleSignOut()(request);
+}


### PR DESCRIPTION
The `/api/logto/sign-out` route is missing, this commit fix it, otherwise it will lead to a 404 not found.

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

The next.js app dir sample project is missing `/api/logto/sign-out` page route, and when user clicks sign-out button, it will lead to a 404 not found page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Demo before fix:
https://github.com/logto-io/js/assets/1164623/a4358f5f-5ce7-4fef-8d82-87cef49917eb

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] ~`.changeset`~
- [x] ~unit tests~
- [x] ~integration tests~
- [x] ~necessary TSDoc comments~
