### PR TITLE
feat(react-router): add request middleware

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -44,7 +44,7 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "react-router": ">=7"
+    "react-router": "^7.9.0"
   },
   "eslintConfig": {
     "extends": "@silverhand"

--- a/packages/react-router/src/create-logto-react-router.ts
+++ b/packages/react-router/src/create-logto-react-router.ts
@@ -1,0 +1,42 @@
+import type { MiddlewareFunction, RouterContext, SessionStorage } from 'react-router';
+import { createContext } from 'react-router';
+
+import {
+  createProcessLocalSessionCoordinator,
+  type SessionCoordinator,
+} from './infrastructure/session/index.js';
+import { createLogtoMiddleware } from './middleware/create-middleware.js';
+import type { LogtoRequestContext } from './middleware/request-context.js';
+import type { LogtoReactRouterConfig } from './types.js';
+
+type CreateLogtoReactRouterDependencies = Readonly<{
+  sessionStorage: SessionStorage;
+  sessionCoordinator?: SessionCoordinator;
+}>;
+
+export type LogtoReactRouter = Readonly<{
+  context: RouterContext<LogtoRequestContext>;
+  middleware: MiddlewareFunction<Response>;
+}>;
+
+/**
+ * Creates a server-side Logto integration for React Router Framework Mode. The middleware relies
+ * on the framework response pipeline to persist session changes through `Set-Cookie` headers.
+ */
+export const createLogtoReactRouter = (
+  config: LogtoReactRouterConfig,
+  { sessionStorage, sessionCoordinator }: CreateLogtoReactRouterDependencies
+): LogtoReactRouter => {
+  const context = createContext<LogtoRequestContext>();
+  const coordinator = sessionCoordinator ?? createProcessLocalSessionCoordinator();
+
+  return Object.freeze({
+    context,
+    middleware: createLogtoMiddleware({
+      config,
+      context,
+      sessionStorage,
+      sessionCoordinator: coordinator,
+    }),
+  });
+};

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -1,16 +1,13 @@
-import type { GetContextParameters, LogtoConfig } from '@logto/node';
+import type { GetContextParameters } from '@logto/node';
 import type { SessionStorage } from 'react-router';
 
 import { makeLogtoAdapter } from './infrastructure/logto/index.js';
+import type { LogtoReactRouterConfig } from './types.js';
 import { makeGetContext } from './useCases/getContext/index.js';
 import { makeHandleAuthRoutes } from './useCases/handleAuthRoutes/index.js';
 
-type Config = Readonly<LogtoConfig> & {
-  readonly baseUrl: string;
-};
-
 export const makeLogtoReactRouter = (
-  config: Config,
+  config: LogtoReactRouterConfig,
   deps: {
     sessionStorage: SessionStorage;
   }
@@ -35,6 +32,22 @@ export const makeLogtoReactRouter = (
       }),
   });
 };
