### PR TITLE
fix(client): pass includeReservedScopes to generateSignInUri

### DIFF
--- a/.changeset/eighty-bulldogs-wonder.md
+++ b/.changeset/eighty-bulldogs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+pass `includeReservedScopes` to `generateSignInUri` to fix the issue where the option was not being respected

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -319,7 +319,13 @@ export class StandardLogtoClient {
       : options;
     const redirectUri = redirectUriUrl.toString();
     const postRedirectUri = postRedirectUriUrl?.toString();
-    const { appId: clientId, prompt: promptViaConfig, resources, scopes } = this.logtoConfig;
+    const {
+      appId: clientId,
+      prompt: promptViaConfig,
+      resources,
+      scopes,
+      includeReservedScopes,
+    } = this.logtoConfig;
     const { authorizationEndpoint } = await this.getOidcConfig();
     const [codeVerifier, state] = await Promise.all([
       this.adapter.generateCodeVerifier(),
@@ -342,6 +348,7 @@ export class StandardLogtoClient {
       loginHint,
       directSignIn,
       extraParams,
+      includeReservedScopes,
     });
 
     await Promise.all([

--- a/packages/client/src/index.sign-in.test.ts
+++ b/packages/client/src/index.sign-in.test.ts
@@ -25,6 +25,7 @@ import {
   mockedSignUpUri,
   mockedUserHint,
   mockedSignInUriWithLoginHint,
+  mockedSignInUriWithoutReservedScopes,
 } from './mock.js';
 
 describe('LogtoClient', () => {
@@ -164,6 +165,15 @@ describe('LogtoClient', () => {
       const logtoClient = createClient(Prompt.Consent);
       await logtoClient.signIn({ redirectUri, prompt: Prompt.Login });
       expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithLoginPrompt, {
+        redirectUri,
+        for: 'sign-in',
+      });
+    });
+
+    it('should pass includeReservedScopes to generateSignInUri', async () => {
+      const logtoClient = createClient(undefined, undefined, false, ['custom_scope'], false);
+      await logtoClient.signIn(redirectUri);
+      expect(navigate).toHaveBeenCalledWith(mockedSignInUriWithoutReservedScopes, {
         redirectUri,
         for: 'sign-in',
       });

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -90,6 +90,16 @@ export const mockedSignInUriWithLoginHint = generateSignInUri({
   loginHint: mockedUserHint,
 });
 
+export const mockedSignInUriWithoutReservedScopes = generateSignInUri({
+  authorizationEndpoint,
+  clientId: appId,
+  redirectUri,
+  codeChallenge: mockCodeChallenge,
+  state: mockedState,
+  scopes: ['custom_scope'],
+  includeReservedScopes: false,
+});
+
 export const accessToken = 'access_token_value';
 export const refreshToken = 'new_refresh_token_value';
 export const idToken = 'id_token_value';
@@ -138,10 +148,11 @@ export const createClient = (
   prompt?: Prompt,
   storage = new MockedStorage(),
   withCache = false,
-  scopes?: string[]
+  scopes?: string[],
+  includeReservedScopes?: boolean
 ) => {
   const client = new LogtoClientWithAccessors(
-    { endpoint, appId, prompt, scopes },
+    { endpoint, appId, prompt, scopes, includeReservedScopes },
     {
       ...createAdapters(withCache),
       storage,

--- a/packages/client/src/types/index.test.ts
+++ b/packages/client/src/types/index.test.ts
@@ -52,4 +52,26 @@ describe('normalizeLogtoConfigs', () => {
     });
     expect(normalized.scopes).toEqual(['openid']);
   });
+
+  it('should preserve `includeReservedScopes` in the returned config', () => {
+    const normalizedWithFalse = normalizeLogtoConfig({
+      appId: '123',
+      endpoint: 'https://example.com',
+      includeReservedScopes: false,
+    });
+    expect(normalizedWithFalse.includeReservedScopes).toBe(false);
+
+    const normalizedWithTrue = normalizeLogtoConfig({
+      appId: '123',
+      endpoint: 'https://example.com',
+      includeReservedScopes: true,
+    });
+    expect(normalizedWithTrue.includeReservedScopes).toBe(true);
+
+    const normalizedWithDefault = normalizeLogtoConfig({
+      appId: '123',
+      endpoint: 'https://example.com',
+    });
+    expect(normalizedWithDefault.includeReservedScopes).toBe(true);
+  });
 });

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -77,6 +77,7 @@ export const normalizeLogtoConfig = (config: LogtoConfig): LogtoConfig => {
     resources: scopes.includes(UserScope.Organizations)
       ? deduplicate([...(resources ?? []), ReservedResource.Organization])
       : resources,
+    includeReservedScopes,
   };
 };
 


### PR DESCRIPTION
## Summary

Fix a bug where `includeReservedScopes` option was not being passed to `generateSignInUri`, causing the option to be ignored when generating sign-in URLs.

The issue was that `normalizeLogtoConfig` processed the `includeReservedScopes` option but didn't preserve it in the returned config object. This meant when `client.ts` later extracted `includeReservedScopes` from `logtoConfig`, it was `undefined`, and `generateSignInUri` would use its default value (`true`) instead.

### Changes:
- Preserve `includeReservedScopes` in `normalizeLogtoConfig` return value
- Pass `includeReservedScopes` from config to `generateSignInUri` in `client.ts`
- Add tests to verify the fix

## Testing

- Added unit test `should pass includeReservedScopes to generateSignInUri` to verify the parameter is correctly passed
- Added unit test `should preserve includeReservedScopes in the returned config` to verify `normalizeLogtoConfig` preserves the option
- All 71 tests pass

## Checklist

- [x] Changeset file created
- [x] Unit tests
- [ ] Integration tests (N/A - unit tests cover this fix)
- [ ] TSDoc comments (N/A - no new public APIs)