### PR TITLE
fix(nuxt): add H3EventContext type augmentation for logtoUser and logtoClient

### DIFF
--- a/packages/nuxt/src/runtime/utils/types.ts
+++ b/packages/nuxt/src/runtime/utils/types.ts
@@ -1,5 +1,13 @@
-// eslint-disable-next-line unused-imports/no-unused-imports -- used in comments
-import type { LogtoConfig, CookieConfig, SignInOptions } from '@logto/node';
+import type LogtoClient from '@logto/node';
+import type { LogtoConfig, SignInOptions, IdTokenClaims, UserInfoResponse } from '@logto/node';
+
+declare module 'h3' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- interface required for module augmentation
+  interface H3EventContext {
+    logtoUser: UserInfoResponse | IdTokenClaims | undefined;
+    logtoClient: LogtoClient;
+  }
+}
 
 type DeepPartial<T> = T extends Record<string, unknown>
   ? {


### PR DESCRIPTION
## Summary
- Add TypeScript type declarations for `event.context.logtoUser` and `event.context.logtoClient` properties
- These properties are set by the Logto event handler but were missing type definitions
- Enables proper type checking in Nuxt server routes

## Test plan
- [x] Build succeeds (`pnpm build`)
- [x] ESLint passes (`pnpm lint`)  
- [x] Tests pass (`pnpm test`)
- [ ] Verify types are available when accessing `event.context.logtoUser` in a Nuxt server route

Closes #917