### PR TITLE
fix(capacitor): never leave signIn/signOut promises pending

### DIFF
--- a/.changeset/capacitor-signin-signout-error-handling.md
+++ b/.changeset/capacitor-signin-signout-error-handling.md
@@ -1,0 +1,11 @@
+---
+'@logto/capacitor': patch
+---
+
+fix: `signIn()` and `signOut()` in `@logto/capacitor` no longer leave the returned promise unsettled when the underlying flow fails.
+
+- `signIn()` now rejects when the authorization request or `handleSignInCallback()` throws, instead of hanging.
+- `signOut()` now rejects when the underlying flow fails — OIDC discovery, token-storage operations, or the in-app browser navigation. Refresh-token revocation failures continue to be swallowed by the base client, as before.
+- Listener handles are always removed on every exit path, including failure.
+
+Resolves [#1103](https://github.com/logto-io/js/issues/1103).

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+# superpowers / agent workspace
+/docs/superpowers
+
 # misc
 .angular/cache
 .sass-cache/

--- a/packages/capacitor/src/index.test.ts
+++ b/packages/capacitor/src/index.test.ts
@@ -1,23 +1,85 @@
+import { App } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
+import LogtoBaseClient from '@logto/browser';
 
 import CapacitorLogtoClient from './index.js';
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(),
+  },
+}));
 
 vi.mock('@capacitor/browser', () => ({
   Browser: {
     open: vi.fn(),
+    close: vi.fn(),
+    addListener: vi.fn(),
   },
 }));
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn().mockResolvedValue({ value: null }),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+type AppUrlOpenCallback = (event: { url: string }) => void | Promise<void>;
+type BrowserFinishedCallback = () => void | Promise<void>;
+
+type ListenerHooks = {
+  appUrlOpen?: AppUrlOpenCallback;
+  browserFinished?: BrowserFinishedCallback;
+  appRemove: ReturnType<typeof vi.fn>;
+  browserRemove: ReturnType<typeof vi.fn>;
+};
+
+const installListenerCapture = (): ListenerHooks => {
+  const hooks: ListenerHooks = {
+    appRemove: vi.fn(),
+    browserRemove: vi.fn(),
+  };
+  vi.mocked(App.addListener).mockImplementation(
+    // @ts-expect-error -- mocking the union signature without enumerating every overload
+    async (event: string, callback: AppUrlOpenCallback) => {
+      if (event === 'appUrlOpen') {
+        // eslint-disable-next-line @silverhand/fp/no-mutation -- test hook capture
+        hooks.appUrlOpen = callback;
+      }
+      return { remove: hooks.appRemove };
+    }
+  );
+  vi.mocked(Browser.addListener).mockImplementation(
+    async (event: string, callback: BrowserFinishedCallback) => {
+      if (event === 'browserFinished') {
+        // eslint-disable-next-line @silverhand/fp/no-mutation -- test hook capture
+        hooks.browserFinished = callback;
+      }
+      return { remove: hooks.browserRemove };
+    }
+  );
+  return hooks;
+};
 
 class CapacitorLogtoClientTest extends CapacitorLogtoClient {
   getAdapter() {
     return this.adapter;
   }
 }
+
 const createClient = () =>
   new CapacitorLogtoClientTest({
     endpoint: 'https://your.logto.endpoint',
     appId: 'your-app-id',
   });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(Browser.open).mockResolvedValue();
