### PR TITLE
feat(next): add getAccessToken function to server actions

### DIFF
--- a/.changeset/nine-actors-leave.md
+++ b/.changeset/nine-actors-leave.md
@@ -1,0 +1,14 @@
+---
+'@logto/next-server-actions-sample': minor
+'@logto/next': minor
+---
+
+add getAccessToken to the server actions package
+
+Previously, in order to get access tokens (and organization tokens) in App Router, you'll use `getLogtoContext` with config `{ getAccessToken: true }`, this won't cache the token and will make a network request every time you call it. That is because Next.js does not allow to write cookies in the server side: HTTP does not allow setting cookies after streaming starts, so you must use .set() in a Server Action or Route Handler.
+
+This change adds a new function `getAccessToken` for you to get the access token in a server action or a route handler. It will cache the token and only make a network request when the token is expired.
+
+And also, this change adds a new function `getOrganizationToken` for you to get the organization token.
+
+The original method is deprecated and will be removed in the future.

--- a/packages/next-server-actions-sample/app/get-access-token.tsx
+++ b/packages/next-server-actions-sample/app/get-access-token.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+type Props = {
+  onGetAccessToken: () => Promise<string>;
+};
+
+const GetAccessToken = ({ onGetAccessToken }: Props) => {
+  return (
+    <button
+      onClick={async () => {
+        const token = await onGetAccessToken();
+        console.log(token);
+      }}
+    >
+      Get access token (see console log)
+    </button>
+  );
+};
+
+export default GetAccessToken;

--- a/packages/next-server-actions-sample/app/logto.ts
+++ b/packages/next-server-actions-sample/app/logto.ts
@@ -9,5 +9,5 @@ export const logtoConfig = {
   cookieSecure: process.env.NODE_ENV === 'production',
   // Optional fields for RBAC
   resources: process.env.RESOURCES?.split(','),
-  scopes: process.env.SCOPES?.split(',') ?? [UserScope.Organizations],
+  scopes: process.env.SCOPES?.split(',') ?? [UserScope.Organizations, UserScope.OrganizationRoles],
 };

--- a/packages/next-server-actions-sample/app/page.tsx
+++ b/packages/next-server-actions-sample/app/page.tsx
@@ -1,28 +1,33 @@
-import { getLogtoContext, getOrganizationTokens, signIn, signOut } from '@logto/next/server-actions';
+import { getAccessToken, getLogtoContext, signIn, signOut } from '@logto/next/server-actions';
 import SignIn from './sign-in';
 import SignOut from './sign-out';
 import { logtoConfig } from './logto';
+import GetAccessToken from './get-access-token';
 
 export default async function Home() {
   const { isAuthenticated, claims } = await getLogtoContext(logtoConfig);
-  // If you need access token, pass the getAccessToken option.
-  // and you can pass the access token to other API server or pass down to a client component.
-  // const { isAuthenticated, claims, accessToken } = await getLogtoContext({ getAccessToken: true });
-  // console.log(accessToken);
-  const organizations = await getOrganizationTokens(logtoConfig);
 
   return (
     <main>
       <h1>Hello Logto.</h1>
       <div>
         {isAuthenticated ? (
-          <SignOut
-            onSignOut={async () => {
-              'use server';
+          <>
+            <SignOut
+              onSignOut={async () => {
+                'use server';
 
-              await signOut(logtoConfig);
-            }}
-          />
+                await signOut(logtoConfig);
+              }}
+            />{' '}
+            <GetAccessToken
+              onGetAccessToken={async () => {
+                'use server';
+
+                return getAccessToken(logtoConfig);
+              }}
+            />
+          </>
         ) : (
           <SignIn
             onSignIn={async () => {
@@ -54,16 +59,6 @@ export default async function Home() {
           </table>
         </div>
       )}
-      {organizations.length > 0 ? (
-        <div>
-          <h2>Organizations</h2>
-          <ul>
-            {organizations.map((organization) => (
-              <li key={organization.id}>{organization.id}</li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Previously, in order to get access tokens (and organization tokens) in App Router, you'll use `getLogtoContext` with config `{ getAccessToken: true }`, this won't cache the token and will make a network request every time you call it. That is because Next.js does not allow to write cookies in the server side: HTTP does not allow setting cookies after streaming starts, so you must use .set() in a Server Action or Route Handler.

This change adds a new function `getAccessToken` for you to get the access token in a server action or a route handler. It will cache the token and only make a network request when the token is expired.

And also, this change adds a new function `getOrganizationToken` for you to get the organization token.

The original method is deprecated and will be removed in the future.
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with the sample project.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
