### PR TITLE
feat(react-router): add coordinated session runtime

### DIFF
--- a/packages/react-router/src/infrastructure/session/index.ts
+++ b/packages/react-router/src/infrastructure/session/index.ts
@@ -1,0 +1,11 @@
+export {
+  ProcessLocalSessionCoordinator,
+  createProcessLocalSessionCoordinator,
+  type SessionCoordinator,
+} from './session-coordinator.js';
+export {
+  SessionRuntime,
+  type SessionOperation,
+  type SessionRuntimeOptions,
+} from './session-runtime.js';
+export { TrackedSession } from './tracked-session.js';

--- a/packages/react-router/src/infrastructure/session/session-coordinator.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-coordinator.spec.ts
@@ -1,0 +1,86 @@
+import { createProcessLocalSessionCoordinator } from './session-coordinator.js';
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+describe('infrastructure:session:sessionCoordinator', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('serializes operations for the same session', async () => {
+    vi.useFakeTimers();
+
+    const coordinator = createProcessLocalSessionCoordinator();
+    const firstStart = vi.fn();
+    const firstEnd = vi.fn();
+    const secondStart = vi.fn();
+
+    const first = coordinator.runExclusive('session', async () => {
+      firstStart();
+      await delay(25);
+      firstEnd();
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstStart).toHaveBeenCalledOnce();
+
+    const second = coordinator.runExclusive('session', async () => {
+      secondStart();
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(secondStart).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await Promise.all([first, second]);
+
+    expect(firstEnd.mock.invocationCallOrder[0]).toBeLessThan(
+      secondStart.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('allows operations for different sessions to run concurrently', async () => {
+    vi.useFakeTimers();
+
+    const coordinator = createProcessLocalSessionCoordinator();
+    const firstStart = vi.fn();
+    const firstEnd = vi.fn();
+    const secondStart = vi.fn();
+
+    const first = coordinator.runExclusive('first-session', async () => {
+      firstStart();
+      await delay(25);
+      firstEnd();
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstStart).toHaveBeenCalledOnce();
+
+    await coordinator.runExclusive('second-session', async () => {
+      secondStart();
+    });
+
+    expect(secondStart).toHaveBeenCalledOnce();
+    expect(firstEnd).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await first;
+  });
+
+  it('releases the session after an operation fails', async () => {
+    const coordinator = createProcessLocalSessionCoordinator();
+
+    await expect(
+      coordinator.runExclusive('session', async () => {
+        throw new Error('failed');
+      })
+    ).rejects.toThrow('failed');
+
+    await expect(coordinator.runExclusive('session', async () => 'completed')).resolves.toBe(
+      'completed'
+    );
+  });
+});

--- a/packages/react-router/src/infrastructure/session/session-coordinator.ts
+++ b/packages/react-router/src/infrastructure/session/session-coordinator.ts
@@ -1,4 +1,12 @@
+/**
+ * Serializes asynchronous session operations by a stable session key.
+ *
+ * Implementations must invoke each operation once, hold exclusivity until it settles, and
+ * propagate its result or error. A slow operation must not be force-released because it may
+ * still commit stale state; the operation owns its timeout and cancellation policy.
+ */
 export type SessionCoordinator = {
+  /** Runs an operation exclusively from other operations using the same session key. */
   readonly runExclusive: <Result>(
     sessionKey: string,
     operation: () => Promise<Result>
@@ -39,7 +47,8 @@ class SessionLock {
 
 /**
  * Serializes operations only within the current JavaScript process. Multi-instance deployments
- * need a distributed coordinator together with shared server-side session storage.
+ * need a distributed coordinator together with shared server-side session storage. Acquisition
+ * order is not part of this coordinator's contract.
  */
 export class ProcessLocalSessionCoordinator implements SessionCoordinator {
   private readonly sessionLocks = new Map<string, SessionLock>();

--- a/packages/react-router/src/infrastructure/session/session-coordinator.ts
+++ b/packages/react-router/src/infrastructure/session/session-coordinator.ts
@@ -7,42 +7,39 @@
  */
 export type SessionCoordinator = {
   /** Runs an operation exclusively from other operations using the same session key. */
-  readonly runExclusive: <Result>(
-    sessionKey: string,
-    operation: () => Promise<Result>
-  ) => Promise<Result>;
+  runExclusive<Result>(sessionKey: string, operation: () => Promise<Result>): Promise<Result>;
 };
 
 type ReleaseSessionLock = () => boolean;
 type SessionLockWaiter = (release: ReleaseSessionLock) => void;
 
-class SessionLock {
+class ProcessLocalSessionLock {
   private locked = false;
   private readonly waiters = new Set<SessionLockWaiter>();
 
-  public readonly acquire = async (): Promise<ReleaseSessionLock> => {
+  public async acquire(): Promise<ReleaseSessionLock> {
     if (!this.locked) {
       this.locked = true;
-      return this.release;
+      return this.release.bind(this);
     }
 
     return new Promise<ReleaseSessionLock>((resolve) => {
       this.waiters.add(resolve);
     });
-  };
+  }
 
-  private readonly release = () => {
+  private release() {
     const nextWaiter = this.waiters.values().next();
 
     if (!nextWaiter.done) {
       this.waiters.delete(nextWaiter.value);
-      nextWaiter.value(this.release);
+      nextWaiter.value(this.release.bind(this));
       return false;
     }
 
     this.locked = false;
     return true;
-  };
+  }
 }
 
 /**
@@ -51,14 +48,14 @@ class SessionLock {
  * order is not part of this coordinator's contract.
  */
 export class ProcessLocalSessionCoordinator implements SessionCoordinator {
-  private readonly sessionLocks = new Map<string, SessionLock>();
+  private readonly sessionLocks = new Map<string, ProcessLocalSessionLock>();
 
-  public readonly runExclusive = async <Result>(
+  public async runExclusive<Result>(
     sessionKey: string,
     operation: () => Promise<Result>
-  ): Promise<Result> => {
+  ): Promise<Result> {
     const existingLock = this.sessionLocks.get(sessionKey);
-    const sessionLock = existingLock ?? new SessionLock();
+    const sessionLock = existingLock ?? new ProcessLocalSessionLock();
 
     if (!existingLock) {
       this.sessionLocks.set(sessionKey, sessionLock);
@@ -73,7 +70,7 @@ export class ProcessLocalSessionCoordinator implements SessionCoordinator {
         this.sessionLocks.delete(sessionKey);
       }
     }
-  };
+  }
 }
 
 export const createProcessLocalSessionCoordinator = (): SessionCoordinator =>

--- a/packages/react-router/src/infrastructure/session/session-coordinator.ts
+++ b/packages/react-router/src/infrastructure/session/session-coordinator.ts
@@ -1,0 +1,71 @@
+export type SessionCoordinator = {
+  readonly runExclusive: <Result>(
+    sessionKey: string,
+    operation: () => Promise<Result>
+  ) => Promise<Result>;
+};
+
+type ReleaseSessionLock = () => boolean;
+type SessionLockWaiter = (release: ReleaseSessionLock) => void;
+
+class SessionLock {
+  private locked = false;
+  private readonly waiters = new Set<SessionLockWaiter>();
+
+  public readonly acquire = async (): Promise<ReleaseSessionLock> => {
+    if (!this.locked) {
+      this.locked = true;
+      return this.release;
+    }
+
+    return new Promise<ReleaseSessionLock>((resolve) => {
+      this.waiters.add(resolve);
+    });
+  };
+
+  private readonly release = () => {
+    const nextWaiter = this.waiters.values().next();
+
+    if (!nextWaiter.done) {
+      this.waiters.delete(nextWaiter.value);
+      nextWaiter.value(this.release);
+      return false;
+    }
+
+    this.locked = false;
+    return true;
+  };
+}
+
+/**
+ * Serializes operations only within the current JavaScript process. Multi-instance deployments
+ * need a distributed coordinator together with shared server-side session storage.
+ */
+export class ProcessLocalSessionCoordinator implements SessionCoordinator {
+  private readonly sessionLocks = new Map<string, SessionLock>();
+
+  public readonly runExclusive = async <Result>(
+    sessionKey: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> => {
+    const existingLock = this.sessionLocks.get(sessionKey);
+    const sessionLock = existingLock ?? new SessionLock();
+
+    if (!existingLock) {
+      this.sessionLocks.set(sessionKey, sessionLock);
+    }
+
+    const release = await sessionLock.acquire();
+
+    try {
+      return await operation();
+    } finally {
+      if (release()) {
+        this.sessionLocks.delete(sessionKey);
+      }
+    }
+  };
+}
+
+export const createProcessLocalSessionCoordinator = (): SessionCoordinator =>
+  new ProcessLocalSessionCoordinator();

--- a/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
@@ -1,0 +1,283 @@
+import type { Session, SessionStorage } from 'react-router';
+import { createSession } from 'react-router';
+
+import {
+  createProcessLocalSessionCoordinator,
+  type SessionCoordinator,
+} from './session-coordinator.js';
+import { SessionRuntime } from './session-runtime.js';
+import type { TrackedSession } from './tracked-session.js';
+
+type TestSessionData = {
+  refreshToken?: string;
+  idToken?: string;
+  locale?: string;
+  theme?: string;
+  pending?: string;
+};
+
+const sessionCookie = 'logto-session=session-id';
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+const getSessionId = (cookieHeader: string | undefined) =>
+  /logto-session=([^;]+)/.exec(cookieHeader ?? '')?.[1] ?? '';
+
+const createTestSessionStorage = (
+  initialData: TestSessionData,
+  beforeCommit?: () => Promise<void>
+) => {
+  const sessions = new Map<string, TestSessionData>([['session-id', structuredClone(initialData)]]);
+
+  const commitSession = vi.fn(async (session: Session<TestSessionData>) => {
+    await beforeCommit?.();
+    sessions.set(session.id, structuredClone(session.data));
+    const cookiePath = session.has('theme') ? 'final' : 'checkpoint';
+
+    return `logto-session=${session.id}; Path=/${cookiePath}; HttpOnly`;
+  });
+  const destroySession = vi.fn(async (session: Session<TestSessionData>) => {
+    sessions.delete(session.id);
+
+    return 'logto-session=; Max-Age=0';
+  });
+
+  const getSession = vi.fn(async (cookieHeader: string | undefined) => {
+    const sessionId = getSessionId(cookieHeader ?? undefined);
+    const data = sessions.get(sessionId) ?? {};
+
+    return createSession(structuredClone(data), sessionId);
+  });
+
+  const sessionStorage: SessionStorage<TestSessionData> = {
+    getSession: async (cookieHeader) => getSession(cookieHeader ?? undefined),
+    commitSession,
+    destroySession,
+  };
+
+  return {
+    sessionStorage,
+    getData: () => structuredClone(sessions.get('session-id') ?? {}),
+    getSession,
+    commitSession,
+    destroySession,
+  };
+};
+
+const createRuntime = async (
+  sessionStorage: SessionStorage<TestSessionData>,
+  sessionCoordinator = createProcessLocalSessionCoordinator()
+) =>
+  SessionRuntime.create({
+    cookieHeader: sessionCookie,
+    sessionStorage,
+    sessionCoordinator,
+  });
+
+describe('infrastructure:session:SessionRuntime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('merges delayed mutations into the latest committed session', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old', locale: 'en' });
+    const coordinator = createProcessLocalSessionCoordinator();
+    const delayedRuntime = await createRuntime(store.sessionStorage, coordinator);
+    const refreshRuntime = await createRuntime(store.sessionStorage, coordinator);
+
+    delayedRuntime.session.set('theme', 'dark');
+
+    await refreshRuntime.checkpoint(async (session) => {
+      session.set('refreshToken', 'rotated');
+    });
+    await delayedRuntime.finalize();
+
+    expect(store.getData()).toEqual({
+      refreshToken: 'rotated',
+      locale: 'en',
+      theme: 'dark',
+    });
+    expect(store.commitSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the stable session ID as the coordination key', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const observeSessionKey = vi.fn();
+    const sessionCoordinator: SessionCoordinator = {
+      runExclusive: async (sessionKey, operation) => {
+        observeSessionKey(sessionKey);
+        return operation();
+      },
+    };
+    const runtime = await createRuntime(store.sessionStorage, sessionCoordinator);
+
+    runtime.session.set('theme', 'dark');
+    await runtime.finalize();
+
+    expect(observeSessionKey).toHaveBeenCalledOnce();
+    expect(observeSessionKey).toHaveBeenCalledWith('session-id');
+  });
+
+  it('does not share coordination keys for cookie-only sessions', async () => {
+    const observeSessionKey = vi.fn();
+    const sessionCoordinator: SessionCoordinator = {
+      runExclusive: async (sessionKey, operation) => {
+        observeSessionKey(sessionKey);
+        return operation();
+      },
+    };
+    const sessionStorage: SessionStorage<TestSessionData> = {
+      getSession: async () => createSession<TestSessionData>({}),
+      commitSession: async () => 'logto-session=value; Path=/',
+      destroySession: async () => 'logto-session=; Max-Age=0',
+    };
+    const firstRuntime = await createRuntime(sessionStorage, sessionCoordinator);
+    const secondRuntime = await createRuntime(sessionStorage, sessionCoordinator);
+
+    firstRuntime.session.set('theme', 'dark');
+    secondRuntime.session.set('theme', 'dark');
+    await Promise.all([firstRuntime.finalize(), secondRuntime.finalize()]);
+
+    expect(observeSessionKey).toHaveBeenCalledTimes(2);
+    expect(observeSessionKey.mock.calls[0]?.[0]).not.toBe(observeSessionKey.mock.calls[1]?.[0]);
+  });
+
+  it('reloads the session inside the coordinator before refreshing', async () => {
+    vi.useFakeTimers();
+
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const coordinator = createProcessLocalSessionCoordinator();
+    const firstRuntime = await createRuntime(store.sessionStorage, coordinator);
+    const secondRuntime = await createRuntime(store.sessionStorage, coordinator);
+    const rotateRefreshToken = vi.fn(async (session: TrackedSession<TestSessionData>) => {
+      await delay(10);
+      session.set('refreshToken', 'rotated');
+    });
+    const refresh = async (runtime: SessionRuntime<TestSessionData>) =>
+      runtime.checkpoint(async (session) => {
+        if (session.get('refreshToken') === 'old') {
+          await rotateRefreshToken(session);
+        }
+      });
+
+    const first = refresh(firstRuntime);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(rotateRefreshToken).toHaveBeenCalledOnce();
+
+    const second = refresh(secondRuntime);
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.all([first, second]);
+
+    expect(rotateRefreshToken).toHaveBeenCalledOnce();
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(secondRuntime.session.get('refreshToken')).toBe('rotated');
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('keeps pending mutations when a checkpoint fails', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await createRuntime(store.sessionStorage);
+
+    runtime.session.set('theme', 'dark');
+
+    await expect(
+      runtime.checkpoint(async (session) => {
+        session.set('refreshToken', 'not-committed');
+        throw new Error('refresh failed');
+      })
+    ).rejects.toThrow('refresh failed');
+
+    expect(store.getData()).toEqual({ refreshToken: 'old' });
+    expect(runtime.session.get('theme')).toBe('dark');
+
+    await runtime.finalize();
+
+    expect(store.getData()).toEqual({ refreshToken: 'old', theme: 'dark' });
+  });
+
+  it('commits mutations made through the request session during a checkpoint', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await createRuntime(store.sessionStorage);
+
+    await runtime.checkpoint(async () => {
+      runtime.session.set('theme', 'dark');
+    });
+
+    expect(store.getData()).toEqual({ refreshToken: 'old', theme: 'dark' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+    expect(runtime.session.hasPendingMutations).toBe(false);
+  });
+
+  it('retains request mutations made while a checkpoint commit is pending', async () => {
+    vi.useFakeTimers();
+
+    const commitStarted = vi.fn();
+    const store = createTestSessionStorage({ refreshToken: 'old' }, async () => {
+      commitStarted();
+      await delay(25);
+    });
+    const runtime = await createRuntime(store.sessionStorage);
+
+    const checkpoint = runtime.checkpoint(async (session) => {
+      session.set('refreshToken', 'rotated');
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(commitStarted).toHaveBeenCalledOnce();
+
+    runtime.session.set('theme', 'dark');
+    await vi.advanceTimersByTimeAsync(25);
+    await checkpoint;
+
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(runtime.session.hasPendingMutations).toBe(true);
+    expect(runtime.session.get('theme')).toBe('dark');
+
+    const finalize = runtime.finalize();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await finalize;
+
+    expect(store.getData()).toEqual({ refreshToken: 'rotated', theme: 'dark' });
+  });
+
+  it('returns the newest cookie header produced by the request', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await createRuntime(store.sessionStorage);
+
+    await runtime.checkpoint(async (session) => {
+      session.set('refreshToken', 'rotated');
+    });
+    expect(runtime.getResponseCookieHeader()).toBe(
+      'logto-session=session-id; Path=/checkpoint; HttpOnly'
+    );
+
+    runtime.session.set('theme', 'dark');
+
+    const cookieHeader = await runtime.finalize();
+
+    expect(cookieHeader).toBe('logto-session=session-id; Path=/final; HttpOnly');
+    expect(store.getSession).toHaveBeenLastCalledWith('logto-session=session-id');
+  });
+
+  it('destroys the latest session as a coordinated checkpoint', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token' });
+    const runtime = await createRuntime(store.sessionStorage);
+
+    runtime.session.set('pending', 'value');
+
+    const idToken = await runtime.destroy(async (session) => session.get('idToken'));
+
+    expect(idToken).toBe('id-token');
+    expect(store.getData()).toEqual({});
+    expect(store.destroySession).toHaveBeenCalledOnce();
+    expect(runtime.session.data).toEqual({});
+    await expect(runtime.finalize()).resolves.toBe('logto-session=; Max-Age=0');
+    await expect(runtime.checkpoint(async () => true)).rejects.toThrow(
+      'Cannot update a destroyed session.'
+    );
+  });
+});

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -4,18 +4,29 @@ import { createSession } from 'react-router';
 import type { SessionCoordinator } from './session-coordinator.js';
 import { TrackedSession } from './tracked-session.js';
 
+/**
+ * Work performed against the latest coordinated session state. The provided session must not be
+ * retained after the operation settles.
+ */
 export type SessionOperation<
   Result,
   Data extends SessionData = SessionData,
   FlashData extends SessionData = Data,
 > = (session: TrackedSession<Data, FlashData>) => Promise<Result>;
 
+/** Inputs for creating a request-scoped session runtime. */
 export type SessionRuntimeOptions<
   Data extends SessionData = SessionData,
   FlashData extends SessionData = Data,
 > = Readonly<{
+  /** The incoming request's `Cookie` header. */
   cookieHeader: string | undefined;
+  /**
+   * React Router session storage. Cross-request coordination requires stable session IDs;
+   * multi-instance coordination also requires shared server-side storage.
+   */
   sessionStorage: SessionStorage<Data, FlashData>;
+  /** Serializes persistence operations that share a session identifier. */
   sessionCoordinator: SessionCoordinator;
 }>;
 
@@ -39,14 +50,18 @@ const getRequestCookieHeader = (setCookieHeader: string) => {
 };
 
 /**
+ * Tracks one request's session mutations and coordinates persistence against the latest stored
+ * state. Create one runtime per request and finalize it before producing the response.
+ *
  * Cross-request coordination requires storage that returns a stable session ID. Cookie-only
- * sessions receive request-local keys because their state cannot be reloaded after another
- * response commits it.
+ * sessions receive request-local keys because they cannot reload state committed by another
+ * response.
  */
 export class SessionRuntime<
   Data extends SessionData = SessionData,
   FlashData extends SessionData = Data,
 > {
+  /** Creates a request-scoped runtime from the incoming request cookie. */
   public static readonly create = async <
     Data extends SessionData = SessionData,
     FlashData extends SessionData = Data,
@@ -62,6 +77,7 @@ export class SessionRuntime<
     });
   };
 
+  /** The current session view. Its mutations remain pending until checkpoint or finalization. */
   public readonly session: TrackedSession<Data, FlashData>;
 
   private currentCookieHeader: string | undefined;
@@ -79,8 +95,13 @@ export class SessionRuntime<
     this.session = new TrackedSession(options.session);
   }
 
+  /** Returns the latest response `Set-Cookie` header produced by this runtime. */
   public readonly getResponseCookieHeader = () => this.responseCookieHeader;
 
+  /**
+   * Reloads and updates the session under coordination, then persists the resulting state.
+   * Mutations recorded on {@link session} while the operation is in flight remain pending.
+   */
   public readonly checkpoint = async <Result>(
     operation: SessionOperation<Result, Data, FlashData>
   ): Promise<Result> => {
@@ -117,6 +138,10 @@ export class SessionRuntime<
     });
   };
 
+  /**
+   * Runs an operation against the latest session, then destroys it under coordination. Once
+   * destroyed, further checkpoints and destruction fail and finalization performs no commit.
+   */
   public readonly destroy = async <Result>(
     operation: SessionOperation<Result, Data, FlashData>
   ): Promise<Result> => {
@@ -141,6 +166,7 @@ export class SessionRuntime<
     });
   };
 
+  /** Commits remaining mutations once and returns the latest response `Set-Cookie` header. */
   public readonly finalize = async () => {
     if (this.destroyed || !this.session.hasPendingMutations) {
       return this.responseCookieHeader;

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -1,0 +1,159 @@
+import type { Session, SessionData, SessionStorage } from 'react-router';
+import { createSession } from 'react-router';
+
+import type { SessionCoordinator } from './session-coordinator.js';
+import { TrackedSession } from './tracked-session.js';
+
+export type SessionOperation<
+  Result,
+  Data extends SessionData = SessionData,
+  FlashData extends SessionData = Data,
+> = (session: TrackedSession<Data, FlashData>) => Promise<Result>;
+
+export type SessionRuntimeOptions<
+  Data extends SessionData = SessionData,
+  FlashData extends SessionData = Data,
+> = Readonly<{
+  cookieHeader: string | undefined;
+  sessionStorage: SessionStorage<Data, FlashData>;
+  sessionCoordinator: SessionCoordinator;
+}>;
+
+const createSessionKey = (session: Session) => {
+  if (session.id) {
+    return session.id;
+  }
+
+  // Cookie-backed sessions cannot reload state committed by another response.
+  return globalThis.crypto.randomUUID();
+};
+
+const getRequestCookieHeader = (setCookieHeader: string) => {
+  const attributeSeparatorIndex = setCookieHeader.indexOf(';');
+
+  if (attributeSeparatorIndex === -1) {
+    return setCookieHeader;
+  }
+
+  return setCookieHeader.slice(0, attributeSeparatorIndex);
+};
+
+/**
+ * Cross-request coordination requires storage that returns a stable session ID. Cookie-only
+ * sessions receive request-local keys because their state cannot be reloaded after another
+ * response commits it.
+ */
+export class SessionRuntime<
+  Data extends SessionData = SessionData,
+  FlashData extends SessionData = Data,
+> {
+  public static readonly create = async <
+    Data extends SessionData = SessionData,
+    FlashData extends SessionData = Data,
+  >(
+    options: SessionRuntimeOptions<Data, FlashData>
+  ) => {
+    const session = await options.sessionStorage.getSession(options.cookieHeader);
+
+    return new SessionRuntime({
+      ...options,
+      session,
+      sessionKey: createSessionKey(session),
+    });
+  };
+
+  public readonly session: TrackedSession<Data, FlashData>;
+
+  private currentCookieHeader: string | undefined;
+  private responseCookieHeader: string | undefined;
+  private destroyed = false;
+
+  private constructor(
+    private readonly options: SessionRuntimeOptions<Data, FlashData> &
+      Readonly<{
+        session: Session<Data, FlashData>;
+        sessionKey: string;
+      }>
+  ) {
+    this.currentCookieHeader = options.cookieHeader;
+    this.session = new TrackedSession(options.session);
+  }
+
+  public readonly getResponseCookieHeader = () => this.responseCookieHeader;
+
+  public readonly checkpoint = async <Result>(
+    operation: SessionOperation<Result, Data, FlashData>
+  ): Promise<Result> => {
+    this.assertActive();
+
+    const { sessionCoordinator, sessionStorage, sessionKey } = this.options;
+
+    return sessionCoordinator.runExclusive(sessionKey, async () => {
+      const latestSession = await sessionStorage.getSession(this.currentCookieHeader);
+      const replayedMutationCount = this.session.pendingMutationCount;
+
+      this.session.applyPendingMutations(latestSession, 0, replayedMutationCount);
+
+      const checkpointSession = new TrackedSession(latestSession);
+      const result = await operation(checkpointSession);
+      const mutationCountBeforeCommit = this.session.pendingMutationCount;
+
+      this.session.applyPendingMutations(
+        latestSession,
+        replayedMutationCount,
+        mutationCountBeforeCommit
+      );
+
+      if (mutationCountBeforeCommit > 0 || checkpointSession.hasPendingMutations) {
+        const cookieHeader = await sessionStorage.commitSession(latestSession);
+
+        this.currentCookieHeader = getRequestCookieHeader(cookieHeader);
+        this.responseCookieHeader = cookieHeader;
+      }
+
+      this.session.adopt(latestSession, mutationCountBeforeCommit);
+
+      return result;
+    });
+  };
+
+  public readonly destroy = async <Result>(
+    operation: SessionOperation<Result, Data, FlashData>
+  ): Promise<Result> => {
+    this.assertActive();
+
+    const { sessionCoordinator, sessionStorage, sessionKey } = this.options;
+
+    return sessionCoordinator.runExclusive(sessionKey, async () => {
+      const latestSession = await sessionStorage.getSession(this.currentCookieHeader);
+
+      this.session.applyPendingMutations(latestSession);
+
+      const result = await operation(new TrackedSession(latestSession));
+      const cookieHeader = await sessionStorage.destroySession(latestSession);
+
+      this.currentCookieHeader = getRequestCookieHeader(cookieHeader);
+      this.responseCookieHeader = cookieHeader;
+      this.destroyed = true;
+      this.session.adopt(createSession<Data, FlashData>());
+
+      return result;
+    });
+  };
+
+  public readonly finalize = async () => {
+    if (this.destroyed || !this.session.hasPendingMutations) {
+      return this.responseCookieHeader;
+    }
+
+    await this.checkpoint(async () => true);
+
+    return this.responseCookieHeader;
+  };
+
+  private readonly assertActive = () => {
+    if (this.destroyed) {
+      throw new Error('Cannot update a destroyed session.');
+    }
+  };
+}

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -62,12 +62,10 @@ export class SessionRuntime<
   FlashData extends SessionData = Data,
 > {
   /** Creates a request-scoped runtime from the incoming request cookie. */
-  public static readonly create = async <
+  public static async create<
     Data extends SessionData = SessionData,
     FlashData extends SessionData = Data,
-  >(
-    options: SessionRuntimeOptions<Data, FlashData>
-  ) => {
+  >(options: SessionRuntimeOptions<Data, FlashData>) {
     const session = await options.sessionStorage.getSession(options.cookieHeader);
 
     return new SessionRuntime({
@@ -75,7 +73,7 @@ export class SessionRuntime<
       session,
       sessionKey: createSessionKey(session),
     });
-  };
+  }
 
   /** The current session view. Its mutations remain pending until checkpoint or finalization. */
   public readonly session: TrackedSession<Data, FlashData>;
@@ -96,15 +94,17 @@ export class SessionRuntime<
   }
 
   /** Returns the latest response `Set-Cookie` header produced by this runtime. */
-  public readonly getResponseCookieHeader = () => this.responseCookieHeader;
+  public getResponseCookieHeader() {
+    return this.responseCookieHeader;
+  }
 
   /**
    * Reloads and updates the session under coordination, then persists the resulting state.
    * Mutations recorded on {@link session} while the operation is in flight remain pending.
    */
-  public readonly checkpoint = async <Result>(
+  public async checkpoint<Result>(
     operation: SessionOperation<Result, Data, FlashData>
-  ): Promise<Result> => {
+  ): Promise<Result> {
     this.assertActive();
 
     const { sessionCoordinator, sessionStorage, sessionKey } = this.options;
@@ -136,15 +136,15 @@ export class SessionRuntime<
 
       return result;
     });
-  };
+  }
 
   /**
    * Runs an operation against the latest session, then destroys it under coordination. Once
    * destroyed, further checkpoints and destruction fail and finalization performs no commit.
    */
-  public readonly destroy = async <Result>(
+  public async destroy<Result>(
     operation: SessionOperation<Result, Data, FlashData>
-  ): Promise<Result> => {
+  ): Promise<Result> {
     this.assertActive();
 
     const { sessionCoordinator, sessionStorage, sessionKey } = this.options;
@@ -164,10 +164,10 @@ export class SessionRuntime<
 
       return result;
     });
-  };
+  }
 
   /** Commits remaining mutations once and returns the latest response `Set-Cookie` header. */
-  public readonly finalize = async () => {
+  public async finalize() {
     if (this.destroyed || !this.session.hasPendingMutations) {
       return this.responseCookieHeader;
     }
@@ -175,11 +175,11 @@ export class SessionRuntime<
     await this.checkpoint(async () => true);
 
     return this.responseCookieHeader;
-  };
+  }
 
-  private readonly assertActive = () => {
+  private assertActive() {
     if (this.destroyed) {
       throw new Error('Cannot update a destroyed session.');
     }
-  };
+  }
 }

