### PR TITLE
feat: add package exports compatibility for react-native apps

### DIFF
--- a/.changeset/chatty-dingos-confess.md
+++ b/.changeset/chatty-dingos-confess.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+fix react-native compatibility issues by re-exporting the shim

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,6 +7,7 @@
   "react-native": "./lib/shim.js",
   "exports": {
     "types": "./lib/index.d.ts",
+    "react-native": "./lib/shim.js",
     "import": "./lib/index.js",
     "default": "./lib/index.js"
   },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The new 0.4.0 react-native package release breaks if developers have unstable_enablePackageExports set to true, since https://github.com/logto-io/js/pull/791 uses root react-native fields in package.json.

While in office [React Native](https://reactnative.dev/blog/2023/06/21/package-exports-support#the-new-react-native-condition) and [metro](https://metrobundler.dev/docs/package-exports/#replacing-browser-and-react-native-fields) docs, enablePackageExports is going to be turned on by default in the future and the suggested way is to put react-native field under exports (instead of root).

To support both situations, we can add `react-native` field under both root and `exports`.

Discussion reference: https://github.com/logto-io/react-native/issues/20#issuecomment-2513375814


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
