### PR TITLE
fix(react-sample): handle user info query errors correctly

### DIFF
--- a/packages/react-sample/src/pages/ReactQuery/index.tsx
+++ b/packages/react-sample/src/pages/ReactQuery/index.tsx
@@ -31,6 +31,14 @@ const useApi = () => {
 
 const queryClient = new QueryClient();
 
+const getErrorMessage = (data: unknown, status: number) => {
+  if (typeof data === 'object' && data && 'message' in data && typeof data.message === 'string') {
+    return data.message;
+  }
+
+  return `Failed to fetch user info: ${status}`;
+};
+
 const ReactQuery = () => {
   return (
     <QueryClientProvider client={queryClient}>
@@ -45,7 +53,13 @@ const Content = () => {
     queryKey: ['userinfo'],
     queryFn: async () => {
       const response = await api(new URL('/oidc/me', endpoint));
-      return response.json();
+      const data: unknown = await response.json();
+
+      if (!response.ok) {
+        throw new Error(getErrorMessage(data, response.status));
+      }
+
+      return data;
     },
   });
 
@@ -57,7 +71,7 @@ const Content = () => {
     return (
       <div>
         <h1>Error</h1>
-        <p>{JSON.stringify(query.error)}</p>
+        <p>{query.error instanceof Error ? query.error.message : JSON.stringify(query.error)}</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Fix the react-query user info page so non-2xx API responses are treated as errors instead of showing the success state.
Improve the error display to show the SDK or API error message directly when available.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments