### PR TITLE
fix(node): remove global.crypto

### DIFF
--- a/.changeset/shaggy-cups-switch.md
+++ b/.changeset/shaggy-cups-switch.md
@@ -1,0 +1,8 @@
+---
+"@logto/next-sample": patch
+"@logto/node": patch
+---
+
+remove the parameter of crypto, fix global undefined error in edge runtime
+
+Remove the default `crypto` parameter in `unwrapSession` and `wrapSession`, `global.crypto` is unavailable in edge runtime, since Node.js 20, we can access `crypto` directly, this also works in edge runtime like Vercel.

--- a/packages/node/src/utils/session.test.ts
+++ b/packages/node/src/utils/session.test.ts
@@ -6,22 +6,21 @@ const secret = 'secret';
 
 describe('session', () => {
   it('should be able to wrap', async () => {
-    const cookie = await wrapSession({ [PersistKey.IdToken]: 'idToken' }, secret, crypto);
+    const cookie = await wrapSession({ [PersistKey.IdToken]: 'idToken' }, secret);
     expect(cookie).toContain('.');
   });
 
   it('should be able to unwrap', async () => {
     const session = await unwrapSession(
       'BShU2NGKg5762PWEOFu8lhzXKZMktgjH1RR4ifik4aGOOerM7w==.DFFnnlzSnjRbTl7I',
-      secret,
-      crypto
+      secret
     );
     expect(session[PersistKey.IdToken]).toEqual('idToken');
   });
 
   it('should be able to wrap and unwrap', async () => {
-    const cookie = await wrapSession({ [PersistKey.IdToken]: 'idToken' }, secret, crypto);
-    const session = await unwrapSession(cookie, secret, crypto);
+    const cookie = await wrapSession({ [PersistKey.IdToken]: 'idToken' }, secret);
+    const session = await unwrapSession(cookie, secret);
     expect(session[PersistKey.IdToken]).toEqual('idToken');
   });
 });

--- a/packages/node/src/utils/session.ts
+++ b/packages/node/src/utils/session.ts
@@ -77,11 +77,7 @@ async function decrypt(ciphertext: string, iv: string, password: string, crypto:
   return new TextDecoder().decode(cleartext);
 }
 
-export const unwrapSession = async (
-  cookie: string,
-  secret: string,
-  crypto: Crypto = global.crypto
-): Promise<SessionData> => {
+export const unwrapSession = async (cookie: string, secret: string): Promise<SessionData> => {
   try {
     const [ciphertext, iv] = cookie.split('.');
 
@@ -99,36 +95,7 @@ export const unwrapSession = async (
   return {};
 };
 
-export const wrapSession = async (
-  session: SessionData,
-  secret: string,
-  crypto: Crypto = global.crypto
-): Promise<string> => {
+export const wrapSession = async (session: SessionData, secret: string): Promise<string> => {
   const { ciphertext, iv } = await encrypt(JSON.stringify(session), secret, crypto);
   return `${ciphertext}.${iv}`;
-};
-
-type SessionConfigs = {
-  secret: string;
-  crypto: Crypto;
-};
-
-export const createSession = async (
-  { secret, crypto }: SessionConfigs,
-  cookie: string,
-  setCookie?: (value: string) => void
-): Promise<Session> => {
-  const data = await unwrapSession(cookie, secret, crypto);
-
-  const getValues = async () => wrapSession(session, secret, crypto);
-
-  const session: Session = {
-    ...data,
-    save: async () => {
-      setCookie?.(await getValues());
-    },
-    getValues,
-  };
-
-  return session;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

The crypto parameter has been removed from the `unwrapSession` and `wrapSession` functions. With the introduction of Node.js 20, accessing crypto directly is now possible, which resolves issues related to `global is not defined` in edge runtimes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with Node.js and Vercel edge runtime.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
