### PR TITLE
fix(nuxt): change default configuration error to warning

### DIFF
--- a/.changeset/chilly-spiders-deliver.md
+++ b/.changeset/chilly-spiders-deliver.md
@@ -1,0 +1,5 @@
+---
+"@logto/nuxt": patch
+---
+
+use warning to replace the error of empty configuration

--- a/packages/nuxt/src/runtime/server/event-handler.ts
+++ b/packages/nuxt/src/runtime/server/event-handler.ts
@@ -28,7 +28,7 @@ export default defineEventHandler(async (event) => {
     .map(([key]) => key);
 
   if (defaultValueKeys.length > 0) {
-    throw new TypeError(
+    console.warn(
       `The following Logto configuration keys have default values: ${defaultValueKeys.join(
         ', '
       )}. Please replace them with your own values.`


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Change the error of "empty configuration" to warning, because in some situations like static prerender, it makes sense to not setting any configurations. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
