### PR TITLE
feat(client,next): support force-refreshing access and organization tokens

### DIFF
--- a/.changeset/force-refresh-organization-token.md
+++ b/.changeset/force-refresh-organization-token.md
@@ -1,0 +1,29 @@
+---
+'@logto/client': minor
+'@logto/next': minor
+---
+
+add a supported way to force-refresh access tokens and organization tokens
+
+Access tokens (including organization tokens) are cached in the session until they expire, so a
+cached token keeps its original scopes even after the user's organization roles have changed on
+the Logto side. Since Logto re-reads the user's organization scopes from the database on every
+`refresh_token` exchange, a fresh token already reflects role changes immediately — there was
+just no supported way to trigger that exchange from `@logto/next`.
+
+Two additions:
+
+- `getAccessToken()` / `getOrganizationToken()` now accept an optional
+  `{ forceRefresh: boolean }` argument. When `true`, the cached token is skipped and a new one is
+  exchanged with the Refresh Token.
+- `clearAccessToken()` now accepts optional `resource` / `organizationId` arguments to evict a
+  single cached token instead of all of them. Calling it with no arguments keeps the existing
+  "clear everything" behavior.
+
+Both are exposed through `@logto/next` for the Pages Router, the Edge runtime, and server
+actions, where `clearAccessToken(config, resource?, organizationId?)` is now exported from
+`@logto/next/server-actions`.
+
+Note that a token can still only carry scopes that were requested in the original authorization
+request. Introducing a brand new scope continues to require a new authorization request, e.g.
+`signIn({ prompt: 'consent' })`.

--- a/.changeset/force-refresh-organization-token.md
+++ b/.changeset/force-refresh-organization-token.md
@@ -24,6 +24,11 @@ Both are exposed through `@logto/next` for the Pages Router, the Edge runtime, a
 actions, where `clearAccessToken(config, resource?, organizationId?)` is now exported from
 `@logto/next/server-actions`.
 
