### PR TITLE
feat(client): add new sign-in option to skip clearing tokens on sign-in

### DIFF
--- a/.changeset/tame-colts-sparkle.md
+++ b/.changeset/tame-colts-sparkle.md
@@ -1,0 +1,11 @@
+---
+"@logto/client": minor
+---
+
+add new sign-in option to skip clearing cached tokens from storage on sign-in
+
+Example usage:
+
+```typescript
+await logtoClient.signIn({ redirectUri, clearTokens: false });
+```

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -52,6 +52,10 @@ export type SignInOptions = {
    * Note: If specified, it will override the prompt value in Logto configs.
    */
   prompt?: SignInUriParameters['prompt'];
+  /**
+   * Clear cached tokens from storage before sign-in. Defaults to: `true`
+   */
+  clearTokens?: boolean;
 } & Pick<
   SignInUriParameters,
   'interactionMode' | 'firstScreen' | 'identifiers' | 'loginHint' | 'directSignIn' | 'extraParams'
@@ -298,6 +302,7 @@ export class StandardLogtoClient {
       directSignIn,
       extraParams,
       prompt,
+      clearTokens,
     } = typeof options === 'string' || options instanceof URL
       ? {
           redirectUri: options,
@@ -309,6 +314,7 @@ export class StandardLogtoClient {
           directSignIn: undefined,
           extraParams: undefined,
           prompt: undefined,
+          clearTokens: true,
         }
       : options;
     const redirectUri = redirectUriUrl.toString();
@@ -340,7 +346,7 @@ export class StandardLogtoClient {
 
     await Promise.all([
       this.setSignInSession({ redirectUri, postRedirectUri, codeVerifier, state }),
-      this.clearAllTokens(),
+      clearTokens === false ? undefined : this.clearAllTokens(),
     ]);
     await this.adapter.navigate(signInUri, { redirectUri, for: 'sign-in' });
   }

--- a/packages/client/src/index.sign-in.test.ts
+++ b/packages/client/src/index.sign-in.test.ts
@@ -101,6 +101,35 @@ describe('LogtoClient', () => {
       expect(idToken).toBeNull();
     });
 
+    it('should keep the tokens if clearTokens is false', async () => {
+      const storage = new MockedStorage({
+        accessToken: '"resource":{"token":"access_token"}',
+        refreshToken: 'refresh_token',
+        idToken: 'id_token',
+      });
+      const [mockedAccessToken, mockedRefreshToken, mockedIdToken] = await Promise.all([
+        storage.getItem('accessToken'),
+        storage.getItem('refreshToken'),
+        storage.getItem('idToken'),
+      ]);
+      expect(mockedAccessToken).toBe('"resource":{"token":"access_token"}');
+      expect(mockedRefreshToken).toBe('refresh_token');
+      expect(mockedIdToken).toBe('id_token');
+
+      // Sign in
+      const logtoClient = createClient(undefined, storage);
+      await logtoClient.signIn({ redirectUri, clearTokens: false });
+
+      const [accessToken, refreshToken, idToken] = await Promise.all([
+        storage.getItem('accessToken'),
+        storage.getItem('refreshToken'),
+        storage.getItem('idToken'),
+      ]);
+      expect(accessToken).toBe('"resource":{"token":"access_token"}');
+      expect(refreshToken).toBe('refresh_token');
+      expect(idToken).toBe('id_token');
+    });
+
     it('should redirect to signInUri just after calling signIn', async () => {
       const logtoClient = createClient();
       await logtoClient.signIn(redirectUri);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add new sign-in option to skip clearing cached tokens (ID token, refresh token, and access tokens) on calling `signIn()` method.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