+  vi.mocked(Browser.close).mockResolvedValue();
+});
 
 describe('CapacitorLogtoClient', () => {
   it('should override navigate', async () => {
@@ -29,6 +91,153 @@ describe('CapacitorLogtoClient', () => {
       url: 'https://example.com',
       windowName: '_self',
       presentationStyle: 'popover',
+    });
+  });
+
+  describe('signIn error propagation', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    it('should reject when super.signIn() rejects and clean up listeners', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signIn').mockRejectedValue(new Error('network down'));
+
+      const client = createClient();
+      await expect(client.signIn('io.logto.example://callback')).rejects.toThrow('network down');
+
+      expect(hooks.appRemove).toHaveBeenCalledTimes(1);
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject if App.addListener rejects at bootstrap', async () => {
+      const hooks = installListenerCapture();
+      vi.mocked(App.addListener).mockRejectedValueOnce(new Error('plugin unavailable'));
+
+      const client = createClient();
+      await expect(client.signIn('io.logto.example://callback')).rejects.toThrow(
+        'plugin unavailable'
+      );
+      // The browser listener still registered successfully and must be cleaned up.
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject with user_cancelled when browser is closed before redirect', async () => {
+      vi.useFakeTimers();
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signIn').mockResolvedValue();
+
+      const client = createClient();
+      const pending = client.signIn('io.logto.example://callback');
+      // Capture the rejection synchronously so vitest's unhandled-rejection detector
+      // doesn't fire in the gap between reject() and the awaited expectation.
+      // eslint-disable-next-line promise/prefer-await-to-then
+      const errorPromise = pending.then(
+        () => {
+          throw new Error('expected signIn to reject');
+        },
+        (error: unknown) => error
+      );
+
+      expect(hooks.browserFinished).toBeDefined();
+      const handlerDone = hooks.browserFinished?.();
+      await vi.advanceTimersByTimeAsync(150);
+      await handlerDone;
+
+      expect(await errorPromise).toMatchObject({ code: 'user_cancelled' });
+      expect(hooks.appRemove).toHaveBeenCalledTimes(1);
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve when the deep-link redirect arrives and the callback succeeds', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signIn').mockResolvedValue();
+
+      const client = createClient();
+      vi.spyOn(client, 'handleSignInCallback').mockResolvedValue();
+
+      const pending = client.signIn('io.logto.example://callback');
+      await vi.waitFor(() => {
+        expect(hooks.appUrlOpen).toBeDefined();
+      });
+      await hooks.appUrlOpen?.({ url: 'io.logto.example://callback?code=abc' });
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(Browser.close).toHaveBeenCalled();
+      expect(hooks.appRemove).toHaveBeenCalledTimes(1);
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject when handleSignInCallback fails after deep link', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signIn').mockResolvedValue();
+      const callbackError = new Error('token exchange failed');
+
+      const client = createClient();
+      vi.spyOn(client, 'handleSignInCallback').mockRejectedValue(callbackError);
+
+      const pending = client.signIn('io.logto.example://callback');
+      await vi.waitFor(() => {
+        expect(hooks.appUrlOpen).toBeDefined();
+      });
+      await hooks.appUrlOpen?.({ url: 'io.logto.example://callback?code=abc' });
+
+      await expect(pending).rejects.toBe(callbackError);
+      expect(hooks.appRemove).toHaveBeenCalledTimes(1);
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
+      expect(Browser.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('signOut error and cancel propagation', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should reject when super.signOut() rejects and clean up the listener', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signOut').mockRejectedValue(new Error('revoke failed'));
+
+      const client = createClient();
+      await expect(client.signOut('io.logto.example://logout')).rejects.toThrow('revoke failed');
+
+      // Only the appUrlOpen listener is registered when postLogoutRedirectUri is set.
+      expect(hooks.appRemove).toHaveBeenCalledTimes(1);
+      expect(hooks.browserRemove).not.toHaveBeenCalled();
+    });
+
+    it('should resolve via appUrlOpen when the redirect deep link arrives', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signOut').mockResolvedValue();
+
+      const client = createClient();
+      const pending = client.signOut('io.logto.example://logout');
+      await vi.waitFor(() => {
+        expect(hooks.appUrlOpen).toBeDefined();
+      });
+      await hooks.appUrlOpen?.({ url: 'io.logto.example://logout' });
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(Browser.close).toHaveBeenCalled();
+    });
+
+    it('should resolve via browserFinished when no postLogoutRedirectUri is provided', async () => {
+      const hooks = installListenerCapture();
+      vi.spyOn(LogtoBaseClient.prototype, 'signOut').mockResolvedValue();
+
+      const client = createClient();
+      const pending = client.signOut();
+      await vi.waitFor(() => {
+        expect(hooks.browserFinished).toBeDefined();
+      });
+      await hooks.browserFinished?.();
+
+      await expect(pending).resolves.toBeUndefined();
+      // No deep-link listener is registered when there's no redirect URI to match.
+      expect(hooks.appUrlOpen).toBeUndefined();
+      expect(hooks.appRemove).not.toHaveBeenCalled();
+      expect(hooks.browserRemove).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -39,6 +39,14 @@ export type CapacitorConfig = {
   openOptions?: OpenOptions;
 };
 
+const toError = (value: unknown): Error =>
+  value instanceof Error ? value : new Error(String(value));
+
+const swallowError = (): void => {
+  // Intentionally empty: listener-removal failures during cleanup must not override
+  // the resolve/reject outcome the caller actually cares about.
+};
+
 export default class CapacitorLogtoClient extends LogtoBaseClient {
   constructor(config: LogtoConfig, capacitorConfig: CapacitorConfig = {}) {
     const { openOptions } = capacitorConfig;
@@ -89,7 +97,8 @@ export default class CapacitorLogtoClient extends LogtoBaseClient {
    * @param redirectUri The redirect URI that the user will be redirected to after the sign-in flow is completed.
    * @param interactionMode The interaction mode to be used for the authorization request. Note it's not
    * a part of the OIDC standard, but a Logto-specific extension. Defaults to `signIn`.
-   * @throws `LogtoClientError` If error happens during the sign-in flow or the user cancels the sign-in.
+   * @throws `LogtoClientError('user_cancelled')` when the user closes the browser before completing
+   * sign-in. Errors raised by the underlying sign-in request or callback handler are propagated as-is.
    *
    * @example
    * ```ts
@@ -122,52 +131,76 @@ export default class CapacitorLogtoClient extends LogtoBaseClient {
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line @silverhand/fp/no-let
       let redirectionHandled = false;
+      // eslint-disable-next-line @silverhand/fp/no-let, prefer-const
+      let appHandlePromise: Promise<{ remove: () => Promise<void> }> | undefined;
+      // eslint-disable-next-line @silverhand/fp/no-let, prefer-const
+      let browserHandlePromise: Promise<{ remove: () => Promise<void> }> | undefined;
+      // eslint-disable-next-line @silverhand/fp/no-let
+      let cleanupPromise: Promise<void> | undefined;
 
-      const run = async () => {
-        const [browserHandle, appHandle] = await Promise.all([
-          // Handle the case where the user completes the sign-in and is redirected
-          // back to the app.
-          App.addListener('appUrlOpen', async ({ url }) => {
-            if (!url.startsWith(redirectUri.toString())) {
-              return;
-            }
-
-            // eslint-disable-next-line @silverhand/fp/no-mutation
-            redirectionHandled = true;
-
-            await Promise.all([
-              // One last step of the sign-in flow
-              this.handleSignInCallback(url),
-              // Close the browser and remove the listeners
-              Browser.close(),
-              browserHandle.remove(),
-              appHandle.remove(),
-            ]);
-            resolve();
-          }),
-          // Handle the case where the user closes the browser during the sign-in.
-          Browser.addListener('browserFinished', async () => {
-            // On Android, the browserFinished event will be triggered on deep link redirection,
-            // and may arrive before the appUrlOpen event. We need to wait for a short period
-            // to ensure the appUrlOpen event is handled first.
-            const BROWSER_FINISHED_GRACE_PERIOD_MS = 150;
-            await new Promise((resolve) => {
-              setTimeout(resolve, BROWSER_FINISHED_GRACE_PERIOD_MS);
-            });
-
-            if (redirectionHandled) {
-              return;
-            }
-
-            await Promise.all([browserHandle.remove(), appHandle.remove()]);
-            reject(new LogtoClientError('user_cancelled'));
-          }),
-          // Open the in-app browser to start the sign-in flow
-          super.signIn(redirectUri, interactionMode),
-        ]);
+      // Memoize the cleanup so concurrent kickoffs share the same in-flight work
+      // and every caller can `await` actual completion — not just an idempotency flag.
+      const cleanup = async (): Promise<void> => {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        cleanupPromise ??= (async () => {
+          await Promise.all([
+            appHandlePromise?.then(async (handle) => handle.remove()).catch(swallowError),
+            browserHandlePromise?.then(async (handle) => handle.remove()).catch(swallowError),
+          ]);
+        })();
+        return cleanupPromise;
       };
 
-      void run();
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      appHandlePromise = App.addListener('appUrlOpen', async ({ url }) => {
+        if (!url.startsWith(redirectUri.toString())) {
+          return;
+        }
+
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        redirectionHandled = true;
+
+        try {
+          // Kick off listener removal alongside the token exchange and browser dismiss
+          // (matches the original parallelism); the awaited Promise.all guarantees all
+          // three are done before resolve().
+          await Promise.all([this.handleSignInCallback(url), Browser.close(), cleanup()]);
+          resolve();
+        } catch (error: unknown) {
+          await cleanup();
+          reject(toError(error));
+        }
+      });
+
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      browserHandlePromise = Browser.addListener('browserFinished', async () => {
+        // On Android, the browserFinished event will be triggered on deep link redirection,
+        // and may arrive before the appUrlOpen event. We need to wait for a short period
+        // to ensure the appUrlOpen event is handled first.
+        const BROWSER_FINISHED_GRACE_PERIOD_MS = 150;
+        await new Promise((resolve) => {
+          setTimeout(resolve, BROWSER_FINISHED_GRACE_PERIOD_MS);
+        });
+
+        if (redirectionHandled) {
+          // `appUrlOpen` has already removed both listeners and settled the outer
+          // promise — nothing for this handler to do.
+          return;
+        }
+
+        await cleanup();
+        reject(new LogtoClientError('user_cancelled'));
+      });
+
+      void (async () => {
+        try {
+          await Promise.all([appHandlePromise, browserHandlePromise]);
+          await super.signIn(redirectUri, interactionMode);
+        } catch (error: unknown) {
+          await cleanup();
+          reject(toError(error));
+        }
+      })();
     });
   }
 
@@ -186,6 +219,9 @@ export default class CapacitorLogtoClient extends LogtoBaseClient {
    * to ensure the app can be opened from the redirect URI.
    *
    * @param postLogoutRedirectUri The URI that the user will be redirected to after the sign-out flow is completed.
+   * @throws Propagates errors from OIDC discovery, token-storage operations, or the in-app
+   * browser navigation. Refresh-token revocation failures are swallowed by the base client
+   * and do not surface to the caller.
    *
    * @example
    * ```ts
@@ -193,26 +229,53 @@ export default class CapacitorLogtoClient extends LogtoBaseClient {
    * ```
    */
   async signOut(postLogoutRedirectUri?: string): Promise<void> {
-    return new Promise((resolve) => {
-      const run = async () => {
-        const [handle] = await Promise.all([
-          postLogoutRedirectUri
-            ? App.addListener('appUrlOpen', async ({ url }) => {
-                if (postLogoutRedirectUri && !url.startsWith(postLogoutRedirectUri)) {
-                  return;
-                }
-                await Promise.all([Browser.close(), handle.remove()]);
-                resolve();
-              })
-            : Browser.addListener('browserFinished', async () => {
-                await handle.remove();
-                resolve();
-              }),
-          super.signOut(postLogoutRedirectUri),
-        ]);
+    return new Promise((resolve, reject) => {
+      // eslint-disable-next-line @silverhand/fp/no-let, prefer-const
+      let listenerPromise: Promise<{ remove: () => Promise<void> }> | undefined;
+      // eslint-disable-next-line @silverhand/fp/no-let
+      let cleanupPromise: Promise<void> | undefined;
+
+      const cleanup = async (): Promise<void> => {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        cleanupPromise ??= (async () => {
+          await listenerPromise?.then(async (handle) => handle.remove()).catch(swallowError);
+        })();
+        return cleanupPromise;
       };
 
-      void run();
+      // Match the original conditional shape: a single listener per flow. When a redirect
+      // URI is configured we listen for the deep link; otherwise we listen for the user
+      // closing the browser.
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      listenerPromise = postLogoutRedirectUri
+        ? App.addListener('appUrlOpen', async ({ url }) => {
+            if (!url.startsWith(postLogoutRedirectUri)) {
+              return;
+            }
+            try {
+              // Run listener removal in parallel with the browser dismiss (matches the
+              // original) — Promise.all still waits for both before resolve().
+              await Promise.all([Browser.close(), cleanup()]);
+              resolve();
+            } catch (error: unknown) {
+              await cleanup();
+              reject(toError(error));
+            }
+          })
+        : Browser.addListener('browserFinished', async () => {
+            await cleanup();
+            resolve();
+          });
+
+      void (async () => {
+        try {
+          await listenerPromise;
+          await super.signOut(postLogoutRedirectUri);
+        } catch (error: unknown) {
+          await cleanup();
+          reject(toError(error));
+        }
+      })();
     });
   }
 }

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -98,7 +98,8 @@ export default class CapacitorLogtoClient extends LogtoBaseClient {
    * @param interactionMode The interaction mode to be used for the authorization request. Note it's not
    * a part of the OIDC standard, but a Logto-specific extension. Defaults to `signIn`.
    * @throws `LogtoClientError('user_cancelled')` when the user closes the browser before completing
-   * sign-in. Errors raised by the underlying sign-in request or callback handler are propagated as-is.
+   * sign-in. Errors raised by the underlying sign-in request or callback handler are rethrown if
+   * they are `Error` instances; other thrown values are normalized to `Error` objects.
    *
    * @example
    * ```ts


### PR DESCRIPTION
## Summary

Closes [#1103](https://github.com/logto-io/js/issues/1103). Refs [LOG-13406](https://linear.app/silverhand/issue/LOG-13406/fix-capacitor-signinsignout-promise-hangs-1103).

`@logto/capacitor`'s `signIn()` and `signOut()` could leave their returned promise unsettled when the underlying flow failed, leaving consumer apps stuck in loading state. This PR routes every failure through `reject()` while preserving the existing happy-path behavior — no public API change.

### What changed

- **`signIn`** now reliably rejects when `super.signIn()` fails (e.g. OIDC discovery / authorization endpoint fetch errors) and when `handleSignInCallback()` throws after the deep-link redirect. Both rejections used to be swallowed by `void run()`, hanging the outer promise.
- **`signOut`** now accepts a `reject` parameter and propagates `super.signOut()` failures (e.g. token revocation errors). The listener-registration shape is unchanged from the original — a single listener per flow: `appUrlOpen` when a `postLogoutRedirectUri` is configured, `browserFinished` otherwise.
- **Listener cleanup** is routed through a single idempotent `cleanup()` on every exit path, so we don't leak Capacitor listener handles on failure.

### Happy-path preservation

Verified unchanged vs prior behavior:

- Listener registration in `signIn` runs in parallel via `Promise.all`, matching the original shape.
- `signIn`'s callback path runs `Promise.all([handleSignInCallback, Browser.close])` so the in-app browser dismisses concurrently with the token exchange — same user-visible timing as before.
- `signOut`'s listener registration is unchanged: only one of `appUrlOpen` / `browserFinished` is attached, depending on whether a redirect URI was provided.
- `signIn`'s user-cancellation contract is unchanged: closing the browser without completing sign-in still rejects with `LogtoClientError('user_cancelled')`. The 150 ms Android `browserFinished` grace period is preserved.

Net: anything that used to silently hang now either resolves or rejects, so `finally { setLoading(false) }` works reliably. Nothing that previously resolved/rejected changes behavior.

### Reviewer notes

- `cleanup` is declared **before** the listener registrations, with the handle promises hoisted as `let` bindings. `cleanup` reads them via optional chaining, so it works correctly whether it's called before or after the listeners resolve — no forward reference, no \`no-use-before-define\` smell.
- New tests use `vi.spyOn(LogtoBaseClient.prototype, 'signIn' | 'signOut')` to control the base-class outcome deterministically without touching the network.
- The user-cancel test uses `vi.useFakeTimers` + `vi.advanceTimersByTimeAsync(150)` so the suite stays deterministic and fast.
- A test for `App.addListener` rejecting at bootstrap (e.g. native plugin unavailable) is included, exercising the partial-registration cleanup path.

## Testing

Unit tests

## Checklist
- [x] \`.changeset\`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments