### PR TITLE
refactor: drop common JS support and become pure ESM

### DIFF
--- a/.changeset/many-peaches-kneel.md
+++ b/.changeset/many-peaches-kneel.md
@@ -11,4 +11,4 @@
 "@logto/js": major
 ---
 
-drop common JS support and become pure ESM
+drop CommonJS support and become pure ESM

--- a/.changeset/many-peaches-kneel.md
+++ b/.changeset/many-peaches-kneel.md
@@ -1,0 +1,14 @@
+---
+"@logto/capacitor": major
+"@logto/browser": major
+"@logto/express": major
+"@logto/client": major
+"@logto/react": major
+"@logto/remix": major
+"@logto/next": major
+"@logto/node": major
+"@logto/vue": major
+"@logto/js": major
+---
+
+drop common JS support and become pure ESM

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/browser",
   "version": "2.2.19",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/capacitor",
   "version": "2.0.5",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,13 +2,11 @@
   "name": "@logto/client",
   "version": "2.8.2",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "react-native": "./lib/shim.js",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },
@@ -35,7 +33,7 @@
   "dependencies": {
     "@logto/js": "workspace:^",
     "@silverhand/essentials": "^2.9.2",
-    "camelcase-keys": "^7.0.1",
+    "camelcase-keys": "^9.1.3",
     "jose": "^5.2.2"
   },
   "devDependencies": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/express",
   "version": "2.4.0",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },
@@ -27,9 +25,8 @@
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
     "test": "vitest",