--- a/packages/react-router/src/infrastructure/session/tracked-session.spec.ts
+++ b/packages/react-router/src/infrastructure/session/tracked-session.spec.ts
@@ -1,0 +1,70 @@
+import { createSession } from 'react-router';
+
+import { TrackedSession } from './tracked-session.js';
+
+describe('infrastructure:session:TrackedSession', () => {
+  it('replays mutations without replacing unrelated session data', () => {
+    const trackedSession = new TrackedSession(
+      createSession({ refreshToken: 'old', theme: 'light' }, 'session-id')
+    );
+
+    trackedSession.set('refreshToken', 'new');
+    trackedSession.unset('theme');
+
+    const latestSession = createSession(
+      { refreshToken: 'other', theme: 'light', concurrent: 'preserved' },
+      'session-id'
+    );
+
+    trackedSession.applyPendingMutations(latestSession);
+
+    expect(latestSession.data).toEqual({
+      refreshToken: 'new',
+      concurrent: 'preserved',
+    });
+  });
+
+  it('replays flash consumption without replacing unrelated data', () => {
+    type Data = { concurrent?: string };
+    type FlashData = { notice: string };
+
+    const initialSession = createSession<Data, FlashData>({}, 'session-id');
+    initialSession.flash('notice', 'read once');
+    const trackedSession = new TrackedSession(initialSession);
+
+    expect(trackedSession.get('notice')).toBe('read once');
+
+    const latestSession = createSession<Data, FlashData>({ concurrent: 'preserved' }, 'session-id');
+    latestSession.flash('notice', 'read once');
+
+    trackedSession.applyPendingMutations(latestSession);
+
+    expect(latestSession.data).toEqual({ concurrent: 'preserved' });
+  });
+
+  it('replays flash writes', () => {
+    type Data = { concurrent?: string };
+    type FlashData = { notice: string };
+
+    const trackedSession = new TrackedSession(createSession<Data, FlashData>({}, 'session-id'));
+    trackedSession.flash('notice', 'read once');
+
+    const latestSession = createSession<Data, FlashData>({ concurrent: 'preserved' }, 'session-id');
+    trackedSession.applyPendingMutations(latestSession);
+
+    expect(latestSession.get('notice')).toBe('read once');
+    expect(latestSession.data).toEqual({ concurrent: 'preserved' });
+  });
+
+  it('clears pending mutations after adopting a committed session', () => {
+    const trackedSession = new TrackedSession(createSession({ value: 'old' }, 'session-id'));
+
+    trackedSession.set('value', 'new');
+    expect(trackedSession.hasPendingMutations).toBe(true);
+
+    trackedSession.adopt(createSession({ value: 'committed' }, 'session-id'));
+
+    expect(trackedSession.hasPendingMutations).toBe(false);
+    expect(trackedSession.get('value')).toBe('committed');
+  });
+});

