### PR TITLE
fix(browser): support ssr

### DIFF
--- a/.changeset/neat-glasses-think.md
+++ b/.changeset/neat-glasses-think.md
@@ -1,0 +1,9 @@
+---
+"@logto/browser": patch
+---
+
+support ssr for browser-based SDKs
+
+Check if the `window` is defined, if not, ignore the storage operations, avoid breaking the server side rendering.
+
+For this kind of SDKs, it doesn't make sense to be used in server side, because the auth state is usually stored in the client side which is not available in server side. So we can safely ignore the storage operations in server side.

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -15,6 +15,11 @@ export class BrowserStorage implements Storage<StorageKey> {
   }
 
   async getItem(key: StorageKey): Promise<Nullable<string>> {
+    // Make it compatible with server side, usually used in SSR, in which `null` is acceptable.
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
     if (key === 'signInSession') {
       // The latter `getItem()` is for backward compatibility. Can be removed when major bump.
       return sessionStorage.getItem(this.getKey(key)) ?? sessionStorage.getItem(this.getKey());
@@ -24,6 +29,11 @@ export class BrowserStorage implements Storage<StorageKey> {
   }
 
   async setItem(key: StorageKey, value: string): Promise<void> {
+    // Make it compatible with server side, ignore it if it's not in browser.
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     if (key === 'signInSession') {
       sessionStorage.setItem(this.getKey(key), value);
       return;
@@ -32,6 +42,11 @@ export class BrowserStorage implements Storage<StorageKey> {
   }
 
   async removeItem(key: StorageKey): Promise<void> {
+    // Make it compatible with server side, ignore it if it's not in browser.
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     if (key === 'signInSession') {
       sessionStorage.removeItem(this.getKey(key));
       return;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

support ssr for browser-based SDKs

Check if the `window` is defined, if not, ignore the storage operations, avoid breaking the server side rendering.

For this kind of SDKs, it doesn't make sense to be used in server side, because the auth state is usually stored in the client side which is not available in server side. So we can safely ignore the storage operations in server side.

fix https://github.com/logto-io/js/issues/890

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
