### PR TITLE
fix(next): use postRedirectUri in server-actions handleSignIn callback

### DIFF
--- a/packages/next/server-actions/client.test.ts
+++ b/packages/next/server-actions/client.test.ts
@@ -4,6 +4,7 @@ import LogtoClient from './client.js';
 
 const signInUrl = 'http://mock-logto-server.com/sign-in';
 const callbackUrl = 'http://localhost:3000/callback';
+const postRedirectUri = 'http://localhost:3000/dashboard';
 
 const configs: LogtoNextConfig = {
   appId: 'app_id_value',
@@ -40,7 +41,10 @@ vi.mock('@logto/node/edge', () => ({
       navigate(signInUrl);
       signIn();
     },
-    handleSignInCallback,
+    handleSignInCallback: (url: string) => {
+      handleSignInCallback(url);
+      navigate(postRedirectUri);
+    },
     getContext,
     getIdTokenClaims,
     signOut: () => {
@@ -65,10 +69,11 @@ describe('Next (server actions)', () => {
   });
 
   describe('handleSignInCallback', () => {
-    it('should call nodClient.handleSignInCallback', async () => {
+    it('should call nodClient.handleSignInCallback and return postRedirectUri', async () => {
       const client = new LogtoClient(configs);
-      await client.handleSignInCallback(callbackUrl);
+      const result = await client.handleSignInCallback(callbackUrl);
       expect(handleSignInCallback).toHaveBeenCalledWith(callbackUrl);
+      expect(result).toEqual(postRedirectUri);
     });
   });
 

--- a/packages/next/server-actions/client.ts
+++ b/packages/next/server-actions/client.ts
@@ -82,11 +82,14 @@ export default class LogtoClient extends BaseClient {
    * Handle sign-in callback from Logto.
    *
    * @param callbackUrl the uri (callbackUri) to redirect to after sign in, should match the one used in handleSignIn
+   * @returns the postRedirectUri if configured, otherwise undefined
    */
-  async handleSignInCallback(callbackUrl: string) {
+  async handleSignInCallback(callbackUrl: string): Promise<string | undefined> {
     const nodeClient = await this.createNodeClient();
 
     await nodeClient.handleSignInCallback(callbackUrl);
+
+    return this.navigateUrl;
   }
 
   /**

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -47,7 +47,8 @@ export function handleSignIn(config: LogtoNextConfig, searchParams: URLSearchPar
 export function handleSignIn(config: LogtoNextConfig, url: URL): Promise<void>;
 
 /**
- * Handle sign in callback from search params or full redirect URL, save tokens to session
+ * Handle sign in callback from search params or full redirect URL, save tokens to session,
+ * and redirect to postRedirectUri if configured
  * @param config The Logto configuration object
  * @param searchParamsOrUrl Either URLSearchParams from the callback URL or the complete URL object
  */
@@ -56,11 +57,15 @@ export async function handleSignIn(
   searchParamsOrUrl: URLSearchParams | URL
 ): Promise<void> {
   const client = new LogtoClient(config);
-  await client.handleSignInCallback(
+  const postRedirectUri = await client.handleSignInCallback(
     searchParamsOrUrl instanceof URL
       ? searchParamsOrUrl.toString()
       : `${config.baseUrl}/callback?${searchParamsOrUrl.toString()}`
   );
+
+  if (postRedirectUri) {
+    redirect(postRedirectUri);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `handleSignInCallback` in `packages/next/server-actions/client.ts` to return `navigateUrl` (the `postRedirectUri`) after processing the callback
- Update `handleSignIn` in `packages/next/server-actions/index.ts` to redirect to `postRedirectUri` if configured

The `postRedirectUri` was stored in the sign-in session but never used after processing the callback. The core client correctly calls `adapter.navigate(postRedirectUri)`, which sets `this.navigateUrl`, but the server-actions client wasn't returning this value.

## Test plan

- [x] Updated existing test to verify `handleSignInCallback` returns `postRedirectUri`
- [x] All tests pass (`pnpm --filter @logto/next test`)

Closes #1028