### PR TITLE
fix: remove import from dev dependency

### DIFF
--- a/.changeset/perfect-rabbits-tap.md
+++ b/.changeset/perfect-rabbits-tap.md
@@ -2,4 +2,4 @@
 "@logto/js": patch
 ---
 
-remove import from dev dependency
+fix an incorrect `Nullable` import in js core

--- a/.changeset/perfect-rabbits-tap.md
+++ b/.changeset/perfect-rabbits-tap.md
@@ -1,0 +1,5 @@
+---
+"@logto/js": patch
+---
+
+remove import from dev dependency

--- a/packages/js/src/core/user-info.ts
+++ b/packages/js/src/core/user-info.ts
@@ -1,3 +1,5 @@
+import { type Nullable } from '@silverhand/essentials';
+
 import { type IdTokenClaims } from '../index.js';
 import type { Requester } from '../types/index.js';
 
@@ -9,7 +11,7 @@ type Identity = {
 type OrganizationData = {
   id: string;
   name: string;
-  description?: string;
+  description: Nullable<string>;
 };
 
 export type UserInfoResponse = IdTokenClaims & {

--- a/packages/js/src/core/user-info.ts
+++ b/packages/js/src/core/user-info.ts
@@ -1,5 +1,3 @@
-import { type Nullable } from 'vitest';
-
 import { type IdTokenClaims } from '../index.js';
 import type { Requester } from '../types/index.js';
 
@@ -11,7 +9,7 @@ type Identity = {
 type OrganizationData = {
   id: string;
   name: string;
-  description: Nullable<string>;
+  description?: string;
 };
 
 export type UserInfoResponse = IdTokenClaims & {


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
DevDependency not available in angular app
<!-- Provide detailed PR description below -->
DevDependency import from **vitest** introduced in PR https://github.com/logto-io/js/pull/760 

This causes build problems in angular app as test runner is still **jest** 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Executed all unit tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