-    "test:coverage": "node test.cjs && vitest --silent --coverage",
-    "prepack": "pnpm build && pnpm test",
-    "postpack": "node test.cjs"
+    "test:coverage": "vitest --silent --coverage",
+    "prepack": "pnpm build && pnpm test"
   },
   "dependencies": {
     "@logto/node": "workspace:^"

--- a/packages/express/test.cjs
+++ b/packages/express/test.cjs
@@ -1,6 +1,0 @@
-const assert = require('node:assert');
-
-const { withLogto } = require('.');
-
-// Sanity check for resolving CJS in Node.js
-assert.strictEqual(typeof withLogto, 'function');

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/js",
   "version": "4.2.1",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js"
   },
   "files": [
@@ -31,7 +29,7 @@
   },
   "dependencies": {
     "@silverhand/essentials": "^2.9.2",
-    "camelcase-keys": "^7.0.1"
+    "camelcase-keys": "^9.1.3"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^6.0.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -2,7 +2,6 @@
   "name": "@logto/next",
   "version": "3.7.2",
   "type": "module",
-  "main": "./lib/src/index.cjs",
   "module": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",
   "typesVersions": {
@@ -20,17 +19,14 @@
   },
   "exports": {
     ".": {
-      "require": "./lib/src/index.cjs",
       "import": "./lib/src/index.js",
       "types": "./lib/src/index.d.ts"
     },
     "./edge": {
-      "require": "./lib/edge/index.cjs",
       "import": "./lib/edge/index.js",
       "types": "./lib/edge/index.d.ts"
     },
     "./server-actions": {
-      "require": "./lib/server-actions/index.cjs",
       "import": "./lib/server-actions/index.js",
       "types": "./lib/server-actions/index.d.ts"
     }
@@ -51,9 +47,8 @@
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
     "test": "vitest",
-    "test:coverage": "node test.cjs && vitest --silent --coverage",
-    "prepack": "pnpm build && pnpm test",
-    "postpack": "node test.cjs"
+    "test:coverage": "vitest --silent --coverage",
+    "prepack": "pnpm build && pnpm test"
   },
   "dependencies": {
     "@edge-runtime/cookies": "^5.0.0",

--- a/packages/next/test.cjs
+++ b/packages/next/test.cjs
@@ -1,6 +1,0 @@
-const assert = require('node:assert');
-
-const logto = require('.');
-
-// Sanity check for resolving CJS in Node.js
-assert.strictEqual(typeof logto.default, 'function');

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,22 +2,18 @@
   "name": "@logto/node",
   "version": "2.5.9",
   "type": "module",
-  "main": "./lib/src/index.cjs",
   "module": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/src/index.cjs",
       "import": "./lib/src/index.js",
       "types": "./lib/src/index.d.ts"
     },
     "./edge": {
-      "require": "./lib/edge/index.cjs",
       "import": "./lib/edge/index.js",
       "types": "./lib/edge/index.d.ts"
     },
     "./exports": {
-      "require": "./lib/exports/index.cjs",
       "import": "./lib/exports/index.js",
       "types": "./lib/exports/index.d.ts"
     }
@@ -38,9 +34,8 @@
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
     "lint": "eslint --ext .ts src",
     "test": "vitest",
-    "test:coverage": "node test.cjs && vitest --silent --coverage",
-    "prepack": "pnpm build && pnpm test",
-    "postpack": "node test.cjs"
+    "test:coverage": "vitest --silent --coverage",
+    "prepack": "pnpm build && pnpm test"
   },
   "dependencies": {
     "@logto/client": "workspace:^",

--- a/packages/node/test.cjs
+++ b/packages/node/test.cjs
@@ -1,6 +1,0 @@
-const assert = require('node:assert');
-
-const logto = require('.');
-
-// Sanity check for resolving CJS in Node.js
-assert.strictEqual(typeof logto.default, 'function');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/react",
   "version": "3.0.17",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/remix",
   "version": "2.2.8",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,12 +2,10 @@
   "name": "@logto/vue",
   "version": "2.2.18",
   "type": "module",
-  "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     "types": "./lib/index.d.ts",
-    "require": "./lib/index.cjs",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: ^2.9.2
         version: 2.9.2
       camelcase-keys:
-        specifier: ^7.0.1
-        version: 7.0.2
+        specifier: ^9.1.3
+        version: 9.1.3
       jose:
         specifier: ^5.2.2
         version: 5.2.2
@@ -412,8 +412,8 @@ importers:
         specifier: ^2.9.2
         version: 2.9.2
       camelcase-keys:
-        specifier: ^7.0.1
-        version: 7.0.2
+        specifier: ^9.1.3
+        version: 9.1.3
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^6.0.1
@@ -4243,17 +4243,17 @@ packages:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
 
-  camelcase-keys@7.0.2:
-    resolution: {integrity: sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==}
-    engines: {node: '>=12'}
+  camelcase-keys@9.1.3:
+    resolution: {integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==}
+    engines: {node: '>=16'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
-  camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -6699,6 +6699,10 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  map-obj@5.0.0:
+    resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
@@ -7904,9 +7908,9 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
 
   radix3@1.1.0:
     resolution: {integrity: sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A==}
@@ -8802,6 +8806,10 @@ packages:
 
   type-fest@4.0.0:
     resolution: {integrity: sha512-d/oYtUnPM9zar2fqqGLYPzgcY0qUlYK0evgNVti93xpzfjGkMgZHu9Lvgrkn0rqGXTgsFRxFamzjGoD9Uo+dgw==}
+    engines: {node: '>=16'}
+
+  type-fest@4.26.1:
+    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
     engines: {node: '>=16'}
 
   type-is@1.6.18:
@@ -12009,10 +12017,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.1.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.0.0)
@@ -13471,16 +13479,16 @@ snapshots:
       map-obj: 4.3.0
       quick-lru: 4.0.1
 
-  camelcase-keys@7.0.2:
+  camelcase-keys@9.1.3:
     dependencies:
-      camelcase: 6.3.0
-      map-obj: 4.3.0
-      quick-lru: 5.1.1
-      type-fest: 1.4.0
+      camelcase: 8.0.0
+      map-obj: 5.0.0
+      quick-lru: 6.1.2
+      type-fest: 4.26.1
 
   camelcase@5.3.1: {}
 
-  camelcase@6.3.0: {}
+  camelcase@8.0.0: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -14598,13 +14606,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.5.0
       is-core-module: 2.13.0
@@ -14626,14 +14634,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.1.1(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14682,7 +14690,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.3
@@ -14692,7 +14700,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -16418,6 +16426,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  map-obj@5.0.0: {}
+
   mathml-tag-names@2.1.3: {}
 
   mdn-data@2.0.14: {}
@@ -17750,7 +17760,7 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
-  quick-lru@5.1.1: {}
+  quick-lru@6.1.2: {}
 
   radix3@1.1.0: {}
 
@@ -18798,6 +18808,8 @@ snapshots:
   type-fest@3.13.1: {}
 
   type-fest@4.0.0: {}
+
+  type-fest@4.26.1: {}
 
   type-is@1.6.18:
     dependencies:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,11 +9,11 @@ const configs = {
   input: ['src/index.ts'],
   output: [
     {
-      format: 'cjs',
+      format: 'esm',
       dir: 'lib',
       preserveModules: true,
       exports: 'named',
-      entryFileNames: '[name].cjs',
+      entryFileNames: '[name].js',
       interop: 'auto',
     },
     { dir: 'lib', preserveModules: true },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- [BREAKING CHANGE] Drop common JS support
- Bump `camelcase-keys` to latest version.

Should also fix #618 since it's now pure ESM.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
