### PR TITLE
feat(react-router)!: replace InteractionMode type export

### DIFF
--- a/.changeset/neat-mirrors-rest.md
+++ b/.changeset/neat-mirrors-rest.md
@@ -1,0 +1,10 @@
+---
+"@logto/client": patch
+"@logto/node": patch
+"@logto/react-router": major
+---
+
+export `FirstScreen` and update the React Router type surface
+
+React Router users should replace `InteractionMode` imports with `FirstScreen`. The client and Node
+SDKs retain `InteractionMode` for compatibility.

--- a/packages/client/src/shim.ts
+++ b/packages/client/src/shim.ts
@@ -6,6 +6,7 @@
 
 export type {
   AccessTokenClaims,
+  FirstScreen,
   IdTokenClaims,
   LogtoErrorCode,
   UserInfoResponse,

--- a/packages/node/src/exports.ts
+++ b/packages/node/src/exports.ts
@@ -5,6 +5,7 @@ export type { LogtoContext, GetContextParameters } from './types.js';
 
 export type {
   AccessTokenClaims,
+  FirstScreen,
   IdTokenClaims,
   LogtoErrorCode,
   LogtoConfig,

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -51,9 +51,9 @@ export type { LogtoReactRouterConfig } from './types.js';
 
 export type {
   AccessTokenClaims,
+  FirstScreen,
   IdTokenClaims,
   LogtoContext,
-  InteractionMode,
   LogtoErrorCode,
   UserInfoResponse,
 } from '@logto/node';


### PR DESCRIPTION
The React Router SDK's new auth route API uses `FirstScreen`, while its current public type surface still exposes the deprecated `InteractionMode` type.

This stacked change:

- exports `FirstScreen` through `@logto/client` and `@logto/node`
- replaces the React Router `InteractionMode` export with `FirstScreen`
- keeps the client and Node `InteractionMode` exports for compatibility
- records patch releases for client and Node, and a major release for React Router