--- a/packages/react-router/src/infrastructure/session/tracked-session.ts
+++ b/packages/react-router/src/infrastructure/session/tracked-session.ts
@@ -1,0 +1,107 @@
+import type { Session, SessionData } from 'react-router';
+
+type SessionMutation<Data, FlashData> = (session: Session<Data, FlashData>) => void;
+
+const applySessionMutations = <Data, FlashData>(
+  session: Session<Data, FlashData>,
+  mutations: ReadonlyArray<SessionMutation<Data, FlashData>>
+) => {
+  for (const mutation of mutations) {
+    mutation(session);
+  }
+};
+
+export class TrackedSession<Data = SessionData, FlashData = Data>
+  implements Session<Data, FlashData>
+{
+  private mutations: ReadonlyArray<SessionMutation<Data, FlashData>> = [];
+
+  public constructor(private currentSession: Session<Data, FlashData>) {}
+
+  public get id() {
+    return this.currentSession.id;
+  }
+
+  public get data() {
+    return this.currentSession.data;
+  }
+
+  public get hasPendingMutations() {
+    return this.mutations.length > 0;
+  }
+
+  public get pendingMutationCount() {
+    return this.mutations.length;
+  }
+
+  public has(name: (keyof Data | keyof FlashData) & string) {
+    return this.currentSession.has(name);
+  }
+
+  public get<Key extends (keyof Data | keyof FlashData) & string>(name: Key) {
+    const dataKeysBeforeGet = Object.keys(this.currentSession.data);
+    const value = this.currentSession.get(name);
+    const dataKeysAfterGet = new Set(Object.keys(this.currentSession.data));
+    const mutatedSession = dataKeysBeforeGet.some((key) => !dataKeysAfterGet.has(key));
+
+    if (mutatedSession) {
+      this.mutations = [
+        ...this.mutations,
+        (session) => {
+          session.get(name);
+        },
+      ];
+    }
+
+    return value;
+  }
+
+  public set<Key extends keyof Data & string>(name: Key, value: Data[Key]) {
+    this.currentSession.set(name, value);
+    this.mutations = [
+      ...this.mutations,
+      (session) => {
+        session.set(name, value);
+      },
+    ];
+  }
+
+  public flash<Key extends keyof FlashData & string>(name: Key, value: FlashData[Key]) {
+    this.currentSession.flash(name, value);
+    this.mutations = [
+      ...this.mutations,
+      (session) => {
+        session.flash(name, value);
+      },
+    ];
+  }
+
+  public unset(name: keyof Data & string) {
+    this.currentSession.unset(name);
+    this.mutations = [
+      ...this.mutations,
+      (session) => {
+        session.unset(name);
+      },
+    ];
+  }
+
+  public readonly applyPendingMutations = (
+    session: Session<Data, FlashData>,
+    startIndex = 0,
+    endIndex = this.mutations.length
+  ) => {
+    applySessionMutations(session, this.mutations.slice(startIndex, endIndex));
+  };
+
+  public readonly adopt = (
+    session: Session<Data, FlashData>,
+    appliedMutationCount = this.mutations.length
+  ) => {
+    const remainingMutations = this.mutations.slice(appliedMutationCount);
+
+    this.currentSession = session;
+    applySessionMutations(this.currentSession, remainingMutations);
+    this.mutations = remainingMutations;
+  };
+}

