### PR TITLE
fix(nuxt): remove default value of customRedirectBaseUrl

### DIFF
--- a/.changeset/nine-meals-behave.md
+++ b/.changeset/nine-meals-behave.md
@@ -1,0 +1,7 @@
+---
+"@logto/nuxt": patch
+---
+
+fix the default value of customRedirectBaseUrl
+
+Previously, it was set to '<replace-with-custom-redirect-base-url>', which is not a valid value. Now the default value is removed because it's not a required value.

--- a/packages/nuxt/src/runtime/utils/constants.ts
+++ b/packages/nuxt/src/runtime/utils/constants.ts
@@ -12,5 +12,4 @@ export const defaults = Object.freeze({
   appId: '<replace-with-logto-app-id>',
   appSecret: '<replace-with-logto-app-secret>',
   cookieEncryptionKey: '<replace-with-random-string>',
-  customRedirectBaseUrl: '<replace-with-custom-redirect-base-url>',
 } as const satisfies LogtoRuntimeConfigInput);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fix the default value of customRedirectBaseUrl

Previously, it was set to `<replace-with-custom-redirect-base-url>`, which is not a valid value, and will cause 500 error.

Now the default value is removed because it's not a required value.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