+The RSC helpers (`getAccessTokenRSC()` / `getOrganizationTokenRSC()`) intentionally do not accept
+`forceRefresh`: an RSC cannot write cookies, so a forced exchange there would drop the refreshed
+tokens and any rotated Refresh Token, which can break subsequent requests. Use a server action or
+API route when you need a forced refresh.
+
 Note that a token can still only carry scopes that were requested in the original authorization
 request. Introducing a brand new scope continues to require a new authorization request, e.g.
 `signIn({ prompt: 'consent' })`.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -61,6 +61,23 @@ export type SignInOptions = {
   'interactionMode' | 'firstScreen' | 'identifiers' | 'loginHint' | 'directSignIn' | 'extraParams'
 >;
 
+export type GetAccessTokenOptions = {
+  /**
+   * Bypass the cached access token and always exchange a new one using the Refresh Token.
+   *
+   * This is useful when the user's permissions have changed on the Logto side (e.g. the user
+   * has been promoted or demoted in an organization) and the application wants the change to
+   * take effect immediately instead of waiting for the cached token to expire.
+   *
+   * Note that a token can only carry the scopes that were requested in the original
+   * authorization request. If a brand new scope needs to be introduced, a new authorization
+   * request (e.g. `signIn()` with `prompt: 'consent'`) is still required.
+   *
+   * @default false
+   */
+  forceRefresh?: boolean;
+};
+
 /**
  * The Logto base client class that provides the essential methods for
  * interacting with the Logto server.
@@ -91,6 +108,9 @@ export class StandardLogtoClient {
    * @param resource The resource that the access token is granted for. If not
    * specified, the access token will be used for OpenID Connect or the default
    * resource, as specified in the Logto Console.
+   * @param organizationId The optional organization ID that the access token is granted for.
+   * @param options See {@link GetAccessTokenOptions}. Use `{ forceRefresh: true }` to skip the
+   * cache and always exchange a new access token using the Refresh Token.
    * @returns The access token string.
    * @throws LogtoClientError if the user is not authenticated.
    */
@@ -103,6 +123,10 @@ export class StandardLogtoClient {
    * methods.
    *
    * @param organizationId The ID of the organization that the access token is granted for.
+   * @param options See {@link GetAccessTokenOptions}. Use `{ forceRefresh: true }` to skip the
+   * cache and always exchange a new organization token using the Refresh Token. This is handy
+   * when the user's organization roles have just changed and the new scopes should take effect
+   * immediately.
    * @returns The access token string.
    * @throws LogtoClientError if the user is not authenticated.
    * @remarks
@@ -111,7 +135,14 @@ export class StandardLogtoClient {
   readonly getOrganizationToken = memoize(this.#getOrganizationToken);
 
   /**
-   * Clear the access token from the cache storage.
+   * Clear the cached access tokens from the storage.
+   *
+   * - When called without arguments, all the cached access tokens will be cleared.
+   * - When called with `resource` and/or `organizationId`, only the matching cached access
+   *   token will be cleared, and other cached tokens will be kept intact.
+   *
+   * @param resource The resource that the access token was granted for.
+   * @param organizationId The organization ID that the access token was granted for.
    */
   readonly clearAccessToken = memoize(this.#clearAccessToken);
 
@@ -531,7 +562,11 @@ export class StandardLogtoClient {
     });
   }
 
-  async #getAccessToken(resource?: string, organizationId?: string): Promise<string> {
+  async #getAccessToken(
+    resource?: string,
+    organizationId?: string,
+    options?: GetAccessTokenOptions
+  ): Promise<string> {
     if (!(await this.isAuthenticated())) {
       throw new LogtoClientError('not_authenticated');
     }
@@ -539,11 +574,11 @@ export class StandardLogtoClient {
     const accessTokenKey = buildAccessTokenKey(resource, organizationId);
     const accessToken = this.accessTokenMap.get(accessTokenKey);
 
-    if (accessToken && accessToken.expiresAt > Date.now() / 1000) {
+    if (!options?.forceRefresh && accessToken && accessToken.expiresAt > Date.now() / 1000) {
       return accessToken.token;
     }
 
-    // Since the access token has expired, delete it from the map.
+    // Since the access token has expired (or a refresh is forced), delete it from the map.
     if (accessToken) {
       this.accessTokenMap.delete(accessTokenKey);
     }
@@ -554,17 +589,26 @@ export class StandardLogtoClient {
     return this.getAccessTokenByRefreshToken(resource, organizationId);
   }
 
-  async #getOrganizationToken(organizationId: string): Promise<string> {
+  async #getOrganizationToken(
+    organizationId: string,
+    options?: GetAccessTokenOptions
+  ): Promise<string> {
     if (!this.logtoConfig.scopes?.includes(UserScope.Organizations)) {
       throw new LogtoClientError('missing_scope_organizations');
     }
 
-    return this.getAccessToken(undefined, organizationId);
+    return this.getAccessToken(undefined, organizationId, options);
   }
 
-  async #clearAccessToken(): Promise<void> {
-    this.accessTokenMap.clear();
-    await this.adapter.storage.removeItem('accessToken');
+  async #clearAccessToken(resource?: string, organizationId?: string): Promise<void> {
+    if (resource === undefined && organizationId === undefined) {
+      this.accessTokenMap.clear();
+      await this.adapter.storage.removeItem('accessToken');
+      return;
+    }
+
+    this.accessTokenMap.delete(buildAccessTokenKey(resource, organizationId));
+    await this.saveAccessTokenMap();
   }
 
   async #clearAllTokens(): Promise<void> {

--- a/packages/client/src/index.token-cache.test.ts
+++ b/packages/client/src/index.token-cache.test.ts
@@ -1,0 +1,155 @@
+import { UserScope } from './index.js';
+import {
+  accessToken,
+  appId,
+  createAdapters,
+  createClient,
+  endpoint,
+  idToken,
+  LogtoClientWithAccessors,
+  MockedStorage,
+  refreshToken,
+  requester,
+  tokenEndpoint,
+} from './mock.js';
+import { buildAccessTokenKey } from './utils/index.js';
+
+describe('LogtoClient access token cache', () => {
+  describe('getAccessToken', () => {
+    it('should return the cached access token without hitting the token endpoint', async () => {
+      requester.mockClear();
+
+      const logtoClient = createClient(
+        undefined,
+        new MockedStorage({
+          idToken,
+          refreshToken,
+          accessToken: JSON.stringify({
+            [buildAccessTokenKey()]: {
+              token: 'cached_access_token_value',
+              scope: '',
+              expiresAt: Date.now() / 1000 + 3600,
+            },
+          }),
+        })
+      );
+
+      await expect(logtoClient.getAccessToken()).resolves.toEqual('cached_access_token_value');
+      expect(requester).not.toHaveBeenCalled();
+    });
+
+    it('should bypass the cache and exchange a new access token when `forceRefresh` is true', async () => {
+      requester.mockClear().mockImplementation(async () => ({
+        accessToken: 'new_access_token_value',
+        expiresIn: 3600,
+      }));
+
+      const logtoClient = createClient(
+        undefined,
+        new MockedStorage({
+          idToken,
+          refreshToken: 'refresh_token_value',
+          accessToken: JSON.stringify({
+            [buildAccessTokenKey()]: {
+              token: 'cached_access_token_value',
+              scope: '',
+              expiresAt: Date.now() / 1000 + 3600,
+            },
+          }),
+        })
+      );
+
+      await expect(
+        logtoClient.getAccessToken(undefined, undefined, { forceRefresh: true })
+      ).resolves.toEqual('new_access_token_value');
+      expect(requester).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getOrganizationToken', () => {
+    it('should bypass the cache and exchange a new organization token when `forceRefresh` is true', async () => {
+      requester.mockClear().mockImplementation(async () => ({
+        accessToken: 'new_organization_token_value',
+        expiresIn: 3600,
+      }));
+
+      const logtoClient = createClient(
+        undefined,
+        new MockedStorage({
+          idToken,
+          refreshToken: 'refresh_token_value',
+          accessToken: JSON.stringify({
+            [buildAccessTokenKey(undefined, 'organization_id')]: {
+              token: 'cached_organization_token_value',
+              scope: '',
+              expiresAt: Date.now() / 1000 + 3600,
+            },
+          }),
+        }),
+        undefined,
+        [UserScope.Organizations]
+      );
+
+      await expect(logtoClient.getOrganizationToken('organization_id')).resolves.toEqual(
+        'cached_organization_token_value'
+      );
+      expect(requester).not.toHaveBeenCalled();
+
+      await expect(
+        logtoClient.getOrganizationToken('organization_id', { forceRefresh: true })
+      ).resolves.toEqual('new_organization_token_value');
+      expect(requester).toHaveBeenCalledWith(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: 'app_id_value',
+          refresh_token: 'refresh_token_value',
+          grant_type: 'refresh_token',
+          organization_id: 'organization_id',
+        }).toString(),
+      });
+    });
+  });
+
+  describe('clearAccessToken', () => {
+    it('should only clear the matching access token when a key is specified', async () => {
+      const storage = new MockedStorage({
+        idToken,
+        refreshToken,
+        accessToken: JSON.stringify({
+          [buildAccessTokenKey()]: {
+            token: accessToken,
+            scope: '',
+            expiresAt: Date.now() / 1000 + 3600,
+          },
+          [buildAccessTokenKey(undefined, 'organization_id')]: {
+            token: 'organization_token_value',
+            scope: '',
+            expiresAt: Date.now() / 1000 + 3600,
+          },
+        }),
+      });
+      const logtoClient = new LogtoClientWithAccessors(
+        { endpoint, appId },
+        { ...createAdapters(), storage },
+        () => ({ verifyIdToken: vi.fn() })
+      );
+
+      // Wait for the initial `loadAccessTokenMap()` to settle.
+      await expect(logtoClient.getAccessToken()).resolves.toEqual(accessToken);
+
+      await logtoClient.clearAccessToken(undefined, 'organization_id');
+
+      const accessTokenMap = logtoClient.getAccessTokenMap();
+      expect(accessTokenMap.has(buildAccessTokenKey(undefined, 'organization_id'))).toBe(false);
+      expect(accessTokenMap.has(buildAccessTokenKey())).toBe(true);
+      await expect(storage.getItem('accessToken')).resolves.toEqual(
+        JSON.stringify({
+          [buildAccessTokenKey()]: accessTokenMap.get(buildAccessTokenKey()),
+        })
+      );
+    });
+  });
+});

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -19,6 +19,7 @@ export type {
   InteractionMode,
   LogtoErrorCode,
   UserInfoResponse,
+  GetAccessTokenOptions,
 } from '@logto/node';
 
 export default class LogtoClient extends BaseClient {

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -190,6 +190,11 @@ export const clearAccessToken = async (
  * this function can be used in React Server Components (RSC)
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.
  * When using server actions or API routes, we highly recommand to use the getAccessToken method
+ *
+ * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
+ * cached token and exchange a new one using the Refresh Token. Since the session is not writable
+ * here, the refreshed token will not be cached, so every call with `forceRefresh` performs a token
+ * exchange. Prefer server actions or API routes when you need the result to be persisted.
  */
 export const getAccessTokenRSC = async (
   config: LogtoNextConfig,
@@ -207,6 +212,11 @@ export const getAccessTokenRSC = async (
  * this function can be used in React Server Components (RSC)
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.
  * When using server actions or API routes, we highly recommand to use the getOrganizationToken method
+ *
+ * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
+ * cached token and exchange a new one using the Refresh Token. Since the session is not writable
+ * here, the refreshed token will not be cached, so every call with `forceRefresh` performs a token
+ * exchange. Prefer server actions or API routes when you need the result to be persisted.
  */
 export const getOrganizationTokenRSC = async (
   config: LogtoNextConfig,

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -191,20 +191,18 @@ export const clearAccessToken = async (
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.
  * When using server actions or API routes, we highly recommand to use the getAccessToken method
  *
- * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
- * cached token and exchange a new one using the Refresh Token. Since the session is not writable
- * here, the refreshed token will not be cached, so every call with `forceRefresh` performs a token
- * exchange. Prefer server actions or API routes when you need the result to be persisted.
+ * To force-refresh the token (e.g. to pick up updated organization scopes), use the
+ * {@link getAccessToken} server action or an API route instead. An RSC cannot write cookies, so a
+ * forced exchange here would drop the refreshed tokens and any rotated Refresh Token.
  */
 export const getAccessTokenRSC = async (
   config: LogtoNextConfig,
   resource?: string,
-  organizationId?: string,
-  options?: GetAccessTokenOptions
+  organizationId?: string
 ): Promise<string> => {
   const client = new LogtoClient(config);
   const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
-  return nodeClient.getAccessToken(resource, organizationId, options);
+  return nodeClient.getAccessToken(resource, organizationId);
 };
 
 /**
@@ -213,17 +211,16 @@ export const getAccessTokenRSC = async (
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.
  * When using server actions or API routes, we highly recommand to use the getOrganizationToken method
  *
- * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
- * cached token and exchange a new one using the Refresh Token. Since the session is not writable
- * here, the refreshed token will not be cached, so every call with `forceRefresh` performs a token
- * exchange. Prefer server actions or API routes when you need the result to be persisted.
+ * To force-refresh the token (e.g. to pick up updated organization scopes), use the
+ * {@link getOrganizationToken} server action or an API route instead. An RSC cannot write
+ * cookies, so a forced exchange here would drop the refreshed tokens and any rotated Refresh
+ * Token.
  */
 export const getOrganizationTokenRSC = async (
   config: LogtoNextConfig,
-  organizationId?: string,
-  options?: GetAccessTokenOptions
+  organizationId?: string
 ): Promise<string> => {
-  return getAccessTokenRSC(config, undefined, organizationId, options);
+  return getAccessTokenRSC(config, undefined, organizationId);
 };
 
 export { default } from './client';

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -2,6 +2,7 @@
 
 import {
   type LogtoContext,
+  type GetAccessTokenOptions,
   type GetContextParameters,
   type InteractionMode,
   type SignInOptions,
@@ -12,7 +13,7 @@ import type { LogtoNextConfig } from '../src/types.js';
 
 import LogtoClient from './client';
 
-export type { LogtoContext, InteractionMode } from '@logto/node';
+export type { LogtoContext, InteractionMode, GetAccessTokenOptions } from '@logto/node';
 
 /**
  * Init sign in process and redirect to the Logto sign-in page
@@ -128,15 +129,19 @@ export const getOrganizationTokens = async (config: LogtoNextConfig) => {
 /**
  * Get access token for the specified resource or organization,
  * this function can be used in server actions or API routes
+ *
+ * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
+ * cached token and exchange a new one using the Refresh Token.
  */
 export const getAccessToken = async (
   config: LogtoNextConfig,
   resource?: string,
-  organizationId?: string
+  organizationId?: string,
+  options?: GetAccessTokenOptions
 ): Promise<string> => {
   const client = new LogtoClient(config);
   const nodeClient = await client.createNodeClient();
-  const accessToken = await nodeClient.getAccessToken(resource, organizationId);
+  const accessToken = await nodeClient.getAccessToken(resource, organizationId, options);
 
   return accessToken;
 };
@@ -144,12 +149,40 @@ export const getAccessToken = async (
 /**
  * Get organization token from session,
  * this function can be used in server actions or API routes
+ *
+ * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to skip the
+ * cached token and exchange a new one using the Refresh Token. This is useful right after the
+ * user's organization roles have changed, so the updated organization scopes take effect
+ * immediately without a re-login.
  */
 export const getOrganizationToken = async (
   config: LogtoNextConfig,
-  organizationId?: string
+  organizationId?: string,
+  options?: GetAccessTokenOptions
 ): Promise<string> => {
-  return getAccessToken(config, undefined, organizationId);
+  return getAccessToken(config, undefined, organizationId, options);
+};
+
+/**
+ * Clear the cached access tokens in the session.
+ *
+ * - When neither `resource` nor `organizationId` is given, all the cached access tokens will be
+ *   cleared.
+ * - Otherwise, only the matching cached access token will be cleared.
+ *
+ * The next `getAccessToken()` / `getOrganizationToken()` call will then exchange a fresh token
+ * using the Refresh Token.
+ *
+ * This function can be used in server actions or API routes, where cookies are writable.
+ */
+export const clearAccessToken = async (
+  config: LogtoNextConfig,
+  resource?: string,
+  organizationId?: string
+): Promise<void> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient();
+  await nodeClient.clearAccessToken(resource, organizationId);
 };
 
 /**
@@ -161,11 +194,12 @@ export const getOrganizationToken = async (
 export const getAccessTokenRSC = async (
   config: LogtoNextConfig,
   resource?: string,
-  organizationId?: string
+  organizationId?: string,
+  options?: GetAccessTokenOptions
 ): Promise<string> => {
   const client = new LogtoClient(config);
   const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
-  return nodeClient.getAccessToken(resource, organizationId);
+  return nodeClient.getAccessToken(resource, organizationId, options);
 };
 
 /**
@@ -176,9 +210,10 @@ export const getAccessTokenRSC = async (
  */
 export const getOrganizationTokenRSC = async (
   config: LogtoNextConfig,
-  organizationId?: string
+  organizationId?: string,
+  options?: GetAccessTokenOptions
 ): Promise<string> => {
-  return getAccessTokenRSC(config, undefined, organizationId);
+  return getAccessTokenRSC(config, undefined, organizationId, options);
 };
 
 export { default } from './client';

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -24,6 +24,7 @@ const signOut = vi.fn();
 const getContext = vi.fn(async () => true);
 const getAccessToken = vi.fn();
 const getOrganizationToken = vi.fn();
+const clearAccessToken = vi.fn();
 
 const mockResponse = (_: unknown, response: NextApiResponse) => {
   response.status(200).end();
@@ -54,6 +55,7 @@ vi.mock('@logto/node', async (importOriginal) => ({
     getContext,
     getAccessToken,
     getOrganizationToken,
+    clearAccessToken,
     getIdTokenClaims,
     signOut: () => {
       navigate(configs.baseUrl);
@@ -150,7 +152,24 @@ describe('Next', () => {
         url: '/api/logto/get-access-token',
         test: async ({ fetch }) => {
           await fetch({ method: 'GET' });
-          expect(getAccessToken).toHaveBeenCalledWith('resource');
+          expect(getAccessToken).toHaveBeenCalledWith('resource', undefined, undefined);
+        },
+      });
+    });
+
+    it('should pass the `forceRefresh` option through', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.getAccessToken(request, response, 'resource', { forceRefresh: true });
+          response.end();
+        },
+        url: '/api/logto/get-access-token',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(getAccessToken).toHaveBeenCalledWith('resource', undefined, {
+            forceRefresh: true,
+          });
         },
       });
     });
@@ -167,7 +186,58 @@ describe('Next', () => {
         url: '/api/logto/get-access-token',
         test: async ({ fetch }) => {
           await fetch({ method: 'GET' });
-          expect(getOrganizationToken).toHaveBeenCalledWith('organization_id');
+          expect(getOrganizationToken).toHaveBeenCalledWith('organization_id', undefined);
+        },
+      });
+    });
+
+    it('should pass the `forceRefresh` option through', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.getOrganizationToken(request, response, 'organization_id', {
+            forceRefresh: true,
+          });
+          response.end();
+        },
+        url: '/api/logto/get-access-token',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(getOrganizationToken).toHaveBeenCalledWith('organization_id', {
+            forceRefresh: true,
+          });
+        },
+      });
+    });
+  });
+
+  describe('clearAccessToken', () => {
+    it('should clear all the cached access tokens by default', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.clearAccessToken(request, response);
+          response.end();
+        },
+        url: '/api/logto/clear-access-token',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(clearAccessToken).toHaveBeenCalledWith(undefined, undefined);
+        },
+      });
+    });
+
+    it('should clear the cached token of the given organization', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.clearAccessToken(request, response, undefined, 'organization_id');
+          response.end();
+        },
+        url: '/api/logto/clear-access-token',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(clearAccessToken).toHaveBeenCalledWith(undefined, 'organization_id');
         },
       });
     });

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -3,6 +3,7 @@ import { type IncomingMessage, type ServerResponse } from 'node:http';
 import NodeClient, {
   CookieStorage,
   type SignInOptions,
+  type GetAccessTokenOptions,
   type GetContextParameters,
   type InteractionMode,
 } from '@logto/node';
