### PR TITLE
fix(client): retry OIDC discovery after a failed request

### DIFF
--- a/.changeset/retry-failed-oidc-discovery.md
+++ b/.changeset/retry-failed-oidc-discovery.md
@@ -1,0 +1,9 @@
+---
+'@logto/client': patch
+---
+
+retry OIDC discovery after a failed request instead of failing for the client's lifetime
+
+The discovery result was cached by a plain `once()`, which has no rejection path, so a rejected promise was memoized permanently and replayed to every later caller. If the very first discovery of a client failed (for example, the app started while offline), every operation that needs the OpenID configuration — `getAccessToken`, `getOrganizationToken`, `fetchUserInfo`, `signIn`, `signOut` and ID token verification — kept failing with the original error and no further network request was ever made. Recovering required constructing a new client, which in a browser app means a page reload.
+
+The successful path is unchanged: discovery is still fetched at most once per client.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -35,7 +35,7 @@ import {
 } from './types/index.js';
 import { buildAccessTokenKey, getDiscoveryEndpoint } from './utils/index.js';
 import { memoize } from './utils/memoize.js';
-import { once } from './utils/once.js';
+import { onceAsync } from './utils/once.js';
 
 export type SignInOptions = {
   /**
@@ -77,9 +77,10 @@ export class StandardLogtoClient {
   readonly logtoConfig: LogtoConfig;
   /**
    * Get the OIDC configuration from the discovery endpoint. This method will
-   * only fetch the configuration once and cache the result.
+   * only fetch the configuration once and cache the result. If the fetch fails, the next call will
+   * retry it.
    */
-  readonly getOidcConfig: () => Promise<OidcConfigResponse> = once(this.#getOidcConfig);
+  readonly getOidcConfig: () => Promise<OidcConfigResponse> = onceAsync(this.#getOidcConfig);
   /**
    * Get the access token from the storage with refresh strategy.
    *

--- a/packages/client/src/index.cache.test.ts
+++ b/packages/client/src/index.cache.test.ts
@@ -21,4 +21,17 @@ describe('LogtoClient cache', () => {
     expect(fetchOidcConfig).toHaveBeenCalledTimes(1);
     expect(config3).toBe(config4);
   });
+
+  it('should retry fetching OpenID config after a failure', async () => {
+    fetchOidcConfig.mockClear();
+    fetchOidcConfig.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const logtoClient = createClient();
+
+    await expect(logtoClient.runGetOidcConfig()).rejects.toThrow('Failed to fetch');
+    expect(fetchOidcConfig).toHaveBeenCalledTimes(1);
+
+    await expect(logtoClient.runGetOidcConfig()).resolves.toHaveProperty('tokenEndpoint');
+    expect(fetchOidcConfig).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/client/src/utils/once.test.ts
+++ b/packages/client/src/utils/once.test.ts
@@ -1,0 +1,56 @@
+import { onceAsync } from './once.js';
+
+describe('onceAsync', () => {
+  it('should run the function only once and share the result', async () => {
+    const run = vi.fn(async () => 'foo');
+    const wrapped = onceAsync(run);
+
+    const [result1, result2] = await Promise.all([wrapped(), wrapped()]);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(result1).toBe('foo');
+    expect(result2).toBe('foo');
+
+    await expect(wrapped()).resolves.toBe('foo');
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry after a rejection instead of replaying it', async () => {
+    const run = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValue('foo');
+    const wrapped = onceAsync(run);
+
+    await expect(wrapped()).rejects.toThrow('Failed to fetch');
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await expect(wrapped()).resolves.toBe('foo');
+    expect(run).toHaveBeenCalledTimes(2);
+
+    // The successful result should be cached again.
+    await expect(wrapped()).resolves.toBe('foo');
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('should share the same rejection between concurrent callers', async () => {
+    const run = vi.fn(async () => {
+      throw new Error('Failed to fetch');
+    });
+    const wrapped = onceAsync(run);
+
+    const results = await Promise.allSettled([wrapped(), wrapped()]);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(results.every(({ status }) => status === 'rejected')).toBe(true);
+  });
+
+  it('should pass arguments and `this` to the wrapped function', async () => {
+    const run = vi.fn(async function (this: unknown, value: string) {
+      return { self: this, value };
+    });
+    const object = { wrapped: onceAsync(run) };
+
+    await expect(object.wrapped('foo')).resolves.toStrictEqual({ self: object, value: 'foo' });
+  });
+});

--- a/packages/client/src/utils/once.ts
+++ b/packages/client/src/utils/once.ts
@@ -1,19 +1,33 @@
-type Procedure<T> = (...args: unknown[]) => T;
-
-// TODO @sijie move to essentials
 /* eslint-disable @silverhand/fp/no-let */
 /* eslint-disable @silverhand/fp/no-mutation */
-export function once<T>(function_: Procedure<T>): Procedure<T> {
-  let called = false;
-  let result: T;
+/**
+ * Run the given async function at most once and cache its promise, so that all callers share the
+ * same result.
+ *
+ * Unlike a plain `once()`, the cache is cleared when the promise rejects. Otherwise a single
+ * failure (e.g. the device was offline when the function was first called) would be replayed to
+ * every later caller for the lifetime of the cache, with no way to recover.
+ */
+export function onceAsync<Args extends unknown[], Return>(
+  run: (...args: Args) => Promise<Return>
+): (...args: Args) => Promise<Return> {
+  let cached: Promise<Return> | undefined;
 
-  return function (this: unknown, ...args: unknown[]) {
-    if (!called) {
-      called = true;
-      result = function_.apply(this, args);
+  return async function (this: unknown, ...args: Args): Promise<Return> {
+    const promise = cached ?? run.apply(this, args);
+    cached = promise;
+
+    try {
+      return await promise;
+    } catch (error: unknown) {
+      // Allow the next caller to retry instead of replaying this failure forever. The identity
+      // check keeps a newer promise (started by another caller) intact.
+      if (cached === promise) {
+        cached = undefined;
+      }
+
+      throw error;
     }
-
-    return result;
   };
 }
 /* eslint-enable @silverhand/fp/no-mutation */


### PR DESCRIPTION
## Summary

Fixes #1160.

`getOidcConfig` is wrapped by `once()`, which has no rejection path:

```ts
readonly getOidcConfig: () => Promise<OidcConfigResponse> = once(this.#getOidcConfig);
```

`#getOidcConfig` is `async`, so the memoized `result` is a promise. When it rejects, the rejected promise stays cached for the lifetime of the client and is replayed to every later caller, with no further network request. A client whose *first* discovery fails — for example an app that starts while offline — can never recover; the user has to construct a new client, which in a browser app means a page reload.

The blast radius is every call that reads the OpenID configuration: `getAccessToken` and `getOrganizationToken` (`tokenEndpoint`), `fetchUserInfo` (`userinfoEndpoint`), `signIn` (`authorizationEndpoint`), `signOut` (`endSessionEndpoint`, `revocationEndpoint`) and the default JWT verifier (`issuer`, `jwksUri`). In `@logto/react` the rejection is converted to `undefined` and the context `error` is frozen at the original failure, so the app looks signed in and loads nothing.

Note that the rest of the client is already correct here: `getAccessToken`, `clearAccessToken` and `handleSignInCallback` use `utils/memoize.ts`, which drops the cache entry in a `finally`, and `ClientAdapter.getWithCache` also falls through and retries when an in-flight getter rejects. `getOidcConfig` was the only caller of `once` in the repository.

## Changes

- Replace `once` with `onceAsync` in `utils/once.ts`: the cached promise is cleared when it rejects, so the next caller retries. An identity check avoids clearing a newer promise started by another caller in the meantime.
- Point `getOidcConfig` at `onceAsync`.

`memoize` was deliberately not reused here: it deletes the entry once the promise settles, which would turn "one discovery per client" into "one discovery per call" whenever `unstable_cache` is not enabled. This change only touches the failure path — on success, discovery is still fetched at most once per client.

## Testing

Unit tests.

- `packages/client/src/index.cache.test.ts`: a client whose first discovery rejects retries on the next call and succeeds. This test fails on `master` (`promise rejected "TypeError: Failed to fetch" instead of resolving`) and passes with the fix.
- `packages/client/src/utils/once.test.ts`: covers `onceAsync` directly — single run on the happy path, retry after rejection, shared rejection between concurrent callers, and argument/`this` forwarding.
