### PR TITLE
fix(client): include scopes in access token request

### DIFF
--- a/.changeset/sweet-snakes-arrive.md
+++ b/.changeset/sweet-snakes-arrive.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+Include scopes in access token request

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -443,7 +443,7 @@ export class StandardLogtoClient {
     }
 
     const accessTokenKey = buildAccessTokenKey(resource, organizationId);
-    const { appId: clientId } = this.logtoConfig;
+    const { appId: clientId, scopes } = this.logtoConfig;
     const { tokenEndpoint } = await this.getOidcConfig();
     const requestedAt = Math.round(Date.now() / 1000);
     const { accessToken, refreshToken, idToken, scope, expiresIn } = await fetchTokenByRefreshToken(
@@ -453,6 +453,7 @@ export class StandardLogtoClient {
         refreshToken: currentRefreshToken,
         resource,
         organizationId,
+        scopes,
       },
       this.adapter.requester
     );

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -73,6 +73,41 @@ describe('LogtoClient', () => {
           client_id: 'app_id_value',
           refresh_token: 'refresh_token_value',
           grant_type: 'refresh_token',
+          scope: 'openid offline_access profile',
+        }).toString(),
+      });
+      expect(accessToken).toEqual('access_token_value');
+    });
+
+    it('should include custom scopes in refresh token request', async () => {
+      requester.mockClear().mockImplementation(async () => {
+        return {
+          accessToken: 'access_token_value',
+          expiresIn: 3600,
+        };
+      });
+
+      const logtoClient = createClient(
+        undefined,
+        new MockedStorage({
+          idToken: 'id_token_value',
+          refreshToken: 'refresh_token_value',
+        }),
+        false,
+        ['custom', 'item']
+      );
+      const accessToken = await logtoClient.getAccessToken();
+
+      expect(requester).toHaveBeenCalledWith(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: 'app_id_value',
+          refresh_token: 'refresh_token_value',
+          grant_type: 'refresh_token',
+          scope: 'openid offline_access profile custom item',
         }).toString(),
       });
       expect(accessToken).toEqual('access_token_value');
@@ -107,6 +142,7 @@ describe('LogtoClient', () => {
           refresh_token: 'refresh_token_value',
           grant_type: 'refresh_token',
           organization_id: 'organization_id',
+          scope: 'openid offline_access profile urn:logto:scope:organizations',
         }).toString(),
       });
       expect(organizationToken).toEqual('organization_token_value');


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
As per https://github.com/logto-io/js/issues/1009, when requesting an access token for a different resource, it should include the scopes from the client options.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Updated unit tests for getAccessToken call
Ran getAccessToken call against my logto instance

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [X] `.changeset`
- [X] unit tests
- [X] integration tests
- [X] necessary TSDoc comments
