### PR TITLE
feat(node): ignore fetch user info error in getContext

### DIFF
--- a/.changeset/dry-bulldogs-travel.md
+++ b/.changeset/dry-bulldogs-travel.md
@@ -1,0 +1,9 @@
+---
+"@logto/node": minor
+---
+
+return undefined when fetch user info failed in getContext
+
+When `fetchUserInfo` is set to `true`, `useContext()` will call `fetchUserInfo` to get user info. If `fetchUserInfo` failed, it now returns `undefined` in `context.userInfo` instead of throwing an error.
+
+You can check the value of `context.userInfo` to see if the user is authenticated.

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -75,7 +75,7 @@ export default class LogtoNodeBaseClient extends BaseClient {
     return {
       isAuthenticated,
       claims,
-      userInfo: conditional(fetchUserInfo && (await this.fetchUserInfo())),
+      userInfo: conditional(fetchUserInfo && (await trySafe(async () => this.fetchUserInfo()))),
       ...conditional(
         getAccessToken && { accessToken, scopes: accessTokenClaims?.scope?.split(' ') }
       ),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Wrap `getUserInfo` with `trySafe` in node SDK's `getContext` method. This method should not throw error if `getUserInfo` failed, it should return undefined for better development experience. If the developer want the handle the error manually, he can use `client.getUserInfo` instead.

This PR is similar to https://github.com/logto-io/js/pull/739

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested and exiting tests shoudl pass.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
