### PR TITLE
feat(client): support clock tolerance config

### DIFF
--- a/.changeset/thin-walls-play.md
+++ b/.changeset/thin-walls-play.md
@@ -1,0 +1,16 @@
+---
+"@logto/client": minor
+---
+
+- support clock tolerance config in `DefaultJwtVerifier`
+- allow set `jwtVerifier` after `LogtoClient` instance created
+
+```ts
+const client = new LogtoClient(
+  config,
+  adapters,
+  (client) => new DefaultJwtVerifier(client, { clockTolerance: 10 })
+);
+
+client.setJwtVerifier(new DefaultJwtVerifier(client, { clockTolerance: 20 }));
+```

--- a/packages/client/src/adapter/defaults.ts
+++ b/packages/client/src/adapter/defaults.ts
@@ -6,17 +6,18 @@ import { type StandardLogtoClient } from '../client.js';
 
 import { type JwtVerifier } from './types.js';
 
-const issuedAtTimeTolerance = 300; // 5 minutes
+export const defaultClockTolerance = 300; // 5 minutes
 
 export const verifyIdToken = async (
   idToken: string,
   clientId: string,
   issuer: string,
-  jwks: JWTVerifyGetKey
+  jwks: JWTVerifyGetKey,
+  clockTolerance = defaultClockTolerance
 ) => {
-  const result = await jwtVerify(idToken, jwks, { audience: clientId, issuer });
+  const result = await jwtVerify(idToken, jwks, { audience: clientId, issuer, clockTolerance });
 
-  if (Math.abs((result.payload.iat ?? 0) - Date.now() / 1000) > issuedAtTimeTolerance) {
+  if (Math.abs((result.payload.iat ?? 0) - Date.now() / 1000) > clockTolerance) {
     throw new LogtoError('id_token.invalid_iat');
   }
 };
@@ -24,7 +25,10 @@ export const verifyIdToken = async (
 export class DefaultJwtVerifier implements JwtVerifier {
   protected getJwtVerifyGetKey?: JWTVerifyGetKey;
 
-  constructor(protected client: StandardLogtoClient) {}
+  constructor(
+    protected client: StandardLogtoClient,
+    public readonly clockTolerance = defaultClockTolerance
+  ) {}
 
   async verifyIdToken(idToken: string): Promise<void> {
     const { appId } = this.client.logtoConfig;
@@ -32,6 +36,6 @@ export class DefaultJwtVerifier implements JwtVerifier {
 
     this.getJwtVerifyGetKey ||= createRemoteJWKSet(new URL(jwksUri));
 
-    await verifyIdToken(idToken, appId, issuer, this.getJwtVerifyGetKey);
+    await verifyIdToken(idToken, appId, issuer, this.getJwtVerifyGetKey, this.clockTolerance);
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -127,9 +127,13 @@ export class StandardLogtoClient {
    */
   readonly handleSignInCallback = memoize(this.#handleSignInCallback);
   readonly adapter: ClientAdapterInstance;
-  readonly jwtVerifier: JwtVerifier;
 
+  protected jwtVerifierInstance: JwtVerifier;
   protected readonly accessTokenMap = new Map<string, AccessToken>();
+
+  get jwtVerifier() {
+    return this.jwtVerifierInstance;
+  }
 
   constructor(
     logtoConfig: LogtoConfig,
@@ -138,9 +142,18 @@ export class StandardLogtoClient {
   ) {
     this.logtoConfig = normalizeLogtoConfig(logtoConfig);
     this.adapter = new ClientAdapterInstance(adapter);
-    this.jwtVerifier = buildJwtVerifier(this);
+    this.jwtVerifierInstance = buildJwtVerifier(this);
 
     void this.loadAccessTokenMap();
+  }
+
+  /**
+   * Set the JWT verifier for the client.
+   * @param buildJwtVerifier The JWT verifier instance or a function that returns the JWT verifier instance.
+   */
+  setJwtVerifier(buildJwtVerifier: JwtVerifier | ((client: StandardLogtoClient) => JwtVerifier)) {
+    this.jwtVerifierInstance =
+      typeof buildJwtVerifier === 'function' ? buildJwtVerifier(this) : buildJwtVerifier;
   }
 
   /**

--- a/packages/client/src/index.constructor.test.ts
+++ b/packages/client/src/index.constructor.test.ts
@@ -1,5 +1,6 @@
 import { Prompt } from '@logto/js';
 
+import { DefaultJwtVerifier, defaultClockTolerance } from './adapter/defaults.js';
 import { appId, endpoint, LogtoClientWithAccessors, createClient, createAdapters } from './mock.js';
 
 describe('LogtoClient', () => {
@@ -32,6 +33,29 @@ describe('LogtoClient', () => {
         createAdapters()
       );
       expect(logtoClient.getLogtoConfig()).toHaveProperty('prompt', 'login');
+    });
+
+    it('should be able to configure the JWT verifier', () => {
+      const logtoClient = new LogtoClientWithAccessors(
+        { endpoint, appId },
+        createAdapters(),
+        (client) => new DefaultJwtVerifier(client, defaultClockTolerance + 1)
+      );
+      expect(logtoClient.jwtVerifier).toHaveProperty('clockTolerance', defaultClockTolerance + 1);
+    });
+  });
+
+  describe('jwtVerifier', () => {
+    it('should be able to update the JWT verifier', () => {
+      const logtoClient = createClient();
+      logtoClient.setJwtVerifier(
+        (client) => new DefaultJwtVerifier(client, defaultClockTolerance + 1)
+      );
+      expect(logtoClient.jwtVerifier).toHaveProperty('clockTolerance', defaultClockTolerance + 1);
+
+      const jwtVerifier = new DefaultJwtVerifier(logtoClient, defaultClockTolerance + 2);
+      logtoClient.setJwtVerifier(jwtVerifier);
+      expect(logtoClient.jwtVerifier).toBe(jwtVerifier);
     });
   });
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- support clock tolerance config in `DefaultJwtVerifier`
- allow set `jwtVerifier` after `LogtoClient` instance created

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
unit test added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
