### PR TITLE
fix(js): add react-native export declarations

### DIFF
--- a/.changeset/wet-mails-do.md
+++ b/.changeset/wet-mails-do.md
@@ -1,0 +1,7 @@
+---
+"@logto/js": patch
+---
+
+fix: add react-native export delclarations to js package.json
+
+Add react-native report declareations to js package.json to fix the issue with react-native: Can not resolve module '@logto/js'`from file`@logto/client/lib/shim.js`.

--- a/.changeset/wet-mails-do.md
+++ b/.changeset/wet-mails-do.md
@@ -4,4 +4,8 @@
 
 fix: add react-native export delclarations to js package.json
 
-Add react-native report declareations to js package.json to fix the issue with react-native: Can not resolve module '@logto/js'`from file`@logto/client/lib/shim.js`.
+Add react-native export entries to js package.json to fix the issue with react-native: 
+
+```
+Can not resolve module '@logto/js'`from file`@logto/client/lib/shim.js`.
+```

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -4,9 +4,11 @@
   "type": "module",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "react-native": "./lib/index.js",
   "exports": {
     "types": "./lib/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "react-native": "./lib/index.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add react-native specific export entry declarations to the @logto/js package. This will address the issue https://github.com/logto-io/react-native/issues/47

React Native uses a different module resolution strategy compared to Node.js. We need to ensure that the paths we are using in the exports are compatible with how React Native resolves modules. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
