### PR TITLE
feat(angular): rebuild SDK on browser client

### DIFF
--- a/.changeset/major-dolls-repeat.md
+++ b/.changeset/major-dolls-repeat.md
@@ -1,0 +1,5 @@
+---
+"@logto/angular": major
+---
+
+rebuild the Angular SDK on the Logto Browser client

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,3 +1,128 @@
-# Logto Angular helper
+# Logto Angular SDK
 
-This package provides a helper for Angular to use Logto.
+The Logto SDK for Angular applications. It is built on `@logto/browser` and exposes Angular-native dependency injection and Signals.
+
+## Installation
+
+```sh
+pnpm add @logto/angular
+```
+
+## Configuration
+
+Register Logto in the application config:
+
+```ts
+import { type ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideLogto, UserScope } from '@logto/angular';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideLogto({
+      endpoint: 'https://your-tenant.logto.app',
+      appId: 'your-app-id',
+      scopes: [UserScope.Email, UserScope.Organizations],
+      resources: ['https://api.example.com'],
+    }),
+    provideRouter(routes),
+  ],
+};
+```
+
+## Sign in and sign out
+
+Inject `LogtoService` and read its Signals directly from the template:
+
+```ts
+import { Component, inject } from '@angular/core';
+import { LogtoService } from '@logto/angular';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    @if (logto.isLoading()) {
+    <p>Loading…</p>
+    } @else if (logto.isAuthenticated()) {
+    <button type="button" (click)="signOut()">Sign out</button>
+    } @else {
+    <button type="button" (click)="signIn()">Sign in</button>
+    }
+  `,
+})
+export class AppComponent {
+  readonly logto = inject(LogtoService);
+
+  async signIn() {
+    await this.logto.signIn({
+      redirectUri: `${window.location.origin}/callback`,
+      postRedirectUri: window.location.origin,
+    });
+  }
+
+  async signOut() {
+    await this.logto.signOut(window.location.origin);
+  }
+}
+```
+
+## Handle the callback
+
+Register a dedicated callback route and complete the sign-in flow after browser rendering:
+
+```ts
+import { afterNextRender, Component, inject } from '@angular/core';
+import { LogtoService } from '@logto/angular';
+
+@Component({
+  standalone: true,
+  template: '<p>Completing sign-in…</p>',
+})
+export class CallbackComponent {
+  private readonly logto = inject(LogtoService);
+
+  constructor() {
+    afterNextRender(() => {
+      void this.logto.handleSignInCallback(window.location.href).catch(() => undefined);
+    });
+  }
+}
+```
+
+`LogtoService` also exposes resource-aware access tokens, organization tokens, ID-token claims, userinfo, token clearing, and an `error` Signal. See the [Angular sample](../angular-sample/) for a complete integration.
+
+## Server-side rendering
+
+Authentication state is restored from browser storage after the first browser render. Tokens are not exposed during server rendering. Use a server or BFF SDK when authenticated data is required while rendering on the server.
+
+## Migrating from v1
+
+Version 2 replaces the `angular-auth-oidc-client` configuration helper with a first-party Logto SDK:
+
+- Replace `provideAuth({ config: buildAngularAuthConfig(...) })` with `provideLogto(...)`.
+- Replace `OidcSecurityService` with `LogtoService`.
+- Pass redirect URIs to `signIn()` and `signOut()` instead of provider configuration.
+- Add a callback route that calls `handleSignInCallback()`.
+- Read `isLoading()`, `isAuthenticated()`, and `error()` Signals instead of subscribing to `checkAuth()`.
+
+Version 1 accepted only one `resource` string. Applications that needed multiple resources sometimes used a comma-separated workaround:
+
+```ts
+buildAngularAuthConfig({
+  // ...
+  resource: 'com.company.resource1,com.company.resource2',
+});
+```
+
+Version 2 supports the Logto resource array directly. Replace the workaround with separate array entries:
+
+```ts
+provideLogto({
+  // ...
+  resources: ['com.company.resource1', 'com.company.resource2'],
+});
+```
+
+Existing third-party session data is not migrated; users need to sign in once after upgrading.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -85,7 +85,13 @@ export class CallbackComponent {
 
   constructor() {
     afterNextRender(() => {
-      void this.logto.handleSignInCallback(window.location.href).catch(() => undefined);
+      void (async () => {
+        const callbackUri = window.location.href;
+
+        if (await this.logto.isSignInRedirected(callbackUri)) {
+          await this.logto.handleSignInCallback(callbackUri);
+        }
+      })().catch(() => undefined);
     });
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,30 +23,27 @@
     "precommit": "lint-staged",
     "check": "tsc --noEmit",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json --noEmit && rollup -c",
-    "lint": "eslint --ext .ts --ext .tsx src",
-    "prepack": "pnpm build"
+    "lint": "eslint --ext .ts src",
+    "test": "vitest",
+    "test:coverage": "vitest --silent --coverage",
+    "prepack": "pnpm build && pnpm test"
   },
   "dependencies": {
-    "@logto/js": "workspace:^",
-    "@silverhand/essentials": "^2.9.3"
+    "@logto/browser": "workspace:^"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^6.0.1",
-    "@silverhand/eslint-config-react": "^6.0.2",
     "@silverhand/ts-config": "^6.0.0",
-    "@silverhand/ts-config-react": "^6.0.0",
-    "angular-auth-oidc-client": "^20.0.3",
+    "@vitest/coverage-v8": "3.2.6",
     "eslint": "^8.57.0",
+    "happy-dom": "^20.0.8",
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "typescript": "^5.3.3",
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "rxjs": "^6.5.3 || ^7.4.0",
-    "@angular/core": "^20.0.0",
-    "@angular/common": "^20.0.0",
-    "@angular/router": "^20.0.0"
+    "@angular/core": "^20.0.0"
   },
   "eslintConfig": {
     "extends": "@silverhand"

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,167 +1,32 @@
-import { Prompt, QueryKey, type SignInUriParameters, withReservedScopes } from '@logto/js';
-import { conditional } from '@silverhand/essentials';
-import { type OpenIdConfiguration } from 'angular-auth-oidc-client';
+export type {
+  AccessTokenClaims,
+  ClientAdapter,
+  IdTokenClaims,
+  InteractionMode,
+  LogtoClientErrorCode,
+  LogtoConfig,
+  LogtoErrorCode,
+  SignInOptions,
+  Storage,
+  UserInfoResponse,
+} from '@logto/browser';
 
-/** The Logto configuration object for Angular apps. */
-export type LogtoAngularConfig = {
-  /**
-   * The endpoint for the Logto server, you can get it from the integration guide
-   * or the team settings page of the Logto Console.
-   *
-   * @example https://foo.logto.app
-   */
-  endpoint: string;
-  /**
-   * The client ID of your application, you can get it from the integration guide
-   * or the application details page of the Logto Console.
-   */
-  appId: string;
-  /**
-   * The scopes (permissions) that your application needs to access.
-   * Scopes that will be added by default: `openid`, `offline_access` and `profile`.
-   */
-  scopes?: string[];
-  /**
-   * The API resource that your application needs to access.
-   *
-   * @see {@link https://docs.logto.io/docs/recipes/rbac/ | RBAC} to learn more about how to use
-   * role-based access control (RBAC) to protect API resources.
-   */
-  resource?: string;
-  /**
-   * @param redirectUri The redirect URI that the user will be redirected to after the sign-in flow
-   * is completed.
-   */
-  redirectUri: string;
-  /**
-   * @param postLogoutRedirectUri The URI that the user will be redirected to after the sign-out
-   * flow is completed.
-   */
-  postLogoutRedirectUri?: string;
-  /**
-   * The prompt parameter to be used for the authorization request.
-   *
-   * @default Prompt.Consent
-   */
-  prompt?: Prompt | Prompt[];
-  /**
-   * Whether to include reserved scopes (`openid`, `offline_access` and `profile`) in the scopes.
-   *
-   * @default true
-   */
-  includeReservedScopes?: boolean;
-  /**
-   * Login hint indicates the current user (usually an email address or a phone number).
-   *
-   * @link SignInUriParameters.loginHint
-   */
-  loginHint?: SignInUriParameters['loginHint'];
-  /**
-   * The first screen to be shown in the sign-in experience.
-   *
-   * @link SignInUriParameters.firstScreen
-   */
-  firstScreen?: SignInUriParameters['firstScreen'];
-  /**
-   * Identifiers used in the identifier sign-in, identifier register or reset password pages.
-   *
-   * Note: This parameter is applicable only when the `firstScreen` is set to either`identifierSignIn`
-   * or `identifierRegister`.
-   *
-   * @link SignInUriParameters.identifiers
-   */
-  identifiers?: SignInUriParameters['identifiers'];
-  /**
-   * Direct sign-in options.
-   *
-   * @link SignInUriParameters.directSignIn
-   */
-  directSignIn?: SignInUriParameters['directSignIn'];
-  /**
-   * Extra parameters to be appended to the sign-in URI.
-   *
-   * Note: The parameters should be supported by the authorization server.
-   *
-   * @link SignInUriParameters.extraParams
-   */
-  extraParams?: SignInUriParameters['extraParams'];
-};
+export {
+  BrowserStorage,
+  LogtoClientError,
+  LogtoError,
+  LogtoRequestError,
+  OidcError,
+  PersistKey,
+  Prompt,
+  ReservedResource,
+  ReservedScope,
+  UserScope,
+  buildOrganizationUrn,
+  getOrganizationIdFromUrn,
+  isLogtoRequestError,
+  organizationUrnPrefix,
+} from '@logto/browser';
 
-/**
- * A helper function to build the OpenID Connect configuration for `angular-auth-oidc-client`
- * using a Logto-friendly way.
- *
- * @example
- * ```ts
- * // A minimal example
- * import { buildAngularAuthConfig } from '@logto/js';
- * import { provideAuth } from 'angular-auth-oidc-client';
- *
- * provideAuth({
- *   config: buildAngularAuthConfig({
- *     endpoint: '<your-logto-endpoint>',
- *     appId: '<your-app-id>',
- *     redirectUri: '<your-app-redirect-uri>',
- *   }),
- * });
- * ```
- *
- * @param logtoConfig The Logto configuration object for Angular apps.
- * @returns The OpenID Connect configuration for `angular-auth-oidc-client`.
- * @see {@link https://angular-auth-oidc-client.com/ | angular-auth-oidc-client} to learn more
- * about how to use the library.
- */
-export const buildAngularAuthConfig = (logtoConfig: LogtoAngularConfig): OpenIdConfiguration => {
-  const {
-    endpoint,
-    appId: clientId,
-    scopes,
-    resource,
-    redirectUri: redirectUrl,
-    postLogoutRedirectUri,
-    prompt = Prompt.Consent,
-    includeReservedScopes = true,
-    loginHint,
-    identifiers,
-    firstScreen,
-    directSignIn,
-    extraParams,
-  } = logtoConfig;
-  const scope = includeReservedScopes ? withReservedScopes(scopes) : scopes?.join(' ');
-  const customParameters = {
-    ...conditional(resource && { [QueryKey.Resource]: resource }),
-    ...conditional(loginHint && { [QueryKey.LoginHint]: loginHint }),
-    ...conditional(firstScreen && { [QueryKey.FirstScreen]: firstScreen }),
-    ...conditional(identifiers && { [QueryKey.Identifier]: identifiers.join(' ') }),
-    ...conditional(
-      directSignIn && { [QueryKey.DirectSignIn]: `${directSignIn.method}:${directSignIn.target}` }
-    ),
-    ...extraParams,
-  };
-
-  return {
-    authority: new URL('/oidc', endpoint).href,
-    redirectUrl,
-    postLogoutRedirectUri,
-    clientId,
-    scope,
-    responseType: 'code',
-    autoUserInfo: !resource,
-    renewUserInfoAfterTokenRenew: !resource,
-    silentRenew: true,
-    useRefreshToken: true,
-    customParamsAuthRequest: {
-      prompt: Array.isArray(prompt) ? prompt.join(' ') : prompt,
-      ...customParameters,
-    },
-    customParamsCodeRequest: {
-      ...customParameters,
-    },
-    customParamsRefreshTokenRequest: {
-      ...customParameters,
-    },
-  };
-};
-
-export type { UserInfoResponse } from '@logto/js';
-export { UserScope } from '@logto/js';
+export { LOGTO_CLIENT, provideLogto, type LogtoAngularOptions } from './provider.js';
+export { LogtoService } from './service.js';

--- a/packages/angular/src/provider.test.ts
+++ b/packages/angular/src/provider.test.ts
@@ -1,0 +1,75 @@
+import {
+  APP_INITIALIZER,
+  createEnvironmentInjector,
+  platformCore,
+  type EnvironmentInjector,
+  type Provider,
+} from '@angular/core';
+import LogtoClient from '@logto/browser';
+
+import { LOGTO_CLIENT, provideLogto } from './provider.js';
+import { LogtoService } from './service.js';
+
+const config = {
+  endpoint: 'https://logto.example',
+  appId: 'app-id',
+};
+
+const platform = platformCore();
+const platformInjector = platform.injector as EnvironmentInjector;
+const createInjector = (additionalProviders: Provider[] = []) =>
+  createEnvironmentInjector(
+    [provideLogto(config, { unstable_enableCache: true }), ...additionalProviders],
+    platformInjector
+  );
+
+describe('provideLogto', () => {
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterAll(() => {
+    platform.destroy();
+  });
+
+  it('provides singleton client and service instances with the configured cache', () => {
+    const injector = createInjector();
+    const client = injector.get(LOGTO_CLIENT);
+    const service = injector.get(LogtoService);
+
+    expect(client).toBeInstanceOf(LogtoClient);
+    expect(client.logtoConfig).toMatchObject(config);
+    expect(client.adapter.unstable_cache).toBeDefined();
+    expect(injector.get(LOGTO_CLIENT)).toBe(client);
+    expect(injector.get(LogtoService)).toBe(service);
+    injector.destroy();
+  });
+
+  it('uses an Angular DI override for the underlying client', async () => {
+    const isAuthenticated = vi.fn(async () => true);
+    const client = { isAuthenticated } as unknown as LogtoClient;
+    const injector = createInjector([{ provide: LOGTO_CLIENT, useValue: client }]);
+
+    const service = injector.get(LogtoService);
+    await service.initialize();
+
+    expect(injector.get(LOGTO_CLIENT)).toBe(client);
+    expect(isAuthenticated).toHaveBeenCalledTimes(1);
+    expect(service.isAuthenticated()).toBe(true);
+    injector.destroy();
+  });
+
+  it('registers non-blocking browser initialization with Angular', () => {
+    const isAuthenticated = vi.fn(async () => true);
+    const client = { isAuthenticated } as unknown as LogtoClient;
+    const injector = createInjector([{ provide: LOGTO_CLIENT, useValue: client }]);
+
+    const initializers = injector.get(APP_INITIALIZER);
+
+    expect(initializers).toHaveLength(1);
+    expect(isAuthenticated).not.toHaveBeenCalled();
+    expect(injector.get(LogtoService).isLoading()).toBe(true);
+    injector.destroy();
+  });
+});

--- a/packages/angular/src/provider.test.ts
+++ b/packages/angular/src/provider.test.ts
@@ -2,8 +2,12 @@ import {
   APP_INITIALIZER,
   createEnvironmentInjector,
   platformCore,
+  provideZonelessChangeDetection,
+  runInInjectionContext,
   type EnvironmentInjector,
   type Provider,
+  ɵAfterRenderManager,
+  ɵINJECTOR_SCOPE,
 } from '@angular/core';
 import LogtoClient from '@logto/browser';
 
@@ -19,7 +23,12 @@ const platform = platformCore();
 const platformInjector = platform.injector as EnvironmentInjector;
 const createInjector = (additionalProviders: Provider[] = []) =>
   createEnvironmentInjector(
-    [provideLogto(config, { unstable_enableCache: true }), ...additionalProviders],
+    [
+      { provide: ɵINJECTOR_SCOPE, useValue: 'root' },
+      provideZonelessChangeDetection(),
+      provideLogto(config, { unstable_enableCache: true }),
+      ...additionalProviders,
+    ],
     platformInjector
   );
 
@@ -60,16 +69,28 @@ describe('provideLogto', () => {
     injector.destroy();
   });
 
-  it('registers non-blocking browser initialization with Angular', () => {
+  it('initializes after the first browser render without blocking app initialization', async () => {
     const isAuthenticated = vi.fn(async () => true);
     const client = { isAuthenticated } as unknown as LogtoClient;
     const injector = createInjector([{ provide: LOGTO_CLIENT, useValue: client }]);
 
     const initializers = injector.get(APP_INITIALIZER);
+    const service = injector.get(LogtoService);
 
     expect(initializers).toHaveLength(1);
     expect(isAuthenticated).not.toHaveBeenCalled();
-    expect(injector.get(LogtoService).isLoading()).toBe(true);
+    expect(service.isLoading()).toBe(true);
+
+    await runInInjectionContext(injector, async () => initializers[0]?.());
+
+    expect(isAuthenticated).not.toHaveBeenCalled();
+    injector.get(ɵAfterRenderManager).execute();
+
+    await vi.waitFor(() => {
+      expect(isAuthenticated).toHaveBeenCalledTimes(1);
+      expect(service.isAuthenticated()).toBe(true);
+      expect(service.isLoading()).toBe(false);
+    });
     injector.destroy();
   });
 });

--- a/packages/angular/src/provider.ts
+++ b/packages/angular/src/provider.ts
@@ -1,0 +1,62 @@
+import {
+  afterNextRender,
+  inject,
+  InjectionToken,
+  makeEnvironmentProviders,
+  provideAppInitializer,
+  type EnvironmentProviders,
+} from '@angular/core';
+import LogtoClient, { type LogtoConfig } from '@logto/browser';
+
+import { LogtoService } from './service.js';
+
+/** Options for the Angular integration around the Logto Browser client. */
+export type LogtoAngularOptions = {
+  /**
+   * Whether to cache OIDC discovery metadata in session storage.
+   *
+   * @default false
+   */
+  unstable_enableCache?: boolean;
+};
+
+const LOGTO_CONFIG = new InjectionToken<LogtoConfig>('logto.config');
+const LOGTO_OPTIONS = new InjectionToken<LogtoAngularOptions>('logto.options');
+
+/** The underlying Logto Browser client for advanced use cases and dependency overrides. */
+export const LOGTO_CLIENT = new InjectionToken<LogtoClient>('logto.client');
+
+/**
+ * Provide a singleton Logto Browser client and Angular-native {@link LogtoService}.
+ *
+ * Authentication state is restored after the first browser render so server-rendered and hydrated
+ * applications start from the same state.
+ */
+export const provideLogto = (
+  config: LogtoConfig,
+  options: LogtoAngularOptions = {}
+): EnvironmentProviders =>
+  makeEnvironmentProviders([
+    { provide: LOGTO_CONFIG, useValue: config },
+    { provide: LOGTO_OPTIONS, useValue: options },
+    {
+      provide: LOGTO_CLIENT,
+      useFactory: () => {
+        const logtoConfig = inject(LOGTO_CONFIG);
+        const { unstable_enableCache = false } = inject(LOGTO_OPTIONS);
+
+        return new LogtoClient(logtoConfig, unstable_enableCache);
+      },
+    },
+    {
+      provide: LogtoService,
+      useFactory: () => new LogtoService(inject(LOGTO_CLIENT)),
+    },
+    provideAppInitializer(() => {
+      const service = inject(LogtoService);
+
+      afterNextRender(() => {
+        void service.initialize();
+      });
+    }),
+  ]);

--- a/packages/angular/src/service.test.ts
+++ b/packages/angular/src/service.test.ts
@@ -22,6 +22,7 @@ const createClient = () => {
   };
   const methods = {
     isAuthenticated: vi.fn(async () => false),
+    isSignInRedirected: vi.fn(async () => false),
     handleSignInCallback: vi.fn(async () => {
       await Promise.resolve();
     }),
@@ -85,6 +86,30 @@ describe('LogtoService', () => {
     expect(service.isAuthenticated()).toBe(false);
     expect(service.isLoading()).toBe(false);
     expect(service.error()).toBe(error);
+  });
+
+  it('retries initialization after a failure and caches the successful result', async () => {
+    const { client, methods } = createClient();
+    const error = new Error('Storage unavailable');
+    methods.isAuthenticated.mockRejectedValueOnce(error).mockResolvedValueOnce(true);
+    const service = new LogtoService(client);
+
+    await Promise.all([service.initialize(), service.initialize()]);
+
+    expect(methods.isAuthenticated).toHaveBeenCalledTimes(1);
+    expect(service.error()).toBe(error);
+    expect(service.isLoading()).toBe(false);
+
+    const retry = service.initialize();
+
+    expect(service.isLoading()).toBe(true);
+    await retry;
+    await service.initialize();
+
+    expect(methods.isAuthenticated).toHaveBeenCalledTimes(2);
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.error()).toBeUndefined();
+    expect(service.isLoading()).toBe(false);
   });
 
   it('keeps loading until all concurrent operations settle', async () => {
@@ -183,6 +208,21 @@ describe('LogtoService', () => {
     expect(service.isAuthenticated()).toBe(true);
   });
 
+  it('checks whether the current URL is a sign-in redirect', async () => {
+    const { client, methods } = createClient();
+    methods.isSignInRedirected.mockResolvedValue(true);
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await expect(service.isSignInRedirected('https://app.example/callback?code=foo')).resolves.toBe(
+      true
+    );
+
+    expect(methods.isSignInRedirected).toHaveBeenCalledWith(
+      'https://app.example/callback?code=foo'
+    );
+  });
+
   it('updates authentication only after all tokens are cleared successfully', async () => {
     const { client, methods } = createClient();
     methods.isAuthenticated.mockResolvedValue(true);
@@ -238,7 +278,7 @@ describe('LogtoService', () => {
     expect(service.error()).toBe(error);
   });
 
-  it('delegates sign-out and keeps loading active for navigation', async () => {
+  it('delegates sign-out and settles loading after starting navigation', async () => {
     const { client, methods } = createClient();
     const service = new LogtoService(client);
     await service.initialize();
@@ -246,6 +286,6 @@ describe('LogtoService', () => {
     await service.signOut('https://app.example/');
 
     expect(methods.signOut).toHaveBeenCalledWith('https://app.example/');
-    expect(service.isLoading()).toBe(true);
+    expect(service.isLoading()).toBe(false);
   });
 });

--- a/packages/angular/src/service.test.ts
+++ b/packages/angular/src/service.test.ts
@@ -208,11 +208,14 @@ describe('LogtoService', () => {
     expect(service.isAuthenticated()).toBe(true);
   });
 
-  it('checks whether the current URL is a sign-in redirect', async () => {
+  it('checks whether the current URL is a sign-in redirect without changing operation state', async () => {
     const { client, methods } = createClient();
     methods.isSignInRedirected.mockResolvedValue(true);
     const service = new LogtoService(client);
     await service.initialize();
+    const error = new Error('Not authenticated');
+    methods.getAccessToken.mockRejectedValueOnce(error);
+    await expect(service.getAccessToken()).rejects.toBe(error);
 
     await expect(service.isSignInRedirected('https://app.example/callback?code=foo')).resolves.toBe(
       true
@@ -221,6 +224,8 @@ describe('LogtoService', () => {
     expect(methods.isSignInRedirected).toHaveBeenCalledWith(
       'https://app.example/callback?code=foo'
     );
+    expect(service.error()).toBe(error);
+    expect(service.isLoading()).toBe(false);
   });
 
   it('updates authentication only after all tokens are cleared successfully', async () => {

--- a/packages/angular/src/service.test.ts
+++ b/packages/angular/src/service.test.ts
@@ -1,0 +1,251 @@
+import type LogtoClient from '@logto/browser';
+import type { AccessTokenClaims, IdTokenClaims, UserInfoResponse } from '@logto/browser';
+
+import { LogtoService } from './service.js';
+
+const createClient = () => {
+  const accessTokenClaims: AccessTokenClaims = { sub: 'access-sub' };
+  const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-sub' };
+  const idTokenClaims: IdTokenClaims = {
+    iss: 'https://logto.example/oidc',
+    sub: 'id-sub',
+    aud: 'app-id',
+    exp: 2_000_000_000,
+    iat: 1_900_000_000,
+  };
+  const userInfo: UserInfoResponse = {
+    iss: 'https://logto.example/oidc',
+    sub: 'user-sub',
+    aud: 'app-id',
+    exp: 2_000_000_000,
+    iat: 1_900_000_000,
+  };
+  const methods = {
+    isAuthenticated: vi.fn(async () => false),
+    handleSignInCallback: vi.fn(async () => {
+      await Promise.resolve();
+    }),
+    getRefreshToken: vi.fn(async () => 'refresh-token'),
+    getAccessToken: vi.fn(async () => 'access-token'),
+    getAccessTokenClaims: vi.fn(async () => accessTokenClaims),
+    getOrganizationToken: vi.fn(async () => 'organization-token'),
+    getOrganizationTokenClaims: vi.fn(async () => organizationTokenClaims),
+    getIdToken: vi.fn(async () => 'id-token'),
+    getIdTokenClaims: vi.fn(async () => idTokenClaims),
+    signIn: vi.fn(async () => {
+      await Promise.resolve();
+    }),
+    signOut: vi.fn(async () => {
+      await Promise.resolve();
+    }),
+    fetchUserInfo: vi.fn(async () => userInfo),
+    clearAccessToken: vi.fn(async () => {
+      await Promise.resolve();
+    }),
+    clearAllTokens: vi.fn(async () => {
+      await Promise.resolve();
+    }),
+  };
+
+  return {
+    client: methods as unknown as LogtoClient,
+    methods,
+  };
+};
+
+describe('LogtoService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('restores authentication once and settles the initial loading state', async () => {
+    const { client, methods } = createClient();
+    methods.isAuthenticated.mockResolvedValue(true);
+    const service = new LogtoService(client);
+
+    expect(service.isLoading()).toBe(true);
+    expect(service.isAuthenticated()).toBe(false);
+
+    await Promise.all([service.initialize(), service.initialize()]);
+
+    expect(methods.isAuthenticated).toHaveBeenCalledTimes(1);
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.isLoading()).toBe(false);
+    expect(service.error()).toBeUndefined();
+  });
+
+  it('exposes initialization errors without rejecting', async () => {
+    const { client, methods } = createClient();
+    const error = new Error('Storage unavailable');
+    methods.isAuthenticated.mockRejectedValue(error);
+    const service = new LogtoService(client);
+
+    await expect(service.initialize()).resolves.toBeUndefined();
+
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.isLoading()).toBe(false);
+    expect(service.error()).toBe(error);
+  });
+
+  it('keeps loading until all concurrent operations settle', async () => {
+    vi.useFakeTimers();
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+    methods.getAccessToken
+      .mockImplementationOnce(
+        async () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve('first-token');
+            }, 10);
+          })
+      )
+      .mockImplementationOnce(
+        async () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve('second-token');
+            }, 20);
+          })
+      );
+
+    const firstToken = service.getAccessToken('first-resource');
+    const secondToken = service.getAccessToken('second-resource');
+
+    expect(service.isLoading()).toBe(true);
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(firstToken).resolves.toBe('first-token');
+    expect(service.isLoading()).toBe(true);
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(secondToken).resolves.toBe('second-token');
+    expect(service.isLoading()).toBe(false);
+  });
+
+  it('returns delegated token, claims, and userinfo values with unchanged arguments', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await expect(service.getRefreshToken()).resolves.toBe('refresh-token');
+    await expect(service.getAccessToken('api-resource')).resolves.toBe('access-token');
+    await expect(service.getAccessTokenClaims('api-resource')).resolves.toEqual({
+      sub: 'access-sub',
+    });
+    await expect(service.getOrganizationToken('organization-id')).resolves.toBe(
+      'organization-token'
+    );
+    await expect(service.getOrganizationTokenClaims('organization-id')).resolves.toEqual({
+      sub: 'organization-sub',
+    });
+    await expect(service.getIdToken()).resolves.toBe('id-token');
+    await expect(service.getIdTokenClaims()).resolves.toMatchObject({ sub: 'id-sub' });
+    await expect(service.fetchUserInfo()).resolves.toMatchObject({ sub: 'user-sub' });
+
+    expect(methods.getAccessToken).toHaveBeenCalledWith('api-resource');
+    expect(methods.getAccessTokenClaims).toHaveBeenCalledWith('api-resource');
+    expect(methods.getOrganizationToken).toHaveBeenCalledWith('organization-id');
+    expect(methods.getOrganizationTokenClaims).toHaveBeenCalledWith('organization-id');
+  });
+
+  it('sets the error signal and rethrows the original operation error', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+    const error = new Error('Not authenticated');
+    methods.getAccessToken.mockRejectedValue(error);
+
+    await expect(service.getAccessToken()).rejects.toBe(error);
+
+    expect(service.error()).toBe(error);
+    expect(service.isLoading()).toBe(false);
+    service.clearError();
+    expect(service.error()).toBeUndefined();
+  });
+
+  it('sets authentication after a successful callback and leaves it unchanged on failure', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await service.handleSignInCallback('https://app.example/callback?code=foo');
+
+    expect(methods.handleSignInCallback).toHaveBeenCalledWith(
+      'https://app.example/callback?code=foo'
+    );
+    expect(service.isAuthenticated()).toBe(true);
+
+    const error = new Error('Invalid state');
+    methods.handleSignInCallback.mockRejectedValueOnce(error);
+    await expect(
+      service.handleSignInCallback('https://app.example/callback?code=bar')
+    ).rejects.toBe(error);
+    expect(service.isAuthenticated()).toBe(true);
+  });
+
+  it('updates authentication only after all tokens are cleared successfully', async () => {
+    const { client, methods } = createClient();
+    methods.isAuthenticated.mockResolvedValue(true);
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await service.clearAccessToken();
+    expect(service.isAuthenticated()).toBe(true);
+
+    const error = new Error('Storage write failed');
+    methods.clearAllTokens.mockRejectedValueOnce(error);
+    await expect(service.clearAllTokens()).rejects.toBe(error);
+    expect(service.isAuthenticated()).toBe(true);
+
+    await service.clearAllTokens();
+    expect(service.isAuthenticated()).toBe(false);
+  });
+
+  it('preserves sign-in overload arguments and loading during successful navigation', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await service.signIn({
+      redirectUri: 'https://app.example/callback',
+      postRedirectUri: 'https://app.example/',
+    });
+
+    expect(methods.signIn).toHaveBeenCalledWith({
+      redirectUri: 'https://app.example/callback',
+      postRedirectUri: 'https://app.example/',
+    });
+    expect(service.isLoading()).toBe(true);
+  });
+
+  it('settles loading and exposes an error when sign-in navigation fails', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+    const error = new Error('Navigation blocked');
+    methods.signIn.mockRejectedValue(error);
+
+    await expect(
+      service.signIn('https://app.example/callback', 'signIn', 'user@example.com')
+    ).rejects.toBe(error);
+
+    expect(methods.signIn).toHaveBeenCalledWith(
+      'https://app.example/callback',
+      'signIn',
+      'user@example.com'
+    );
+    expect(service.isLoading()).toBe(false);
+    expect(service.error()).toBe(error);
+  });
+
+  it('delegates sign-out and keeps loading active for navigation', async () => {
+    const { client, methods } = createClient();
+    const service = new LogtoService(client);
+    await service.initialize();
+
+    await service.signOut('https://app.example/');
+
+    expect(methods.signOut).toHaveBeenCalledWith('https://app.example/');
+    expect(service.isLoading()).toBe(true);
+  });
+});

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -22,18 +22,19 @@ export class LogtoService {
   /** Whether initialization or one or more SDK operations are pending. */
   readonly isLoading: Signal<boolean>;
 
-  /** The latest SDK operation error, if any. */
+  /** The latest SDK operation error, cleared when another operation starts or by {@link clearError}. */
   readonly error: Signal<Error | undefined>;
 
   private readonly authenticatedState = signal(false);
-  private readonly loadingCount = signal(1);
+  private readonly initializationStarted = signal(false);
+  private readonly loadingCount = signal(0);
   // eslint-disable-next-line unicorn/no-useless-undefined -- Angular signal requires an initial value
   private readonly errorState = signal<Error | undefined>(undefined);
-  private initializationPromise?: Promise<void>;
+  private initializationPromise?: Promise<boolean>;
 
   constructor(private readonly client: LogtoClient) {
     this.isAuthenticated = this.authenticatedState.asReadonly();
-    this.isLoading = computed(() => this.loadingCount() > 0);
+    this.isLoading = computed(() => !this.initializationStarted() || this.loadingCount() > 0);
     this.error = this.errorState.asReadonly();
   }
 
@@ -45,22 +46,31 @@ export class LogtoService {
    */
   async initialize(): Promise<void> {
     if (this.initializationPromise) {
-      return this.initializationPromise;
+      await this.initializationPromise;
+      return;
     }
 
     this.clearError();
+    this.initializationStarted.set(true);
+    this.startLoading();
     const initializationPromise = (async () => {
       try {
         this.authenticatedState.set(await this.client.isAuthenticated());
+        return true;
       } catch (error: unknown) {
         this.errorState.set(toError(error));
+        return false;
       } finally {
         this.stopLoading();
       }
     })();
 
     this.initializationPromise = initializationPromise;
-    return initializationPromise;
+    const isInitialized = await initializationPromise;
+
+    if (!isInitialized && this.initializationPromise === initializationPromise) {
+      this.initializationPromise = undefined;
+    }
   }
 
   /** Start the Logto sign-in redirect flow. */
@@ -83,6 +93,7 @@ export class LogtoService {
     interactionMode?: SignInOptions['interactionMode'],
     loginHint?: SignInOptions['loginHint']
   ): Promise<void> {
+    // Keep authentication state stable while the redirect starts to avoid an intermediate UI state.
     return this.run(async () => {
       if (typeof options === 'string' || options instanceof URL) {
         return this.client.signIn(options, interactionMode, loginHint);
@@ -94,7 +105,13 @@ export class LogtoService {
 
   /** Revoke local credentials and start the Logto sign-out redirect flow. */
   async signOut(postLogoutRedirectUri?: string): Promise<void> {
-    return this.run(async () => this.client.signOut(postLogoutRedirectUri), true);
+    // Keep authentication state stable while the redirect starts to avoid an intermediate UI state.
+    return this.run(async () => this.client.signOut(postLogoutRedirectUri));
+  }
+
+  /** Check whether the current URL is the redirect URI for an active sign-in session. */
+  async isSignInRedirected(url: string): Promise<boolean> {
+    return this.run(async () => this.client.isSignInRedirected(url));
   }
 
   /** Exchange the authorization callback for tokens and mark the session as authenticated. */

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -1,0 +1,197 @@
+import { computed, signal, type Signal } from '@angular/core';
+import type LogtoClient from '@logto/browser';
+import type {
+  AccessTokenClaims,
+  IdTokenClaims,
+  SignInOptions,
+  UserInfoResponse,
+} from '@logto/browser';
+
+const toError = (error: unknown) =>
+  error instanceof Error ? error : new Error(`Unexpected error: ${String(error)}`);
+
+/**
+ * Angular-native state and operations for the underlying Logto Browser client.
+ *
+ * Register this service with {@link provideLogto}, then inject it into components and services.
+ */
+export class LogtoService {
+  /** Whether the current browser session has an ID token. */
+  readonly isAuthenticated: Signal<boolean>;
+
+  /** Whether initialization or one or more SDK operations are pending. */
+  readonly isLoading: Signal<boolean>;
+
+  /** The latest SDK operation error, if any. */
+  readonly error: Signal<Error | undefined>;
+
+  private readonly authenticatedState = signal(false);
+  private readonly loadingCount = signal(1);
+  // eslint-disable-next-line unicorn/no-useless-undefined -- Angular signal requires an initial value
+  private readonly errorState = signal<Error | undefined>(undefined);
+  private initializationPromise?: Promise<void>;
+
+  constructor(private readonly client: LogtoClient) {
+    this.isAuthenticated = this.authenticatedState.asReadonly();
+    this.isLoading = computed(() => this.loadingCount() > 0);
+    this.error = this.errorState.asReadonly();
+  }
+
+  /**
+   * Restore authentication state from browser storage.
+   *
+   * The operation is idempotent. Initialization failures are exposed through {@link error} and do
+   * not reject, so they cannot prevent the Angular application from starting.
+   */
+  async initialize(): Promise<void> {
+    if (this.initializationPromise) {
+      return this.initializationPromise;
+    }
+
+    this.clearError();
+    const initializationPromise = (async () => {
+      try {
+        this.authenticatedState.set(await this.client.isAuthenticated());
+      } catch (error: unknown) {
+        this.errorState.set(toError(error));
+      } finally {
+        this.stopLoading();
+      }
+    })();
+
+    this.initializationPromise = initializationPromise;
+    return initializationPromise;
+  }
+
+  /** Start the Logto sign-in redirect flow. */
+  async signIn(options: SignInOptions): Promise<void>;
+  /** Start the Logto sign-in redirect flow. */
+  async signIn(redirectUri: SignInOptions['redirectUri']): Promise<void>;
+  /**
+   * Start the Logto sign-in redirect flow.
+   *
+   * @deprecated Use the object parameter instead.
+   */
+  async signIn(
+    redirectUri: SignInOptions['redirectUri'],
+    interactionMode?: SignInOptions['interactionMode'],
+    // eslint-disable-next-line @typescript-eslint/unified-signatures -- preserve Browser client overloads
+    loginHint?: SignInOptions['loginHint']
+  ): Promise<void>;
+  async signIn(
+    options: SignInOptions | string | URL,
+    interactionMode?: SignInOptions['interactionMode'],
+    loginHint?: SignInOptions['loginHint']
+  ): Promise<void> {
+    return this.run(async () => {
+      if (typeof options === 'string' || options instanceof URL) {
+        return this.client.signIn(options, interactionMode, loginHint);
+      }
+
+      return this.client.signIn(options);
+    }, true);
+  }
+
+  /** Revoke local credentials and start the Logto sign-out redirect flow. */
+  async signOut(postLogoutRedirectUri?: string): Promise<void> {
+    return this.run(async () => this.client.signOut(postLogoutRedirectUri), true);
+  }
+
+  /** Exchange the authorization callback for tokens and mark the session as authenticated. */
+  async handleSignInCallback(callbackUri: string): Promise<void> {
+    return this.run(async () => {
+      await this.client.handleSignInCallback(callbackUri);
+      this.authenticatedState.set(true);
+    });
+  }
+
+  /** Get the persisted refresh token. */
+  // eslint-disable-next-line @typescript-eslint/ban-types -- preserve Browser client return type
+  async getRefreshToken(): Promise<string | null> {
+    return this.run(async () => this.client.getRefreshToken());
+  }
+
+  /** Get an access token for the OIDC or requested API resource. */
+  async getAccessToken(resource?: string): Promise<string> {
+    return this.run(async () => this.client.getAccessToken(resource));
+  }
+
+  /** Get decoded claims for an OIDC or API-resource access token. */
+  async getAccessTokenClaims(resource?: string): Promise<AccessTokenClaims> {
+    return this.run(async () => this.client.getAccessTokenClaims(resource));
+  }
+
+  /** Get an access token for a Logto organization. */
+  async getOrganizationToken(organizationId: string): Promise<string> {
+    return this.run(async () => this.client.getOrganizationToken(organizationId));
+  }
+
+  /** Get decoded claims for a Logto organization token. */
+  async getOrganizationTokenClaims(organizationId: string): Promise<AccessTokenClaims> {
+    return this.run(async () => this.client.getOrganizationTokenClaims(organizationId));
+  }
+
+  /** Get the persisted ID token. */
+  // eslint-disable-next-line @typescript-eslint/ban-types -- preserve Browser client return type
+  async getIdToken(): Promise<string | null> {
+    return this.run(async () => this.client.getIdToken());
+  }
+
+  /** Get decoded claims for the persisted ID token. */
+  async getIdTokenClaims(): Promise<IdTokenClaims> {
+    return this.run(async () => this.client.getIdTokenClaims());
+  }
+
+  /** Fetch user information from the OIDC userinfo endpoint. */
+  async fetchUserInfo(): Promise<UserInfoResponse> {
+    return this.run(async () => this.client.fetchUserInfo());
+  }
+
+  /** Clear all cached access tokens without changing authentication state. */
+  async clearAccessToken(): Promise<void> {
+    return this.run(async () => this.client.clearAccessToken());
+  }
+
+  /** Clear all local tokens and mark the session as unauthenticated. */
+  async clearAllTokens(): Promise<void> {
+    return this.run(async () => {
+      await this.client.clearAllTokens();
+      this.authenticatedState.set(false);
+    });
+  }
+
+  /** Clear the latest SDK operation error. */
+  clearError(): void {
+    this.errorState.set(undefined);
+  }
+
+  private startLoading() {
+    this.loadingCount.update((count) => count + 1);
+  }
+
+  private stopLoading() {
+    this.loadingCount.update((count) => Math.max(0, count - 1));
+  }
+
+  private async run<Result>(
+    operation: () => Promise<Result>,
+    keepLoadingOnSuccess = false
+  ): Promise<Result> {
+    this.clearError();
+    this.startLoading();
+
+    try {
+      const result = await operation();
+
+      if (!keepLoadingOnSuccess) {
+        this.stopLoading();
+      }
+
+      return result;
+    } catch (error: unknown) {
+      this.errorState.set(toError(error));
+      this.stopLoading();
+      throw error;
+    }
+  }
+}

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -68,7 +68,7 @@ export class LogtoService {
     this.initializationPromise = initializationPromise;
     const isInitialized = await initializationPromise;
 
-    if (!isInitialized && this.initializationPromise === initializationPromise) {
+    if (!isInitialized) {
       this.initializationPromise = undefined;
     }
   }

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -94,13 +94,17 @@ export class LogtoService {
     loginHint?: SignInOptions['loginHint']
   ): Promise<void> {
     // Keep authentication state stable while the redirect starts to avoid an intermediate UI state.
-    return this.run(async () => {
-      if (typeof options === 'string' || options instanceof URL) {
-        return this.client.signIn(options, interactionMode, loginHint);
-      }
+    return this.run(
+      async () => {
+        if (typeof options === 'string' || options instanceof URL) {
+          return this.client.signIn(options, interactionMode, loginHint);
+        }
 
-      return this.client.signIn(options);
-    }, true);
+        return this.client.signIn(options);
+      },
+      // Keep loading active while the redirect navigates away.
+      true
+    );
   }
 
   /** Revoke local credentials and start the Logto sign-out redirect flow. */
@@ -111,7 +115,7 @@ export class LogtoService {
 
   /** Check whether the current URL is the redirect URI for an active sign-in session. */
   async isSignInRedirected(url: string): Promise<boolean> {
-    return this.run(async () => this.client.isSignInRedirected(url));
+    return this.client.isSignInRedirected(url);
   }
 
   /** Exchange the authorization callback for tokens and mark the session as authenticated. */

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "@silverhand/ts-config-react/tsconfig.base",
+  "extends": "@silverhand/ts-config/tsconfig.base",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",
     "types": ["vitest/globals"]
   },
-  "include": [
-    "src",
-    "vitest.config.ts"
-  ]
+  "include": ["src", "vitest.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,43 +103,28 @@ importers:
 
   packages/angular:
     dependencies:
-      '@angular/common':
-        specifier: ^20.3.27
-        version: 20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/core':
         specifier: ^20.3.27
         version: 20.3.29(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/router':
-        specifier: ^20.0.0
-        version: 20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
-      '@logto/js':
+      '@logto/browser':
         specifier: workspace:^
-        version: link:../js
-      '@silverhand/essentials':
-        specifier: ^2.9.3
-        version: 2.9.3
-      rxjs:
-        specifier: ^6.5.3 || ^7.4.0
-        version: 7.8.1
+        version: link:../browser
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^6.0.1
         version: 6.0.1(@types/eslint@9.6.1)(eslint@8.57.0)(prettier@3.0.0)(typescript@5.7.2)
-      '@silverhand/eslint-config-react':
-        specifier: ^6.0.2
-        version: 6.0.2(@types/eslint@9.6.1)(eslint@8.57.0)(postcss@8.5.26)(prettier@3.0.0)(typescript@5.7.2)
       '@silverhand/ts-config':
         specifier: ^6.0.0
         version: 6.0.0(typescript@5.7.2)
-      '@silverhand/ts-config-react':
-        specifier: ^6.0.0
-        version: 6.0.0(typescript@5.7.2)
-      angular-auth-oidc-client:
-        specifier: ^20.0.3
-        version: 20.0.3(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/router@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1))(rxjs@7.8.1)
+      '@vitest/coverage-v8':
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.10.0)(happy-dom@20.8.9)(jiti@2.7.0)(less@4.2.2)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.39.0)(yaml@2.9.0))
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
+      happy-dom:
+        specifier: ^20.0.8
+        version: 20.8.9
       lint-staged:
         specifier: ^15.0.0
         version: 15.0.0
@@ -1489,13 +1474,6 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@angular/common@20.3.29':
-    resolution: {integrity: sha512-tlX353N11Uu9Cqn7EssfQNh7zjML9ddHRzhlo+3rsaxd+ngqsFpXieogBUSoo5yDhY3ACam/Bls9aGMfklr2SA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/core': 20.3.29
-      rxjs: ^6.5.3 || ^7.4.0
-
   '@angular/core@20.3.29':
     resolution: {integrity: sha512-aOgEd1+YxC1bcn6Mju0rfz/2/yJyOGd38qY+DEaRDIS24nB6Epr6i0fY6OUW2uDG/nQUyY9kt1L7xjg+1aVitQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1508,26 +1486,6 @@ packages:
         optional: true
       zone.js:
         optional: true
-
-  '@angular/platform-browser@20.3.15':
-    resolution: {integrity: sha512-TxRM/wTW/oGXv/3/Iohn58yWoiYXOaeEnxSasiGNS1qhbkcKtR70xzxW6NjChBUYAixz2ERkLURkpx3pI8Q6Dw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/animations': 20.3.15
-      '@angular/common': ^20.3.27
-      '@angular/core': ^20.3.27
-    peerDependenciesMeta:
-      '@angular/animations':
-        optional: true
-
-  '@angular/router@20.3.15':
-    resolution: {integrity: sha512-6+qgk8swGSoAu7ISSY//GatAyCP36hEvvUgvjbZgkXLLH9yUQxdo77ij05aJ5s0OyB25q/JkqS8VTY0z1yE9NQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': ^20.3.27
-      '@angular/core': ^20.3.27
-      '@angular/platform-browser': 20.3.15
-      rxjs: ^6.5.3 || ^7.4.0
 
   '@auth/core@0.41.3':
     resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
@@ -5114,14 +5072,6 @@ packages:
 
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
-
-  angular-auth-oidc-client@20.0.3:
-    resolution: {integrity: sha512-JwYdFWRz8/Bya8NLFiynKD3Znit5JCxKrlCYZqAgIPiaWZIsh5SMtvEZnjFF27GIStD26NegRsevZs8OOlsrag==}
-    peerDependencies:
-      '@angular/common': ^20.3.27
-      '@angular/core': ^20.3.27
-      '@angular/router': '>=20.0.0'
-      rxjs: ^6.5.3 || ^7.4.0
 
   ansi-escapes@5.0.0:
     resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
@@ -9566,9 +9516,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rfc4648@1.5.3:
-    resolution: {integrity: sha512-MjOWxM065+WswwnmNONOT+bD1nXzY9Km6u3kzvnx8F8/HXGZdz3T6e6vZJ8Q/RIMUSp/nxqjH3GwvJDy8ijeQQ==}
-
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -11187,32 +11134,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)':
-    dependencies:
-      '@angular/core': 20.3.29(rxjs@7.8.1)(zone.js@0.15.0)
-      rxjs: 7.8.1
-      tslib: 2.8.1
-
   '@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)':
     dependencies:
       rxjs: 7.8.1
       tslib: 2.8.1
     optionalDependencies:
       zone.js: 0.15.0
-
-  '@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))':
-    dependencies:
-      '@angular/common': 20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
-      '@angular/core': 20.3.29(rxjs@7.8.1)(zone.js@0.15.0)
-      tslib: 2.8.1
-
-  '@angular/router@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)':
-    dependencies:
-      '@angular/common': 20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
-      '@angular/core': 20.3.29(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))
-      rxjs: 7.8.1
-      tslib: 2.8.1
 
   '@auth/core@0.41.3':
     dependencies:
@@ -14302,26 +14229,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@silverhand/eslint-config-react@6.0.2(@types/eslint@9.6.1)(eslint@8.57.0)(postcss@8.5.26)(prettier@3.0.0)(typescript@5.7.2)':
-    dependencies:
-      '@silverhand/eslint-config': 6.0.1(@types/eslint@9.6.1)(eslint@8.57.0)(prettier@3.0.0)(typescript@5.7.2)
-      eslint-config-xo-react: 0.27.0(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
-      eslint-plugin-react: 7.34.1(eslint@8.57.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
-      postcss-scss: 4.0.9(postcss@8.5.26)
-      stylelint-config-xo: 0.22.0
-      stylelint-scss: 6.2.1
-    transitivePeerDependencies:
-      - '@types/eslint'
-      - eslint
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - postcss
-      - prettier
-      - supports-color
-      - typescript
-
   '@silverhand/eslint-config@6.0.1(@types/eslint@9.6.1)(eslint@8.57.0)(prettier@3.0.0)(typescript@5.3.3)':
     dependencies:
       '@silverhand/eslint-plugin-fp': 2.5.0(eslint@8.57.0)
@@ -15897,15 +15804,6 @@ snapshots:
   alien-signals@0.2.2: {}
 
   alien-signals@3.2.1: {}
-
-  angular-auth-oidc-client@20.0.3(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/router@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1))(rxjs@7.8.1):
-    dependencies:
-      '@angular/common': 20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
-      '@angular/core': 20.3.29(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/router': 20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.3.15(@angular/common@20.3.29(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.3.29(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
-      rfc4648: 1.5.3
-      rxjs: 7.8.1
-      tslib: 2.8.1
 
   ansi-escapes@5.0.0:
     dependencies:
@@ -21359,8 +21257,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rfc4648@1.5.3: {}
-
   rfdc@1.4.1: {}
 
   rimraf@3.0.2:
@@ -21963,11 +21859,6 @@ snapshots:
       postcss: 8.5.26
       postcss-selector-parser: 7.1.0
 
-  stylelint-config-xo@0.22.0:
-    dependencies:
-      stylelint-declaration-block-no-ignored-properties: 2.8.0
-      stylelint-order: 6.0.4
-
   stylelint-config-xo@0.22.0(stylelint@16.9.0(typescript@5.3.3)):
     dependencies:
       stylelint: 16.9.0(typescript@5.3.3)
@@ -21980,8 +21871,6 @@ snapshots:
       stylelint-declaration-block-no-ignored-properties: 2.8.0(stylelint@16.9.0(typescript@5.8.3))
       stylelint-order: 6.0.4(stylelint@16.9.0(typescript@5.8.3))
 
-  stylelint-declaration-block-no-ignored-properties@2.8.0: {}
-
   stylelint-declaration-block-no-ignored-properties@2.8.0(stylelint@16.9.0(typescript@5.3.3)):
     dependencies:
       stylelint: 16.9.0(typescript@5.3.3)
@@ -21989,11 +21878,6 @@ snapshots:
   stylelint-declaration-block-no-ignored-properties@2.8.0(stylelint@16.9.0(typescript@5.8.3)):
     dependencies:
       stylelint: 16.9.0(typescript@5.8.3)
-
-  stylelint-order@6.0.4:
-    dependencies:
-      postcss: 8.5.26
-      postcss-sorting: 8.0.2(postcss@8.5.26)
 
   stylelint-order@6.0.4(stylelint@16.9.0(typescript@5.3.3)):
     dependencies:
@@ -22006,14 +21890,6 @@ snapshots:
       postcss: 8.5.26
       postcss-sorting: 8.0.2(postcss@8.5.26)
       stylelint: 16.9.0(typescript@5.8.3)
-
-  stylelint-scss@6.2.1:
-    dependencies:
-      known-css-properties: 0.29.0
-      postcss-media-query-parser: 0.2.3
-      postcss-resolve-nested-selector: 0.1.1
-      postcss-selector-parser: 6.0.16
-      postcss-value-parser: 4.2.0
 
   stylelint-scss@6.2.1(stylelint@16.9.0(typescript@5.3.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Replace the `angular-auth-oidc-client` configuration helper with a first-party Angular provider and service built on `@logto/browser`.
- Expose Angular Signals for authentication, loading, and error state together with Logto token, claims, userinfo, organization, sign-in, sign-out, and token-clearing APIs.
- Add hydration-safe post-render initialization, an overrideable client DI token, focused unit tests, and a major changeset for the 2.0.0 release.
- Rewrite the package README for v2 and add a v1-to-v2 migration guide, including replacing the comma-separated multi-resource workaround with the native `resources` array.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