--- a/packages/react-router/src/infrastructure/session/tracked-session.ts
+++ b/packages/react-router/src/infrastructure/session/tracked-session.ts
@@ -18,7 +18,7 @@ const applySessionMutations = <Data, FlashData>(
 export class TrackedSession<Data = SessionData, FlashData = Data>
   implements Session<Data, FlashData>
 {
-  private mutations: ReadonlyArray<SessionMutation<Data, FlashData>> = [];
+  private mutations: Array<SessionMutation<Data, FlashData>> = [];
 
   public constructor(private currentSession: Session<Data, FlashData>) {}
 
@@ -49,12 +49,9 @@ export class TrackedSession<Data = SessionData, FlashData = Data>
     const mutatedSession = dataKeysBeforeGet.some((key) => !dataKeysAfterGet.has(key));
 
     if (mutatedSession) {
-      this.mutations = [
-        ...this.mutations,
-        (session) => {
-          session.get(name);
-        },
-      ];
+      this.recordMutation((session) => {
+        session.get(name);
+      });
     }
 
     return value;
@@ -62,55 +59,48 @@ export class TrackedSession<Data = SessionData, FlashData = Data>
 
   public set<Key extends keyof Data & string>(name: Key, value: Data[Key]) {
     this.currentSession.set(name, value);
-    this.mutations = [
-      ...this.mutations,
-      (session) => {
-        session.set(name, value);
-      },
-    ];
+    this.recordMutation((session) => {
+      session.set(name, value);
+    });
   }
 
   public flash<Key extends keyof FlashData & string>(name: Key, value: FlashData[Key]) {
     this.currentSession.flash(name, value);
-    this.mutations = [
-      ...this.mutations,
-      (session) => {
-        session.flash(name, value);
-      },
-    ];
+    this.recordMutation((session) => {
+      session.flash(name, value);
+    });
   }
 
   public unset(name: keyof Data & string) {
     this.currentSession.unset(name);
-    this.mutations = [
-      ...this.mutations,
-      (session) => {
-        session.unset(name);
-      },
-    ];
+    this.recordMutation((session) => {
+      session.unset(name);
+    });
   }
 
   /** Replays pending mutations in the half-open range `[startIndex, endIndex)`. */
-  public readonly applyPendingMutations = (
+  public applyPendingMutations(
     session: Session<Data, FlashData>,
     startIndex = 0,
     endIndex = this.mutations.length
-  ) => {
+  ) {
     applySessionMutations(session, this.mutations.slice(startIndex, endIndex));
-  };
+  }
 
   /**
    * Replaces the backing session, removes the applied mutation prefix, and replays the remaining
    * tail so the current view still includes every pending mutation.
    */
-  public readonly adopt = (
-    session: Session<Data, FlashData>,
-    appliedMutationCount = this.mutations.length
-  ) => {
+  public adopt(session: Session<Data, FlashData>, appliedMutationCount = this.mutations.length) {
     const remainingMutations = this.mutations.slice(appliedMutationCount);
 
     this.currentSession = session;
     applySessionMutations(this.currentSession, remainingMutations);
     this.mutations = remainingMutations;
-  };
+  }
+
+  private recordMutation(mutation: SessionMutation<Data, FlashData>) {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- This class exclusively owns its mutable mutation log.
+    this.mutations.push(mutation);
+  }
 }

--- a/packages/react-router/src/infrastructure/session/tracked-session.ts
+++ b/packages/react-router/src/infrastructure/session/tracked-session.ts
@@ -11,6 +11,10 @@ const applySessionMutations = <Data, FlashData>(
   }
 };
 
