### PR TITLE
fix: cache OIDC discovery for server clients

### DIFF
--- a/.changeset/cache-oidc-discovery.md
+++ b/.changeset/cache-oidc-discovery.md
@@ -1,7 +1,6 @@
 ---
 '@logto/client': patch
 '@logto/node': patch
-'@logto/next': patch
 ---
 
 cache OIDC discovery metadata across server-side client instances and normalize non-JSON request failures

--- a/.changeset/cache-oidc-discovery.md
+++ b/.changeset/cache-oidc-discovery.md
@@ -1,0 +1,7 @@
+---
+'@logto/client': patch
+'@logto/node': patch
+'@logto/next': patch
+---
+
+cache OIDC discovery metadata across server-side client instances and normalize non-JSON request failures

--- a/packages/client/src/adapter/index.test.ts
+++ b/packages/client/src/adapter/index.test.ts
@@ -66,6 +66,17 @@ describe('ClientAdapterInstance', () => {
     await expect(firstCall).rejects.toThrow('transient failure');
     await expect(secondCall).resolves.toEqual({ test: 'recovered' });
     expect(secondGetter).toHaveBeenCalledTimes(1);
+    expect(await adapters.unstable_cache?.getItem(CacheKey.OpenidConfig)).toBe(
+      JSON.stringify({ test: 'recovered' })
+    );
+
+    const thirdGetter = vi.fn().mockResolvedValue({ test: 'should not run' });
+    const thirdAdapterInstance = new ClientAdapterInstance(adapters);
+
+    expect(await thirdAdapterInstance.getWithCache(CacheKey.OpenidConfig, thirdGetter)).toEqual({
+      test: 'recovered',
+    });
+    expect(thirdGetter).not.toHaveBeenCalled();
   });
 
   it('should deduplicate concurrent cache misses for the same cache storage', async () => {

--- a/packages/client/src/adapter/index.test.ts
+++ b/packages/client/src/adapter/index.test.ts
@@ -47,4 +47,25 @@ describe('ClientAdapterInstance', () => {
     expect(spy).toHaveBeenCalledTimes(2);
     expect(getter).toHaveBeenCalledTimes(1);
   });
+
+  it('should deduplicate concurrent cache misses for the same cache storage', async () => {
+    const adapters = createAdapters(true);
+    const firstAdapterInstance = new ClientAdapterInstance(adapters);
+    const secondAdapterInstance = new ClientAdapterInstance(adapters);
+    const getter = vi.fn(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+
+      return { test: 'test' };
+    });
+
+    await expect(
+      Promise.all([
+        firstAdapterInstance.getWithCache(CacheKey.OpenidConfig, getter),
+        secondAdapterInstance.getWithCache(CacheKey.OpenidConfig, getter),
+      ])
+    ).resolves.toEqual([{ test: 'test' }, { test: 'test' }]);
+    expect(getter).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/client/src/adapter/index.test.ts
+++ b/packages/client/src/adapter/index.test.ts
@@ -48,6 +48,26 @@ describe('ClientAdapterInstance', () => {
     expect(getter).toHaveBeenCalledTimes(1);
   });
 
+  it('should fall back to the current caller getter when the in-flight getter rejects', async () => {
+    const adapters = createAdapters(true);
+    const firstAdapterInstance = new ClientAdapterInstance(adapters);
+    const secondAdapterInstance = new ClientAdapterInstance(adapters);
+    const firstGetter = vi.fn(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      throw new Error('transient failure');
+    });
+    const secondGetter = vi.fn().mockResolvedValue({ test: 'recovered' });
+
+    const firstCall = firstAdapterInstance.getWithCache(CacheKey.OpenidConfig, firstGetter);
+    const secondCall = secondAdapterInstance.getWithCache(CacheKey.OpenidConfig, secondGetter);
+
+    await expect(firstCall).rejects.toThrow('transient failure');
+    await expect(secondCall).resolves.toEqual({ test: 'recovered' });
+    expect(secondGetter).toHaveBeenCalledTimes(1);
+  });
+
   it('should deduplicate concurrent cache misses for the same cache storage', async () => {
     const adapters = createAdapters(true);
     const firstAdapterInstance = new ClientAdapterInstance(adapters);

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -101,7 +101,12 @@ export class ClientAdapterInstance implements ClientAdapter {
     if (runningGetter) {
       // Another client sharing the same cache storage is already populating this key. Wait for it
       // instead of issuing a duplicate discovery request.
-      await runningGetter;
+      try {
+        await runningGetter;
+      } catch {
+        // The in-flight getter rejected before writing to cache. Fall through to the cache check
+        // and the current caller's getter below.
+      }
 
       const cachedResult = await this.getCachedObject<T>(key);
 

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -114,9 +114,9 @@ export class ClientAdapterInstance implements ClientAdapter {
         return cachedResult;
       }
 
-      // The in-flight getter may fail before writing to cache. Fall back to the current caller's
-      // getter so a transient failure does not poison future calls.
-      return getter();
+      // The in-flight getter may fail before writing to cache. Retry through the same population
+      // path so a successful recovery is stored for later callers.
+      return this.getWithCache(key, getter);
     }
 
     const newRunningGetter = (async () => {

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -11,6 +11,20 @@ import {
   type InferStorageKey,
 } from './types.js';
 
+const runningCacheGetters = new WeakMap<Storage<CacheKey>, Map<CacheKey, Promise<unknown>>>();
+
+const getRunningCacheGetterMap = (cache: Storage<CacheKey>) => {
+  const runningGetterMap = runningCacheGetters.get(cache);
+
+  if (runningGetterMap) {
+    return runningGetterMap;
+  }
+
+  const newRunningGetterMap = new Map<CacheKey, Promise<unknown>>();
+  runningCacheGetters.set(cache, newRunningGetterMap);
+  return newRunningGetterMap;
+};
+
 export class ClientAdapterInstance implements ClientAdapter {
   /*
    * Implement `ClientAdapter`. Its properties are assigned by
@@ -73,9 +87,39 @@ export class ClientAdapterInstance implements ClientAdapter {
       return cached;
     }
 
-    const result = await getter();
-    await this.unstable_cache?.setItem(key, JSON.stringify(result));
-    return result;
+    const { unstable_cache: cache } = this;
+
+    if (!cache) {
+      return getter();
+    }
+
+    const runningGetterMap = getRunningCacheGetterMap(cache);
+    const runningGetter = runningGetterMap.get(key);
+
+    if (runningGetter) {
+      await runningGetter;
+
+      const cachedResult = await this.getCachedObject<T>(key);
+
+      if (cachedResult) {
+        return cachedResult;
+      }
+
+      return getter();
+    }
+
+    const newRunningGetter = (async () => {
+      const result = await getter();
+      await cache.setItem(key, JSON.stringify(result));
+      return result;
+    })();
+    runningGetterMap.set(key, newRunningGetter);
+
+    try {
+      return await newRunningGetter;
+    } finally {
+      runningGetterMap.delete(key);
+    }
   }
 }
 

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -11,6 +11,8 @@ import {
   type InferStorageKey,
 } from './types.js';
 
+// Track in-flight cache writes per cache storage instance. A WeakMap keeps this helper from
+// extending the lifetime of adapter-provided cache stores.
 const runningCacheGetters = new WeakMap<Storage<CacheKey>, Map<CacheKey, Promise<unknown>>>();
 
 const getRunningCacheGetterMap = (cache: Storage<CacheKey>) => {
@@ -97,6 +99,8 @@ export class ClientAdapterInstance implements ClientAdapter {
     const runningGetter = runningGetterMap.get(key);
 
     if (runningGetter) {
+      // Another client sharing the same cache storage is already populating this key. Wait for it
+      // instead of issuing a duplicate discovery request.
       await runningGetter;
 
       const cachedResult = await this.getCachedObject<T>(key);
@@ -105,6 +109,8 @@ export class ClientAdapterInstance implements ClientAdapter {
         return cachedResult;
       }
 
+      // The in-flight getter may fail before writing to cache. Fall back to the current caller's
+      // getter so a transient failure does not poison future calls.
       return getter();
     }
 

--- a/packages/client/src/utils/requester.test.ts
+++ b/packages/client/src/utils/requester.test.ts
@@ -20,28 +20,35 @@ describe('createRequester', () => {
     const message = 'some error message';
 
     test('failing response json with code and message should throw LogtoRequestError with same code and message', async () => {
-      const fetchFunction = vi
-        .fn()
-        .mockResolvedValue(new Response(JSON.stringify({ code, message }), { status: 400 }));
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ code, message }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).rejects.toMatchObject(new LogtoRequestError(code, message));
     });
 
     test('failing response json with more than code and message should throw LogtoRequestError with same code and message', async () => {
-      const fetchFunction = vi
-        .fn()
-        .mockResolvedValue(
-          new Response(JSON.stringify({ code, message, foo: 'bar' }), { status: 400 })
-        );
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ code, message, foo: 'bar' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).rejects.toMatchObject(new LogtoRequestError(code, message));
     });
 
     test('failing response json with only code should throw LogtoError', async () => {
       const json = { code };
-      const fetchFunction = vi
-        .fn()
-        .mockResolvedValue(new Response(JSON.stringify(json), { status: 400 }));
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(json), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).rejects.toMatchObject(
         new LogtoError('unexpected_response_error', json)
@@ -50,9 +57,12 @@ describe('createRequester', () => {
 
     test('failing response json with only message should throw LogtoError', async () => {
       const json = { message };
-      const fetchFunction = vi
-        .fn()
-        .mockResolvedValue(new Response(JSON.stringify(json), { status: 400 }));
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(json), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).rejects.toMatchObject(
         new LogtoError('unexpected_response_error', json)
@@ -61,23 +71,41 @@ describe('createRequester', () => {
 
     test('failing response json without code and message should throw LogtoError', async () => {
       const json = {};
-      const fetchFunction = vi
-        .fn()
-        .mockResolvedValue(new Response(JSON.stringify(json), { status: 400 }));
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(json), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).rejects.toMatchObject(
         new LogtoError('unexpected_response_error', json)
       );
     });
 
-    test('failing response with non-json text should throw TypeError', async () => {
+    test('failing response with non-json text should throw LogtoRequestError', async () => {
       const fetchFunction = vi.fn().mockResolvedValue(
         new Response('not json content', {
           status: 400,
         })
       );
       const requester = createRequester(fetchFunction);
-      await expect(requester('foo')).rejects.toThrowError(SyntaxError);
+      await expect(requester('foo')).rejects.toMatchObject(
+        new LogtoRequestError('http_error_400', 'not json content')
+      );
+    });
+
+    test('rate limited response with non-json text should throw LogtoRequestError', async () => {
+      const fetchFunction = vi.fn().mockResolvedValue(
+        new Response('Too many requests', {
+          status: 429,
+          headers: { 'content-type': 'text/plain' },
+        })
+      );
+      const requester = createRequester(fetchFunction);
+      await expect(requester('foo')).rejects.toMatchObject(
+        new LogtoRequestError('rate_limited', 'Too many requests')
+      );
     });
   });
 });

--- a/packages/client/src/utils/requester.ts
+++ b/packages/client/src/utils/requester.ts
@@ -14,7 +14,19 @@ export const createRequester = (fetchFunction: typeof fetch): Requester => {
 
     if (!response.ok) {
       const cloned = response.clone();
-      const responseJson = await response.json();
+      const responseJson: unknown = await response
+        .clone()
+        .json()
+        .catch(async () => {
+          const responseText = await response.text();
+          console.error(`Logto requester error: [status=${response.status}]`, responseText);
+          throw new LogtoRequestError(
+            response.status === 429 ? 'rate_limited' : `http_error_${response.status}`,
+            responseText || response.statusText,
+            cloned
+          );
+        });
+
       console.error(`Logto requester error: [status=${response.status}]`, responseJson);
 
       if (!isLogtoRequestErrorJson(responseJson)) {

--- a/packages/node/edge/index.test.ts
+++ b/packages/node/edge/index.test.ts
@@ -1,0 +1,46 @@
+import BaseClient, { type ClientAdapter } from '@logto/client';
+
+import LogtoClient from './index.js';
+
+const appId = 'app_id_value';
+const endpoint = 'https://logto.dev';
+
+const navigate = vi.fn();
+const storage = {
+  setItem: vi.fn(),
+  getItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+
+vi.mock('@logto/client', () => ({
+  __esModule: true,
+  default: vi.fn(),
+  createRequester: vi.fn(),
+}));
+
+const getLatestBaseClientAdapter = (): ClientAdapter => {
+  const { calls } = vi.mocked(BaseClient).mock;
+  const [, adapter] = calls.at(-1)!;
+  return adapter;
+};
+
+describe('LogtoClient (edge)', () => {
+  beforeEach(() => {
+    vi.mocked(BaseClient).mockClear();
+  });
+
+  it('should provide endpoint-scoped cache storage by default', () => {
+    expect(
+      new LogtoClient({ endpoint: `${endpoint}/`, appId }, { navigate, storage })
+    ).toBeDefined();
+    const cache = getLatestBaseClientAdapter().unstable_cache;
+
+    expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
+    expect(getLatestBaseClientAdapter().unstable_cache).toBe(cache);
+
+    expect(
+      new LogtoClient({ endpoint: 'https://another.logto.dev', appId }, { navigate, storage })
+    ).toBeDefined();
+    expect(getLatestBaseClientAdapter().unstable_cache).not.toBe(cache);
+  });
+});

--- a/packages/node/edge/index.ts
+++ b/packages/node/edge/index.ts
@@ -1,7 +1,9 @@
 import type { LogtoConfig, ClientAdapter } from '@logto/client';
 import { createRequester } from '@logto/client';
+import { encode } from 'js-base64';
 
 import BaseClient from '../src/client.js';
+import { createMemoryCache } from '../src/utils/cache.js';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators.js';
 
@@ -17,8 +19,7 @@ export default class LogtoClient extends BaseClient {
           ? async (...args: Parameters<typeof fetch>) => {
               const [input, init] = args;
 
-              // Encode to base64 using btoa
-              const base64Credentials = btoa(`${config.appId}:${config.appSecret ?? ''}`);
+              const base64Credentials = encode(`${config.appId}:${config.appSecret ?? ''}`);
 
               return fetch(input, {
                 ...init,
@@ -33,6 +34,7 @@ export default class LogtoClient extends BaseClient {
       generateCodeChallenge,
       generateCodeVerifier,
       generateState,
+      unstable_cache: createMemoryCache(config.endpoint),
     });
   }
 }

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -1,3 +1,5 @@
+import BaseClient, { type ClientAdapter } from '@logto/client';
+
 import LogtoClient from './index.js';
 
 const appId = 'app_id_value';
@@ -28,10 +30,48 @@ vi.mock('@logto/client', () => ({
   createRequester: vi.fn(),
 }));
 
+const getLatestBaseClientAdapter = (): ClientAdapter => {
+  const { calls } = vi.mocked(BaseClient).mock;
+  const [, adapter] = calls.at(-1)!;
+  return adapter;
+};
+
 describe('LogtoClient', () => {
   describe('constructor', () => {
+    beforeEach(() => {
+      vi.mocked(BaseClient).mockClear();
+    });
+
     it('constructor should not throw', () => {
       expect(() => new LogtoClient({ endpoint, appId }, { navigate, storage })).not.toThrow();
+    });
+
+    it('should provide endpoint-scoped cache storage by default', () => {
+      expect(
+        new LogtoClient({ endpoint: `${endpoint}/`, appId }, { navigate, storage })
+      ).toBeDefined();
+      const cache = getLatestBaseClientAdapter().unstable_cache;
+
+      expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
+      expect(getLatestBaseClientAdapter().unstable_cache).toBe(cache);
+
+      expect(
+        new LogtoClient({ endpoint: 'https://another.logto.dev', appId }, { navigate, storage })
+      ).toBeDefined();
+      expect(getLatestBaseClientAdapter().unstable_cache).not.toBe(cache);
+    });
+
+    it('should allow overriding the default cache storage', () => {
+      const unstableCache = {
+        setItem: vi.fn(),
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+      };
+
+      expect(
+        new LogtoClient({ endpoint, appId }, { navigate, storage, unstable_cache: unstableCache })
+      ).toBeDefined();
+      expect(getLatestBaseClientAdapter().unstable_cache).toBe(unstableCache);
     });
   });
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,6 +4,7 @@ import { createRequester } from '@logto/client';
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../edge/generators.js';
 
 import BaseClient from './client.js';
+import { createMemoryCache } from './utils/cache.js';
 
 export * from './exports.js';
 
@@ -37,6 +38,7 @@ export default class LogtoClient extends BaseClient {
         generateCodeChallenge,
         generateCodeVerifier,
         generateState,
+        unstable_cache: createMemoryCache(config.endpoint),
         ...adapter,
       },
       buildJwtVerifier

--- a/packages/node/src/utils/cache.test.ts
+++ b/packages/node/src/utils/cache.test.ts
@@ -1,0 +1,23 @@
+import { CacheKey } from '@logto/client';
+
+import { createMemoryCache } from './cache.js';
+
+describe('createMemoryCache', () => {
+  it('should reuse cache storage for the same normalized endpoint', async () => {
+    const cache = createMemoryCache('https://logto.dev/');
+    const sameEndpointCache = createMemoryCache('https://logto.dev');
+
+    expect(sameEndpointCache).toBe(cache);
+
+    await cache.setItem(CacheKey.OpenidConfig, 'value');
+    await expect(sameEndpointCache.getItem(CacheKey.OpenidConfig)).resolves.toBe('value');
+  });
+
+  it('should isolate cache data by endpoint', async () => {
+    const cache = createMemoryCache('https://logto.dev');
+    const anotherEndpointCache = createMemoryCache('https://another.logto.dev');
+
+    await cache.setItem(CacheKey.OpenidConfig, 'value');
+    await expect(anotherEndpointCache.getItem(CacheKey.OpenidConfig)).resolves.toBeNull();
+  });
+});

--- a/packages/node/src/utils/cache.ts
+++ b/packages/node/src/utils/cache.ts
@@ -1,0 +1,29 @@
+import type { CacheKey, Storage } from '@logto/client';
+
+const cacheStorageMap = new Map<string, Storage<CacheKey>>();
+const cacheData = new Map<string, string>();
+
+const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, '');
+
+export const createMemoryCache = (endpoint: string): Storage<CacheKey> => {
+  const normalizedEndpoint = normalizeEndpoint(endpoint);
+  const cacheStorage = cacheStorageMap.get(normalizedEndpoint);
+
+  if (cacheStorage) {
+    return cacheStorage;
+  }
+
+  const getCacheKey = (key: CacheKey) => `${normalizedEndpoint}:${key}`;
+  const newCacheStorage: Storage<CacheKey> = {
+    getItem: async (key) => cacheData.get(getCacheKey(key)) ?? null,
+    setItem: async (key, value) => {
+      cacheData.set(getCacheKey(key), value);
+    },
+    removeItem: async (key) => {
+      cacheData.delete(getCacheKey(key));
+    },
+  };
+
+  cacheStorageMap.set(normalizedEndpoint, newCacheStorage);
+  return newCacheStorage;
+};


### PR DESCRIPTION
Fixes #1112

## Summary

- Cache OIDC discovery metadata across server-side client instances using endpoint-scoped in-memory storage.
- Deduplicate concurrent cache misses for shared cache storage.
- Normalize non-JSON request failures into typed Logto request errors.
- Document the adapter cache dedupe flow.

## Testing

Unit tests