+
+export { createLogtoReactRouter } from './create-logto-react-router.js';
+export type { LogtoReactRouter } from './create-logto-react-router.js';
+
+export {
+  ProcessLocalSessionCoordinator,
+  createProcessLocalSessionCoordinator,
+  type SessionCoordinator,
+} from './infrastructure/session/index.js';
+export type {
+  GetAccessTokenOptions,
+  GetLogtoContextOptions,
+  LogtoAuthenticationContext,
+  LogtoRequestContext,
+} from './middleware/request-context.js';
+export type { LogtoReactRouterConfig } from './types.js';
 
 export type {
   AccessTokenClaims,

--- a/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
@@ -177,25 +177,53 @@ describe('infrastructure:session:SessionRuntime', () => {
     expect(store.commitSession).toHaveBeenCalledOnce();
   });
 
-  it('keeps pending mutations when a checkpoint fails', async () => {
+  it('persists completed mutations before rethrowing a checkpoint error', async () => {
     const store = createTestSessionStorage({ refreshToken: 'old' });
     const runtime = await createRuntime(store.sessionStorage);
+    const refreshError = new Error('refresh failed');
 
     runtime.session.set('theme', 'dark');
 
     await expect(
       runtime.checkpoint(async (session) => {
-        session.set('refreshToken', 'not-committed');
-        throw new Error('refresh failed');
+        session.set('refreshToken', 'rotated');
+        throw refreshError;
       })
-    ).rejects.toThrow('refresh failed');
+    ).rejects.toBe(refreshError);
 
-    expect(store.getData()).toEqual({ refreshToken: 'old' });
+    expect(store.getData()).toEqual({ refreshToken: 'rotated', theme: 'dark' });
     expect(runtime.session.get('theme')).toBe('dark');
+    expect(runtime.session.get('refreshToken')).toBe('rotated');
+    expect(runtime.session.hasPendingMutations).toBe(false);
 
     await runtime.finalize();
 
-    expect(store.getData()).toEqual({ refreshToken: 'old', theme: 'dark' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('waits for an active checkpoint before finalizing', async () => {
+    vi.useFakeTimers();
+
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await createRuntime(store.sessionStorage);
+    const checkpoint = runtime.checkpoint(async (session) => {
+      await delay(25);
+      session.set('refreshToken', 'rotated');
+    });
+
+    const finalization = runtime.finalize();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.commitSession).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await checkpoint;
+
+    await expect(finalization).resolves.toBe(
+      'logto-session=session-id; Path=/checkpoint; HttpOnly'
+    );
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
   });
 
   it('commits mutations made through the request session during a checkpoint', async () => {

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -14,6 +14,20 @@ export type SessionOperation<
   FlashData extends SessionData = Data,
 > = (session: TrackedSession<Data, FlashData>) => Promise<Result>;
 
+type SessionOperationOutcome<Result> =
+  | Readonly<{ status: 'fulfilled'; value: Result }>
+  | Readonly<{ status: 'rejected'; error: unknown }>;
+
+const settleSessionOperation = async <Result>(
+  operation: Promise<Result>
+): Promise<SessionOperationOutcome<Result>> => {
+  try {
+    return { status: 'fulfilled', value: await operation };
+  } catch (error: unknown) {
+    return { status: 'rejected', error };
+  }
+};
+
 /** Inputs for creating a request-scoped session runtime. */
 export type SessionRuntimeOptions<
   Data extends SessionData = SessionData,
@@ -81,6 +95,7 @@ export class SessionRuntime<
   private currentCookieHeader: string | undefined;
   private responseCookieHeader: string | undefined;
   private destroyed = false;
+  private readonly activeCheckpoints = new Set<Promise<unknown>>();
 
   private constructor(
     private readonly options: SessionRuntimeOptions<Data, FlashData> &
@@ -100,6 +115,8 @@ export class SessionRuntime<
 
   /**
    * Reloads and updates the session under coordination, then persists the resulting state.
+   * Mutations completed before an operation rejects are still persisted because external effects,
+   * such as refresh-token rotation, cannot be rolled back.
    * Mutations recorded on {@link session} while the operation is in flight remain pending.
    */
   public async checkpoint<Result>(
@@ -109,14 +126,14 @@ export class SessionRuntime<
 
     const { sessionCoordinator, sessionStorage, sessionKey } = this.options;
 
-    return sessionCoordinator.runExclusive(sessionKey, async () => {
+    const checkpoint = sessionCoordinator.runExclusive(sessionKey, async () => {
       const latestSession = await sessionStorage.getSession(this.currentCookieHeader);
       const replayedMutationCount = this.session.pendingMutationCount;
 
       this.session.applyPendingMutations(latestSession, 0, replayedMutationCount);
 
       const checkpointSession = new TrackedSession(latestSession);
-      const result = await operation(checkpointSession);
+      const outcome = await settleSessionOperation(operation(checkpointSession));
       const mutationCountBeforeCommit = this.session.pendingMutationCount;
 
       this.session.applyPendingMutations(
@@ -134,8 +151,14 @@ export class SessionRuntime<
 
       this.session.adopt(latestSession, mutationCountBeforeCommit);
 
-      return result;
+      if (outcome.status === 'rejected') {
+        throw outcome.error;
+      }
+
+      return outcome.value;
     });
+
+    return this.trackCheckpoint(checkpoint);
   }
 
   /**
@@ -168,6 +191,8 @@ export class SessionRuntime<
 
   /** Commits remaining mutations once and returns the latest response `Set-Cookie` header. */
   public async finalize() {
+    await Promise.allSettled(this.activeCheckpoints);
+
     if (this.destroyed || !this.session.hasPendingMutations) {
       return this.responseCookieHeader;
     }
@@ -180,6 +205,16 @@ export class SessionRuntime<
   private assertActive() {
     if (this.destroyed) {
       throw new Error('Cannot update a destroyed session.');
+    }
+  }
+
+  private async trackCheckpoint<Result>(checkpoint: Promise<Result>) {
+    this.activeCheckpoints.add(checkpoint);
+
+    try {
+      return await checkpoint;
+    } finally {
+      this.activeCheckpoints.delete(checkpoint);
     }
   }
 }

--- a/packages/react-router/src/middleware/create-middleware.spec.ts
+++ b/packages/react-router/src/middleware/create-middleware.spec.ts
@@ -53,6 +53,44 @@ const createTestSessionStorage = (initialData: SessionData = {}) => {
   };
 };
 
+const stubTokenRefresh = () => {
+  const tokenRequest = vi.fn(async () => {
+    await delay(10);
+
+    return Response.json({
+      access_token: 'access-token',
+      refresh_token: 'rotated',
+      scope: 'read',
+      expires_in: 3600,
+    });
+  });
+  const fetchRequest = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+
+    if (url.endsWith('/oidc/.well-known/openid-configuration')) {
+      return Response.json({
+        authorization_endpoint: `${config.endpoint}/oidc/auth`,
+        token_endpoint: `${config.endpoint}/oidc/token`,
+        userinfo_endpoint: `${config.endpoint}/oidc/me`,
+        end_session_endpoint: `${config.endpoint}/oidc/session/end`,
+        revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
+        jwks_uri: `${config.endpoint}/oidc/jwks`,
+        issuer: `${config.endpoint}/oidc`,
+      });
+    }
+
+    if (url.endsWith('/oidc/token')) {
+      return tokenRequest();
+    }
+
+    return new Response('Not found', { status: 404 });
+  });
+
+  vi.stubGlobal('fetch', fetchRequest);
+
+  return tokenRequest;
+};
+
 const runRoute = async (
   middleware: MiddlewareFunction<Response>,
   handler: RouteHandler,
@@ -107,6 +145,7 @@ const runRoute = async (
 describe('middleware:createLogtoMiddleware', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it.each([
@@ -162,38 +201,7 @@ describe('middleware:createLogtoMiddleware', () => {
 
   it('coordinates access-token refreshes across concurrent requests', async () => {
     const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'old' });
-    const tokenRequest = vi.fn(async () => {
-      await delay(10);
-
-      return Response.json({
-        access_token: 'access-token',
-        refresh_token: 'rotated',
-        scope: 'read',
-        expires_in: 3600,
-      });
-    });
-    const fetchRequest = vi.fn(async (input: string | URL | Request) => {
-      const url = String(input);
-
-      if (url.endsWith('/oidc/.well-known/openid-configuration')) {
-        return Response.json({
-          authorization_endpoint: `${config.endpoint}/oidc/auth`,
-          token_endpoint: `${config.endpoint}/oidc/token`,
-          userinfo_endpoint: `${config.endpoint}/oidc/me`,
-          end_session_endpoint: `${config.endpoint}/oidc/session/end`,
-          revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
-          jwks_uri: `${config.endpoint}/oidc/jwks`,
-          issuer: `${config.endpoint}/oidc`,
-        });
-      }
-
-      if (url.endsWith('/oidc/token')) {
-        return tokenRequest();
-      }
-
-      return new Response('Not found', { status: 404 });
-    });
-    vi.stubGlobal('fetch', fetchRequest);
+    const tokenRequest = stubTokenRefresh();
     const logto = createLogtoReactRouter(config, { sessionStorage: store.sessionStorage });
     const handler: RouteHandler = async ({ context }) => {
       const accessToken = await context.get(logto.context).getAccessToken();
@@ -211,6 +219,30 @@ describe('middleware:createLogtoMiddleware', () => {
       'access-token',
     ]);
     expect(tokenRequest).toHaveBeenCalledOnce();
+    expect(store.getData()).toMatchObject({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('waits for a started access-token refresh before returning the response', async () => {
+    vi.useFakeTimers();
+
+    const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'old' });
+    const tokenRequest = stubTokenRefresh();
+    const logto = createLogtoReactRouter(config, { sessionStorage: store.sessionStorage });
+    const responsePromise = runRoute(logto.middleware, ({ context }) => {
+      void context.get(logto.context).getAccessToken();
+
+      return new Response('streaming response');
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenRequest).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    const response = await responsePromise;
+
+    expect(response.headers.get('Set-Cookie')).toContain('logto-session=session-id');
     expect(store.getData()).toMatchObject({ refreshToken: 'rotated' });
     expect(store.commitSession).toHaveBeenCalledOnce();
   });

--- a/packages/react-router/src/middleware/create-middleware.spec.ts
+++ b/packages/react-router/src/middleware/create-middleware.spec.ts
@@ -1,0 +1,217 @@
+import type {
+  LoaderFunctionArgs,
+  MiddlewareFunction,
+  RouterContextProvider,
+  Session,
+  SessionData,
+  SessionStorage,
+} from 'react-router';
+import {
+  createSession,
+  createStaticHandler,
+  RouterContextProvider as ContextProvider,
+} from 'react-router';
+
+import { createLogtoReactRouter } from '../create-logto-react-router.js';
+
+const config = {
+  endpoint: 'https://logto.example.com',
+  appId: 'app-id',
+  appSecret: 'app-secret',
+  baseUrl: 'https://app.example.com',
+};
+
+const sessionCookie = 'logto-session=session-id';
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+type RouteHandler = (
+  args: LoaderFunctionArgs<Readonly<RouterContextProvider>>
+) => Response | Promise<Response>;
+
+const createTestSessionStorage = (initialData: SessionData = {}) => {
+  const sessions = new Map<string, SessionData>([['session-id', structuredClone(initialData)]]);
+  const commitSession = vi.fn(async (session: Session) => {
+    sessions.set('session-id', structuredClone(session.data));
+
+    return `${sessionCookie}; Path=/; HttpOnly; SameSite=Lax`;
+  });
+  const sessionStorage: SessionStorage = {
+    getSession: async () =>
+      createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id'),
+    commitSession,
+    destroySession: async () => `${sessionCookie}; Max-Age=0`,
+  };
+
+  return {
+    commitSession,
+    sessionStorage,
+    getData: () => structuredClone(sessions.get('session-id') ?? {}),
+  };
+};
+
+const runRoute = async (
+  middleware: MiddlewareFunction<Response>,
+  handler: RouteHandler,
+  method = 'GET'
+) => {
+  // `createStaticHandler` uses the Data Mode middleware type even when its response generator
+  // supplies the Framework Mode response pipeline exercised here.
+  const dataMiddleware: MiddlewareFunction = async (args, next) =>
+    middleware(args, async () => {
+      const result = await next();
+
+      if (!(result instanceof Response)) {
+        throw new TypeError('Expected downstream middleware to return a response.');
+      }
+
+      return result;
+    });
+  const staticHandler = createStaticHandler([
+    {
+      id: 'root',
+      path: '/',
+      middleware: [dataMiddleware],
+      loader: handler,
+      action: handler,
+    },
+  ]);
+  const request = new Request('https://app.example.com/', {
+    method,
+    headers: { Cookie: sessionCookie },
+  });
+  const response: unknown = await staticHandler.queryRoute(request, {
+    routeId: 'root',
+    requestContext: new ContextProvider(),
+    generateMiddlewareResponse: async (queryRoute) => {
+      try {
+        return await queryRoute(request);
+      } catch (error: unknown) {
+        return error instanceof Response
+          ? error
+          : new Response('Internal Server Error', { status: 500 });
+      }
+    },
+  });
+
+  if (!(response instanceof Response)) {
+    throw new TypeError('Expected the route to return a response.');
+  }
+
+  return response;
+};
+
+describe('middleware:createLogtoMiddleware', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ['loader', 'GET'],
+    ['action', 'POST'],
+  ])('provides request context and commits mutations from a %s', async (source, method) => {
+    const { sessionStorage, commitSession } = createTestSessionStorage();
+    const logto = createLogtoReactRouter(config, { sessionStorage });
+    const response = await runRoute(
+      logto.middleware,
+      ({ context }) => {
+        context.get(logto.context).session.set('source', source);
+
+        return new Response(source);
+      },
+      method
+    );
+
+    await expect(response.text()).resolves.toBe(source);
+    expect(response.headers.get('Set-Cookie')).toBe(
+      'logto-session=session-id; Path=/; HttpOnly; SameSite=Lax'
+    );
+    expect(commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('commits mutations when a route throws an error', async () => {
+    const { sessionStorage, commitSession } = createTestSessionStorage();
+    const logto = createLogtoReactRouter(config, { sessionStorage });
+    const response = await runRoute(logto.middleware, ({ context }) => {
+      context.get(logto.context).session.flash('message', 'sign in required');
+
+      throw new Error('loader failed');
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('Set-Cookie')).toContain('logto-session=session-id');
+    expect(commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('adds the session cookie to an immutable redirect response', async () => {
+    const { sessionStorage } = createTestSessionStorage();
+    const logto = createLogtoReactRouter(config, { sessionStorage });
+    const response = await runRoute(logto.middleware, ({ context }) => {
+      context.get(logto.context).session.set('redirected', true);
+
+      return Response.redirect('https://app.example.com/next');
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://app.example.com/next');
+    expect(response.headers.get('Set-Cookie')).toContain('logto-session=session-id');
+  });
+
+  it('coordinates access-token refreshes across concurrent requests', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'old' });
+    const tokenRequest = vi.fn(async () => {
+      await delay(10);
+
+      return Response.json({
+        access_token: 'access-token',
+        refresh_token: 'rotated',
+        scope: 'read',
+        expires_in: 3600,
+      });
+    });
+    const fetchRequest = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url.endsWith('/oidc/.well-known/openid-configuration')) {
+        return Response.json({
+          authorization_endpoint: `${config.endpoint}/oidc/auth`,
+          token_endpoint: `${config.endpoint}/oidc/token`,
+          userinfo_endpoint: `${config.endpoint}/oidc/me`,
+          end_session_endpoint: `${config.endpoint}/oidc/session/end`,
+          revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
+          jwks_uri: `${config.endpoint}/oidc/jwks`,
+          issuer: `${config.endpoint}/oidc`,
+        });
+      }
+
+      if (url.endsWith('/oidc/token')) {
+        return tokenRequest();
+      }
+
+      return new Response('Not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchRequest);
+    const logto = createLogtoReactRouter(config, { sessionStorage: store.sessionStorage });
+    const handler: RouteHandler = async ({ context }) => {
+      const accessToken = await context.get(logto.context).getAccessToken();
+
+      return new Response(accessToken);
+    };
+
+    const responses = await Promise.all([
+      runRoute(logto.middleware, handler),
+      runRoute(logto.middleware, handler),
+    ]);
+
+    await expect(Promise.all(responses.map(async (response) => response.text()))).resolves.toEqual([
+      'access-token',
+      'access-token',
+    ]);
+    expect(tokenRequest).toHaveBeenCalledOnce();
+    expect(store.getData()).toMatchObject({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-router/src/middleware/create-middleware.ts
+++ b/packages/react-router/src/middleware/create-middleware.ts
@@ -1,0 +1,59 @@
+import type { LogtoConfig } from '@logto/node';
+import type { MiddlewareFunction, RouterContext, Session, SessionStorage } from 'react-router';
+
+import { getCookieHeaderFromRequest } from '../framework/get-cookie-header-from-request.js';
+import { makeLogtoClient } from '../infrastructure/logto/create-client.js';
+import { createStorage } from '../infrastructure/logto/create-storage.js';
+import type { SessionCoordinator } from '../infrastructure/session/index.js';
+import { SessionRuntime } from '../infrastructure/session/index.js';
+
+import type { LogtoRequestContext } from './request-context.js';
+import { createLogtoRequestContext } from './request-context.js';
+
+type CreateLogtoMiddlewareOptions = Readonly<{
+  config: LogtoConfig;
+  context: RouterContext<LogtoRequestContext>;
+  sessionStorage: SessionStorage;
+  sessionCoordinator: SessionCoordinator;
+}>;
+
+const appendSessionCookie = (response: Response, cookieHeader: string | undefined) => {
+  if (!cookieHeader) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.append('Set-Cookie', cookieHeader);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const createLogtoRequestClientFactory = (config: LogtoConfig) => (session: Session) =>
+  makeLogtoClient(config, createStorage(session))();
+
+export const createLogtoMiddleware = ({
+  config,
+  context: logtoContext,
+  sessionStorage,
+  sessionCoordinator,
+}: CreateLogtoMiddlewareOptions): MiddlewareFunction<Response> => {
+  const createClient = createLogtoRequestClientFactory(config);
+
+  return async ({ request, context }, next) => {
+    const runtime = await SessionRuntime.create({
+      cookieHeader: getCookieHeaderFromRequest(request) ?? undefined,
+      sessionStorage,
+      sessionCoordinator,
+    });
+    context.set(logtoContext, createLogtoRequestContext(runtime, createClient));
+
+    const response = await next();
+    const cookieHeader = await runtime.finalize();
+
+    return appendSessionCookie(response, cookieHeader);
+  };
+};

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -177,6 +177,29 @@ describe('middleware:createLogtoRequestContext', () => {
     expect(store.commitSession).toHaveBeenCalledTimes(2);
   });
 
+  it('persists token mutations before propagating a token acquisition error', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const verificationError = new Error('ID token verification failed');
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      getContext: async () => authenticatedContext,
+      getAccessToken: async () => {
+        session.set('refreshToken', 'rotated');
+        throw verificationError;
+      },
+      getOrganizationToken: async () => 'organization-token',
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(context.getAccessToken()).rejects.toBe(verificationError);
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
   it('serializes refresh-token rotation across request contexts', async () => {
     vi.useFakeTimers();
 

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -79,7 +79,7 @@ describe('middleware:createLogtoRequestContext', () => {
     expect(store.commitSession).not.toHaveBeenCalled();
   });
 
-  it('checkpoints context reads that fetch user info', async () => {
+  it('commits token acquisition before fetching user info', async () => {
     const store = createTestSessionStorage({ refreshToken: 'old' });
     const runtime = await SessionRuntime.create({
       cookieHeader: sessionCookie,
@@ -89,12 +89,13 @@ describe('middleware:createLogtoRequestContext', () => {
     const getContext = vi.fn(
       async (_options?: { fetchUserInfo?: boolean }) => authenticatedContext
     );
+    const getAccessToken = vi.fn(async () => 'access-token');
     const createClient: CreateLogtoRequestClient = (session) => ({
-      getContext: async (options) => {
+      getContext,
+      getAccessToken: async () => {
         session.set('refreshToken', 'rotated');
-        return getContext(options);
+        return getAccessToken();
       },
-      getAccessToken: async () => 'access-token',
       getOrganizationToken: async () => 'organization-token',
     });
     const context = createLogtoRequestContext(runtime, createClient);
@@ -102,7 +103,38 @@ describe('middleware:createLogtoRequestContext', () => {
     await expect(context.getContext({ fetchUserInfo: true })).resolves.toEqual(
       authenticatedContext
     );
+    expect(getContext).toHaveBeenNthCalledWith(1);
     expect(getContext).toHaveBeenCalledWith({ fetchUserInfo: true });
+    expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('preserves rotated tokens when fetching user info fails', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const userInfoError = new Error('userinfo unavailable');
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      getContext: async (options) => {
+        if (options?.fetchUserInfo) {
+          throw userInfoError;
+        }
+
+        return authenticatedContext;
+      },
+      getAccessToken: async () => {
+        session.set('refreshToken', 'rotated');
+        return 'access-token';
+      },
+      getOrganizationToken: async () => 'organization-token',
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(context.getContext({ fetchUserInfo: true })).rejects.toBe(userInfoError);
     expect(store.getData()).toEqual({ refreshToken: 'rotated' });
     expect(store.commitSession).toHaveBeenCalledOnce();
   });

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -1,0 +1,195 @@
+import type { LogtoContext } from '@logto/node';
+import type { Session, SessionData, SessionStorage } from 'react-router';
+import { createSession } from 'react-router';
+
+import {
+  createProcessLocalSessionCoordinator,
+  SessionRuntime,
+} from '../infrastructure/session/index.js';
+
+import type { CreateLogtoRequestClient } from './request-context.js';
+import { createLogtoRequestContext } from './request-context.js';
+
+const sessionCookie = 'logto-session=session-id';
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+const createTestSessionStorage = (initialData: SessionData = {}) => {
+  const sessions = new Map<string, SessionData>([['session-id', structuredClone(initialData)]]);
+
+  const getSession = vi.fn(async () =>
+    createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id')
+  );
+  const commitSession = vi.fn(async (session: Session) => {
+    sessions.set('session-id', structuredClone(session.data));
+
+    return `${sessionCookie}; Path=/; HttpOnly`;
+  });
+  const sessionStorage: SessionStorage = {
+    getSession,
+    commitSession,
+    destroySession: async () => `${sessionCookie}; Max-Age=0`,
+  };
+
+  return {
+    sessionStorage,
+    commitSession,
+    getData: () => structuredClone(sessions.get('session-id') ?? {}),
+  };
+};
+
+const authenticatedContext: LogtoContext = {
+  isAuthenticated: true,
+  claims: {
+    aud: 'app-id',
+    exp: 1_700_000_000,
+    iat: 1_600_000_000,
+    iss: 'https://logto.example.com/oidc',
+    sub: 'user-id',
+  },
+};
+
+describe('middleware:createLogtoRequestContext', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads the authentication context without committing the session', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const getContext = vi.fn(
+      async (_options?: { fetchUserInfo?: boolean }) => authenticatedContext
+    );
+    const createClient: CreateLogtoRequestClient = () => ({
+      getContext,
+      getAccessToken: async () => 'access-token',
+      getOrganizationToken: async () => 'organization-token',
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(context.getContext()).resolves.toEqual(authenticatedContext);
+    expect(getContext).toHaveBeenCalledWith();
+    expect(store.commitSession).not.toHaveBeenCalled();
+  });
+
+  it('checkpoints context reads that fetch user info', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const getContext = vi.fn(
+      async (_options?: { fetchUserInfo?: boolean }) => authenticatedContext
+    );
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      getContext: async (options) => {
+        session.set('refreshToken', 'rotated');
+        return getContext(options);
+      },
+      getAccessToken: async () => 'access-token',
+      getOrganizationToken: async () => 'organization-token',
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(context.getContext({ fetchUserInfo: true })).resolves.toEqual(
+      authenticatedContext
+    );
+    expect(getContext).toHaveBeenCalledWith({ fetchUserInfo: true });
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('passes token parameters through a session checkpoint', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const getAccessToken = vi.fn(
+      async (_resource?: string, _organizationId?: string) => 'access-token'
+    );
+    const getOrganizationToken = vi.fn(async (_organizationId: string) => 'organization-token');
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      getContext: async () => authenticatedContext,
+      getAccessToken: async (resource, organizationId) => {
+        session.set('accessToken', 'cached-access-token');
+        return getAccessToken(resource, organizationId);
+      },
+      getOrganizationToken: async (organizationId) => {
+        session.set('accessToken', 'cached-organization-token');
+        return getOrganizationToken(organizationId);
+      },
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(
+      context.getAccessToken({ resource: 'https://api.example.com', organizationId: 'org-id' })
+    ).resolves.toBe('access-token');
+    await expect(context.getOrganizationToken('org-id')).resolves.toBe('organization-token');
+
+    expect(getAccessToken).toHaveBeenCalledWith('https://api.example.com', 'org-id');
+    expect(getOrganizationToken).toHaveBeenCalledWith('org-id');
+    expect(store.getData()).toEqual({
+      refreshToken: 'old',
+      accessToken: 'cached-organization-token',
+    });
+    expect(store.commitSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('serializes refresh-token rotation across request contexts', async () => {
+    vi.useFakeTimers();
+
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const sessionCoordinator = createProcessLocalSessionCoordinator();
+    const firstRuntime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+    const secondRuntime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+    const rotateRefreshToken = vi.fn(async (session: Session) => {
+      await delay(25);
+      session.set('refreshToken', 'rotated');
+    });
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      getContext: async () => authenticatedContext,
+      getAccessToken: async () => {
+        if (session.get('refreshToken') === 'old') {
+          await rotateRefreshToken(session);
+        }
+
+        return 'access-token';
+      },
+      getOrganizationToken: async () => 'organization-token',
+    });
+    const firstContext = createLogtoRequestContext(firstRuntime, createClient);
+    const secondContext = createLogtoRequestContext(secondRuntime, createClient);
+
+    const firstAccessToken = firstContext.getAccessToken();
+    await vi.advanceTimersByTimeAsync(0);
+    const secondAccessToken = secondContext.getAccessToken();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(Promise.all([firstAccessToken, secondAccessToken])).resolves.toEqual([
+      'access-token',
+      'access-token',
+    ]);
+
+    expect(rotateRefreshToken).toHaveBeenCalledOnce();
+    expect(store.getData()).toEqual({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-router/src/middleware/request-context.ts
+++ b/packages/react-router/src/middleware/request-context.ts
@@ -1,0 +1,62 @@
+import type { GetContextParameters, LogtoContext } from '@logto/node';
+import type { Session } from 'react-router';
+
+import type { SessionRuntime } from '../infrastructure/session/index.js';
+
+export type GetLogtoContextOptions = Readonly<Pick<GetContextParameters, 'fetchUserInfo'>>;
+
+export type GetAccessTokenOptions = Readonly<{
+  resource?: string;
+  organizationId?: string;
+}>;
+
+export type LogtoAuthenticationContext = Readonly<
+  Pick<LogtoContext, 'isAuthenticated' | 'claims' | 'userInfo'>
+>;
+
+export type LogtoRequestContext = Readonly<{
+  session: Session;
+  getContext: (options?: GetLogtoContextOptions) => Promise<LogtoAuthenticationContext>;
+  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string>;
+  getOrganizationToken: (organizationId: string) => Promise<string>;
+}>;
+
+type LogtoRequestClient = {
+  getContext: (options?: GetContextParameters) => Promise<LogtoContext>;
+  getAccessToken: (resource?: string, organizationId?: string) => Promise<string>;
+  getOrganizationToken: (organizationId: string) => Promise<string>;
+};
+
+export type CreateLogtoRequestClient = (session: Session) => LogtoRequestClient;
+
+export const createLogtoRequestContext = (
+  runtime: SessionRuntime,
+  createClient: CreateLogtoRequestClient
+): LogtoRequestContext => {
+  const getContext = async (options: GetLogtoContextOptions = {}) => {
+    if (!options.fetchUserInfo) {
+      return createClient(runtime.session).getContext();
+    }
+
+    return runtime.checkpoint(async (session) =>
+      createClient(session).getContext({ fetchUserInfo: true })
+    );
+  };
+
+  const getAccessToken = async ({ resource, organizationId }: GetAccessTokenOptions = {}) =>
+    runtime.checkpoint(async (session) =>
+      createClient(session).getAccessToken(resource, organizationId)
+    );
+
+  const getOrganizationToken = async (organizationId: string) =>
+    runtime.checkpoint(async (session) =>
+      createClient(session).getOrganizationToken(organizationId)
+    );
+
+  return Object.freeze({
+    session: runtime.session,
+    getContext,
+    getAccessToken,
+    getOrganizationToken,
+  });
+};

--- a/packages/react-router/src/middleware/request-context.ts
+++ b/packages/react-router/src/middleware/request-context.ts
@@ -33,20 +33,22 @@ export const createLogtoRequestContext = (
   runtime: SessionRuntime,
   createClient: CreateLogtoRequestClient
 ): LogtoRequestContext => {
-  const getContext = async (options: GetLogtoContextOptions = {}) => {
-    if (!options.fetchUserInfo) {
-      return createClient(runtime.session).getContext();
-    }
-
-    return runtime.checkpoint(async (session) =>
-      createClient(session).getContext({ fetchUserInfo: true })
-    );
-  };
-
   const getAccessToken = async ({ resource, organizationId }: GetAccessTokenOptions = {}) =>
     runtime.checkpoint(async (session) =>
       createClient(session).getAccessToken(resource, organizationId)
     );
+
+  const getContext = async (options: GetLogtoContextOptions = {}) => {
+    const context = await createClient(runtime.session).getContext();
+
+    if (!options.fetchUserInfo || !context.isAuthenticated) {
+      return context;
+    }
+
+    await getAccessToken();
+
+    return createClient(runtime.session).getContext({ fetchUserInfo: true });
+  };
 
   const getOrganizationToken = async (organizationId: string) =>
     runtime.checkpoint(async (session) =>

--- a/packages/react-router/src/types.ts
+++ b/packages/react-router/src/types.ts
@@ -1,0 +1,5 @@
+import type { LogtoConfig } from '@logto/node';
+
+export type LogtoReactRouterConfig = Readonly<LogtoConfig> & {
+  readonly baseUrl: string;
+};

--- a/packages/react-router/vitest.config.ts
+++ b/packages/react-router/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    include: ['src/**/*.spec.ts'],
   },
 });


### PR DESCRIPTION
#1169 introduced the coordinated session runtime for the React Router SDK. This second stacked change wires that runtime into React Router Framework Mode through a typed, request-scoped middleware API.

This middleware layer:

- adds `createLogtoReactRouter()` with `logto.middleware` and `logto.context`
- separates authentication context reads from explicit token acquisition
- checkpoints refresh-capable operations under the session coordinator
- propagates the final session through `Set-Cookie`
- supports custom coordination for multi-instance deployments
- covers loaders, actions, redirects, errors, and concurrent refreshes

The remaining stack will:

- migrate sign-in, callback, and sign-out routes to the middleware API
- remove the legacy React Router APIs
- update documentation and examples
- add the major-version changeset
