### PR TITLE
feat(nuxt): add alias to enable import in server api

### DIFF
--- a/packages/nuxt/playground/nuxt.config.ts
+++ b/packages/nuxt/playground/nuxt.config.ts
@@ -1,7 +1,4 @@
 export default defineNuxtConfig({
-  imports: {
-    autoImport: false,
-  },
   modules: ['../src/module'],
   devtools: { enabled: true },
   compatibilityDate: '2024-12-26',

--- a/packages/nuxt/playground/server/api/auth/get-access-token.get.ts
+++ b/packages/nuxt/playground/server/api/auth/get-access-token.get.ts
@@ -1,0 +1,8 @@
+import { logtoEventHandler } from '#logto';
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  await logtoEventHandler(event, config);
+  const accessToken = await event.context.logtoClient.getAccessToken();
+  return { accessToken };
+});

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -46,6 +46,13 @@ const logtoModule: NuxtModule<LogtoRuntimeConfigInput> = defineNuxtModule<LogtoR
     });
 
     addImportsDir(resolve('./runtime/composables'));
+
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      nitroConfig.alias ||= {};
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      nitroConfig.alias['#logto'] = resolve('./runtime/utils/handler.js');
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

In order to resolve the nuxt module in the server api (nitro) it is required to register an alias as decribed in https://github.com/logto-io/js/issues/909#issuecomment-2655507974.

Closes https://github.com/logto-io/js/issues/909


## Testing

I tested the changes within an existing project locally.


## Checklist

- [x] `.changeset` - not sure
- [x] unit tests - N/A
- [x] integration tests - N/A
- [x] necessary TSDoc comments
