### PR TITLE
refactor(js): refactor @logto/client package exports

### DIFF
--- a/.changeset/poor-lizards-cheer.md
+++ b/.changeset/poor-lizards-cheer.md
@@ -1,0 +1,17 @@
+---
+"@logto/client": patch
+---
+
+add react-native package export condition
+
+[Enabling package export](https://reactnative.dev/blog/2023/06/21/package-exports-support#enabling-package-exports-beta) in react-native is unstable and can cause issues.
+
+Replace the `exports` in `@logto/client` package.json with the `react-native` [condition](https://reactnative.dev/blog/2023/06/21/package-exports-support#the-new-react-native-condition).
+
+```json
+{
+  "react-native": "./lib/shim.js"
+}
+```
+
+So the `shim.js` module can be used in react-native projects, without enabling the unstable package export feature.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,19 +5,12 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "react-native": "./lib/shim.js",
   "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.js",
-      "default": "./lib/index.js"
-    },
-    "./shim": {
-      "types": "./lib/shim.d.ts",
-      "require": "./lib/shim.cjs",
-      "import": "./lib/shim.js",
-      "default": "./lib/shim.js"
-    }
+    "types": "./lib/index.d.ts",
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.js",
+    "default": "./lib/index.js"
   },
   "files": [
     "lib"

--- a/packages/node/src/utils/cookie-storage.test.ts
+++ b/packages/node/src/utils/cookie-storage.test.ts
@@ -1,4 +1,4 @@
-import { PersistKey } from '@logto/client/shim';
+import { PersistKey } from '@logto/client';
 
 import { type CookieConfig, CookieStorage } from './cookie-storage.js';
 import { unwrapSession, wrapSession } from './session.js';

--- a/packages/node/src/utils/session.test.ts
+++ b/packages/node/src/utils/session.test.ts
@@ -1,4 +1,4 @@
-import { PersistKey } from '@logto/client/shim';
+import { PersistKey } from '@logto/client';
 
 import { unwrapSession, wrapSession } from './session.js';
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactor `@logto/client` package exports condition for react-native.
Add `react-native` package export condition.

[Enabling package exports] feature (https://reactnative.dev/blog/2023/06/21/package-exports-support#enabling-package-exports-beta) in react-native is unstable and can cause issues.

Replace the `exports` in `@logto/client` package.json with the `react-native` [condition](https://reactnative.dev/blog/2023/06/21/package-exports-support#the-new-react-native-condition).


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
