### PR TITLE
fix(next): support postRedirectUri when handling sign in

### DIFF
--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -110,6 +110,29 @@ describe('Next', () => {
       });
       expect(handleSignInCallback).toHaveBeenCalled();
     });
+
+    it('should redirect to navigateUrl when postRedirectUri is set', async () => {
+      const customRedirectUrl = 'http://localhost:3000/dashboard';
+      const client = new LogtoClient(configs);
+
+      // Mock handleSignInCallback to simulate the navigate callback setting navigateUrl
+      // In the real implementation, the NodeClient calls navigate() during callback processing
+      // which sets this.navigateUrl. We directly set it here to test the postRedirectUri logic
+      handleSignInCallback.mockImplementationOnce(() => {
+        // eslint-disable-next-line @silverhand/fp/no-mutation, @typescript-eslint/no-explicit-any
+        (client as unknown as any).navigateUrl = customRedirectUrl;
+      });
+
+      await testApiHandler({
+        pagesHandler: client.handleSignInCallback(),
+        url: '/api/logto/sign-in-callback',
+        test: async ({ fetch }) => {
+          const { headers } = await fetch({ method: 'GET', redirect: 'manual' });
+          expect(headers.get('location')).toEqual(customRedirectUrl);
+        },
+      });
+      expect(handleSignInCallback).toHaveBeenCalled();
+    });
   });
 
   describe('getAccessToken', () => {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -99,7 +99,13 @@ export default class LogtoClient extends LogtoNextBaseClient {
 
       if (request.url) {
         await nodeClient.handleSignInCallback(`${this.config.baseUrl}${request.url}`);
-        response.redirect(redirectTo);
+
+        // Check if there's a stored navigation URL (from postRedirectUri) first
+        if (this.navigateUrl) {
+          response.redirect(this.navigateUrl);
+        } else {
+          response.redirect(redirectTo);
+        }
       }
     }, onError);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In the default sign in callback route, check `postRedirectUri` before redirect.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit test and local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