+/**
+ * Wraps a React Router session and records mutations so they can be replayed onto freshly loaded
+ * session state before persistence.
+ */
 export class TrackedSession<Data = SessionData, FlashData = Data>
   implements Session<Data, FlashData>
 {
@@ -86,6 +90,7 @@ export class TrackedSession<Data = SessionData, FlashData = Data>
     ];
   }
 
+  /** Replays pending mutations in the half-open range `[startIndex, endIndex)`. */
   public readonly applyPendingMutations = (
     session: Session<Data, FlashData>,
     startIndex = 0,
@@ -94,6 +99,10 @@ export class TrackedSession<Data = SessionData, FlashData = Data>
     applySessionMutations(session, this.mutations.slice(startIndex, endIndex));
   };
 
+  /**
+   * Replaces the backing session, removes the applied mutation prefix, and replays the remaining
+   * tail so the current view still includes every pending mutation.
+   */
   public readonly adopt = (
     session: Session<Data, FlashData>,
     appliedMutationCount = this.mutations.length


### PR DESCRIPTION
The React Router SDK is moving toward a middleware-first major version. A root middleware will own one request-scoped Logto context, coordinate token-related session changes, and propagate the final `Set-Cookie` response. This first stacked change isolates the session runtime so its concurrency and mutation semantics can be reviewed before it is wired into routes.

This foundation:

- replays tracked request mutations against the latest shared session state
- checkpoints token rotation and destruction under a pluggable coordinator
- preserves mutations added while a commit is in flight
- keeps request `Cookie` input separate from response `Set-Cookie` output
- documents process-local and shared storage boundaries

The remaining stack will:

- add `createLogtoReactRouter`, `logto.middleware`, typed `logto.context`, request-scoped `getContext()` and `getAccessToken()`, and response finalization
- migrate auth routes so callback exchange is committed before redirect, then remove the legacy APIs

```mermaid
sequenceDiagram
    participant A as Request A
    participant C as Session coordinator
    participant S as Shared session storage
    participant B as Request B

    A->>C: acquire(session id)
    B->>C: acquire(same session id)
    C-->>B: wait
    A->>S: reload latest session
    A->>A: run token operation
    A->>S: commit rotated session
    A->>C: release
    C-->>B: acquire
    B->>S: reload committed session
```

An active operation holds the lock until it settles, even if it is slow. Force-releasing it could allow a late commit to overwrite newer session state. Network operations should own their timeout and cancellation policy. A distributed coordinator will additionally need leases with renewal or fencing.