@@ -46,6 +47,7 @@ export type {
   UserInfoResponse,
   SessionWrapper,
   SessionData,
+  GetAccessTokenOptions,
 } from '@logto/node';
 
 export default class LogtoClient extends LogtoNextBaseClient {
@@ -166,22 +168,57 @@ export default class LogtoClient extends LogtoNextBaseClient {
       response.status(404).end();
     };
 
+  /**
+   * Get an access token for the given resource.
+   *
+   * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to bypass the
+   * cached token and exchange a new one using the Refresh Token.
+   */
   getAccessToken = async (
     request: NextApiRequest,
     response: NextApiResponse,
-    resource: string
+    resource: string,
+    options?: GetAccessTokenOptions
   ): Promise<string> => {
     const nodeClient = await this.createNodeClientFromNextApi(request, response);
-    return nodeClient.getAccessToken(resource);
+    return nodeClient.getAccessToken(resource, undefined, options);
   };
 
+  /**
+   * Get an organization token for the given organization.
+   *
+   * @param options See {@link GetAccessTokenOptions}. Pass `{ forceRefresh: true }` to bypass the
+   * cached token and exchange a new one using the Refresh Token. This is useful right after the
+   * user's organization roles have changed, so the updated scopes take effect immediately.
+   */
   getOrganizationToken = async (
     request: NextApiRequest,
     response: NextApiResponse,
-    organizationId: string
+    organizationId: string,
+    options?: GetAccessTokenOptions
   ): Promise<string> => {
     const nodeClient = await this.createNodeClientFromNextApi(request, response);
-    return nodeClient.getOrganizationToken(organizationId);
+    return nodeClient.getOrganizationToken(organizationId, options);
+  };
+
+  /**
+   * Clear the cached access tokens in the session.
+   *
+   * - When neither `resource` nor `organizationId` is given, all the cached access tokens will
+   *   be cleared.
+   * - Otherwise, only the matching cached access token will be cleared.
+   *
+   * The next `getAccessToken()` / `getOrganizationToken()` call will then exchange a fresh token
+   * using the Refresh Token.
+   */
+  clearAccessToken = async (
+    request: NextApiRequest,
+    response: NextApiResponse,
+    resource?: string,
+    organizationId?: string
+  ): Promise<void> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    await nodeClient.clearAccessToken(resource, organizationId);
   };
 
   withLogtoApiRoute = (

--- a/packages/node/src/exports.ts
+++ b/packages/node/src/exports.ts
@@ -16,6 +16,7 @@ export type {
   JwtVerifier,
   UserInfoResponse,
   SignInOptions,
+  GetAccessTokenOptions,
 } from '@logto/client';
 
 export {


### PR DESCRIPTION
## Problem

Reported by a user building multi-tenant org RBAC on `@logto/next` (App Router):

> The organization owner promotes this user from Interviewer to Admin. The user refreshes the browser. We call `getOrganizationToken()` again. The returned Organization Token is **identical** to the previous one and still contains the old scopes. Only after signing out and signing back in do we receive a new Organization Token with the updated scopes.

They observed the same in the opposite direction (demotion), and asked whether there is a supported way to force a refresh-token exchange from the official Next.js SDK.

## Root cause

This is purely a client-side caching gap, not an OAuth or server limitation.

**Server side is already correct.** In `logto-io/logto`, the `refresh_token` grant re-reads the user's organization scopes from the database on *every* exchange (`packages/core/src/oidc/grants/refresh-token.ts`):

```ts
if (organizationId && !params.resource) {
  const availableScopes = await queries.organizations.relations.usersRoles
    .getUserScopes(organizationId, account.accountId)
    .then((scopes) => scopes.map(({ name }) => name));
  await handleOrganizationToken({ envSet, availableScopes, accessToken: at, organizationId, scope });
}
```

`handleOrganizationToken` then issues `availableScopes ∩ scope`, where `scope` falls back to the refresh token's original scope set. So promotions *and* demotions are reflected immediately in a newly exchanged organization token — **no re-login required**, as long as the permission was part of the original authorization request.

**Client side never gets there.** `StandardLogtoClient.#getAccessToken` short-circuits on any unexpired cached token:

```ts
const accessToken = this.accessTokenMap.get(accessTokenKey);

if (accessToken && accessToken.expiresAt > Date.now() / 1000) {
  return accessToken.token;   // never reaches the refresh grant
}
```

In `@logto/next` the `accessTokenMap` is persisted into the encrypted session cookie via `CookieStorage`, so the same token survives page reloads and new server processes — which is why the user saw a byte-identical token. Organization tokens have a fixed 1h TTL (`reversedResourceAccessTokenTtl = 3600`), so the stale window is up to an hour. Sign-in/sign-out appear to "fix" it only because both call `clearAllTokens()` internally.

`@logto/client` does have `clearAccessToken()` / `clearAllTokens()`, and `@logto/react` / `@logto/vue` proxy them — but `@logto/next` exposes neither, so App Router users have no supported escape hatch.

## Changes

`@logto/client`:

- New `GetAccessTokenOptions` type. `getAccessToken(resource?, organizationId?, options?)` and `getOrganizationToken(organizationId, options?)` accept `{ forceRefresh: true }` to skip the cache and always exchange a new token with the Refresh Token.
- `clearAccessToken(resource?, organizationId?)` can now evict a single cached token instead of all of them. Called with no arguments it keeps the existing "clear everything" behavior.

`@logto/next`:

- Pages Router: `getAccessToken` / `getOrganizationToken` take the new `options`, plus a new `clearAccessToken(request, response, resource?, organizationId?)`.
- Server actions: `getAccessToken` / `getOrganizationToken` take the new `options`, plus a new `clearAccessToken(config, resource?, organizationId?)`. The RSC helpers (`getAccessTokenRSC` / `getOrganizationTokenRSC`) intentionally do not accept `options`: an RSC cannot write cookies, so a forced exchange there would drop the rotated Refresh Token. Use a server action or route handler to force-refresh.
- Edge runtime re-exports the new type.

`@logto/node` re-exports `GetAccessTokenOptions`.

Every addition is an optional parameter, so this is fully backward compatible.

## Usage

```ts
'use server';

import { getOrganizationToken, clearAccessToken } from '@logto/next/server-actions';

// Right after promoting/demoting a member — pick up the new scopes immediately:
const token = await getOrganizationToken(logtoConfig, organizationId, { forceRefresh: true });

// Or evict the cache so the next read refreshes:
await clearAccessToken(logtoConfig, undefined, organizationId);
```

Note this must run in a Server Action or Route Handler, not an RSC, so the refreshed token and any rotated refresh token can be written back to the session cookie.

Note also that a token can still only carry scopes present in the original authorization request. Introducing a brand new scope continues to require a new authorization request, e.g. `signIn({ prompt: 'consent' })`.

## Tests

- New `packages/client/src/index.token-cache.test.ts`: asserts the cache is honored by default, that `forceRefresh` bypasses it for both access tokens and organization tokens (verifying the `organization_id` refresh-token request body), and that a targeted `clearAccessToken` evicts only the matching entry while persisting the rest.
- `packages/next/src/index.test.ts`: option pass-through for `getAccessToken` / `getOrganizationToken`, and coverage for the new `clearAccessToken`.

`@logto/client` (79), `@logto/node` (43), `@logto/next` (31) all pass; `tsc --noEmit` and `eslint` are clean across the workspace.
