### PR TITLE
feat(client): support request timeouts

### DIFF
--- a/.changeset/brave-browsers-fetch.md
+++ b/.changeset/brave-browsers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@logto/browser": minor
+---
+
+support configurable request timeouts through native fetch

--- a/.changeset/bright-extensions-fetch.md
+++ b/.changeset/bright-extensions-fetch.md
@@ -1,0 +1,5 @@
+---
+"@logto/chrome-extension": minor
+---
+
+support configurable request timeouts through native fetch

--- a/.changeset/calm-nodes-fetch.md
+++ b/.changeset/calm-nodes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@logto/node": minor
+---
+
+support configurable request timeouts in Node.js and edge runtimes

--- a/.changeset/tidy-ravens-wait.md
+++ b/.changeset/tidy-ravens-wait.md
@@ -1,0 +1,12 @@
+---
+"@logto/client": minor
+---
+
+support configurable request timeouts and optional fetch adapters
+
+Set `requestTimeoutMs` in `LogtoConfig` to apply a timeout to Logto discovery, token, revocation,
+user-info, and remote JSON Web Key Set requests. Existing request abort signals are preserved.
+
+`ClientAdapter` uses native `fetch` by default and accepts an optional custom `fetch` transport so
+the client can consistently apply shared request policies. Existing `requester` adapters remain
+supported but are deprecated. When both are provided, `fetch` takes precedence.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,5 +1,5 @@
 import type { LogtoConfig } from '@logto/client';
-import BaseClient, { createRequester } from '@logto/client';
+import BaseClient from '@logto/client';
 import { conditional } from '@silverhand/essentials';
 
 import { CacheStorage } from './cache.js';
@@ -11,6 +11,7 @@ export { generateCodeChallenge, generateCodeVerifier, generateState } from './ut
 
 export type {
   AccessTokenClaims,
+  CreateRequesterOptions,
   IdTokenClaims,
   LogtoErrorCode,
   LogtoConfig,
@@ -51,9 +52,7 @@ export default class LogtoClient extends BaseClient {
    * Use sessionStorage by default.
    */
   constructor(config: LogtoConfig, unstable_enableCache = false) {
-    const requester = createRequester(fetch);
     super(config, {
-      requester,
       navigate,
       storage: new BrowserStorage(config.appId),
       unstable_cache: conditional(unstable_enableCache && new CacheStorage(config.appId)),

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -1,7 +1,6 @@
 import {
   BaseClient,
   LogtoClientError,
-  createRequester,
   type LogtoConfig,
   type ClientAdapter,
   generateCodeChallenge,
@@ -19,7 +18,6 @@ export default class LogtoClient extends BaseClient {
    * @param config The configuration object for the client.
    */
   constructor(config: LogtoConfig) {
-    const requester = createRequester(fetch);
     // eslint-disable-next-line unicorn/consistent-function-scoping -- we use `this` in the function
     const navigate: ClientAdapter['navigate'] = async (url, params) => {
       switch (params.for) {
@@ -50,7 +48,6 @@ export default class LogtoClient extends BaseClient {
     };
 
     super(config, {
-      requester,
       navigate,
       storage: new ChromeExtensionStorage(config.appId),
       generateCodeChallenge,

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -35,14 +35,39 @@ If Logto does not support your framework and you want to contribute by building 
 
 To implement a platform-specific SDK, you should implement the following adapters:
 
-1. requester: send http requests.
-2. storage: save tokens and other info.
-3. navigate: handle redirect.
-4. generateState: generate state.
-5. generateCodeVerifier: generate code verifier.
-6. generateCodeChallenge: generate code challenge.
+1. storage: save tokens and other info.
+2. navigate: handle redirect.
+3. generateState: generate state.
+4. generateCodeVerifier: generate code verifier.
+5. generateCodeChallenge: generate code challenge.
+
+The client uses the runtime's native `fetch` by default. Set the optional `fetch` adapter only when
+the platform needs a custom transport.
 
 See the [adapters](./src/adapter/index.ts) for more information.
+
+### Request timeouts
+
+Set `requestTimeoutMs` in `LogtoConfig` to apply a timeout to each request to the Logto server. The
+option covers discovery, authorization-code and refresh-token exchange, revocation, user info, and
+remote JSON Web Key Set requests. Framework SDKs built on `@logto/client` inherit the same option.
+
+```ts
+const config = {
+  endpoint: 'https://example.logto.app',
+  appId: 'your-app-id',
+  requestTimeoutMs: 10_000,
+};
+```
+
+The timeout is opt-in. The client builds its requester on top of native `fetch`, or the adapter's
+custom `fetch` transport when provided, so the same timeout policy applies in both cases. A custom
+transport must observe `RequestInit.signal` and settle after the signal is aborted. The client
+awaits that settlement before it rejects the operation.
+
+The deprecated `requester` adapter remains supported for compatibility. When both `fetch` and
+`requester` are provided, `fetch` takes precedence. Since a custom requester is already fully
+configured, the client does not apply `requestTimeoutMs` to it.
 
 ## Resources
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,7 @@
     "lint-staged": "^15.0.0",
     "nock": "14.0.10",
     "prettier": "^3.0.0",
-    "typescript": "^5.3.3",
+    "typescript": "^5.8.3",
     "vitest": "^3.2.6"
   },
   "eslintConfig": {

--- a/packages/client/src/adapter/defaults.test.ts
+++ b/packages/client/src/adapter/defaults.test.ts
@@ -3,7 +3,7 @@ import { createRemoteJWKSet, exportJWK, generateKeyPair, SignJWT } from 'jose';
 
 import { nocked } from '../mock.js';
 
-import { verifyIdToken } from './defaults.js';
+import { buildRemoteJwkSetOptions, verifyIdToken } from './defaults.js';
 
 const createDefaultJwks = () => createRemoteJWKSet(new URL('https://logto.dev/oidc/jwks'));
 
@@ -193,5 +193,15 @@ describe('verifyIdToken', () => {
     const jwks = createDefaultJwks();
 
     await expect(verifyIdToken(idToken, 'qux', 'foo', jwks, 3600)).resolves.not.toThrow();
+  });
+});
+
+describe('buildRemoteJwkSetOptions', () => {
+  it('preserves the default JSON Web Key Set timeout when no timeout is configured', () => {
+    expect(buildRemoteJwkSetOptions()).toBeUndefined();
+  });
+
+  it('uses requestTimeoutMs as the JSON Web Key Set timeout', () => {
+    expect(buildRemoteJwkSetOptions(12_000)).toEqual({ timeoutDuration: 12_000 });
   });
 });

--- a/packages/client/src/adapter/defaults.ts
+++ b/packages/client/src/adapter/defaults.ts
@@ -8,6 +8,9 @@ import { type JwtVerifier } from './types.js';
 
 export const defaultClockTolerance = 300; // 5 minutes
 
+export const buildRemoteJwkSetOptions = (requestTimeoutMs?: number) =>
+  requestTimeoutMs === undefined ? undefined : { timeoutDuration: requestTimeoutMs };
+
 export const verifyIdToken = async (
   idToken: string,
   clientId: string,
@@ -31,10 +34,11 @@ export class DefaultJwtVerifier implements JwtVerifier {
   ) {}
 
   async verifyIdToken(idToken: string): Promise<void> {
-    const { appId } = this.client.logtoConfig;
+    const { appId, requestTimeoutMs } = this.client.logtoConfig;
     const { issuer, jwksUri } = await this.client.getOidcConfig();
+    const remoteJwkSetOptions = buildRemoteJwkSetOptions(requestTimeoutMs);
 
-    this.getJwtVerifyGetKey ||= createRemoteJWKSet(new URL(jwksUri));
+    this.getJwtVerifyGetKey ||= createRemoteJWKSet(new URL(jwksUri), remoteJwkSetOptions);
 
     await verifyIdToken(idToken, appId, issuer, this.getJwtVerifyGetKey, this.clockTolerance);
   }

--- a/packages/client/src/adapter/index.test.ts
+++ b/packages/client/src/adapter/index.test.ts
@@ -1,8 +1,67 @@
+import type { Requester } from '@logto/js';
+
 import { createAdapters } from '../mock.js';
 
-import { CacheKey, ClientAdapterInstance, PersistKey } from './index.js';
+import { CacheKey, type ClientAdapter, ClientAdapterInstance, PersistKey } from './index.js';
+
+const createAdapterWithoutTransport = (): ClientAdapter => {
+  const adapters = createAdapters();
+
+  return {
+    storage: adapters.storage,
+    navigate: adapters.navigate,
+    generateState: adapters.generateState,
+    generateCodeVerifier: adapters.generateCodeVerifier,
+    generateCodeChallenge: adapters.generateCodeChallenge,
+  };
+};
 
 describe('ClientAdapterInstance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses native fetch when no transport is provided', async () => {
+    const fetchTransport = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(Response.json({ source: 'native' }));
+    const adapterInstance = new ClientAdapterInstance(createAdapterWithoutTransport());
+
+    await expect(adapterInstance.requester('https://logto.example.com')).resolves.toEqual({
+      source: 'native',
+    });
+    expect(fetchTransport).toHaveBeenCalledOnce();
+  });
+
+  it('preserves a legacy requester without applying request options', () => {
+    const legacyRequester = vi.fn() as unknown as Requester;
+    const adapterInstance = new ClientAdapterInstance(
+      {
+        ...createAdapterWithoutTransport(),
+        requester: legacyRequester,
+      },
+      { requestTimeoutMs: 1000 }
+    );
+
+    expect(adapterInstance.requester).toBe(legacyRequester);
+  });
+
+  it('prefers fetch when both fetch and a legacy requester are provided', async () => {
+    const legacyRequester = vi.fn() as unknown as Requester;
+    const fetchTransport = vi.fn(async () => Response.json({ source: 'fetch' }));
+    const adapterInstance = new ClientAdapterInstance({
+      ...createAdapters(),
+      fetch: fetchTransport,
+      requester: legacyRequester,
+    });
+
+    await expect(adapterInstance.requester('https://logto.example.com')).resolves.toEqual({
+      source: 'fetch',
+    });
+    expect(fetchTransport).toHaveBeenCalledOnce();
+    expect(legacyRequester).not.toHaveBeenCalled();
+  });
+
   it('should be able to set storage item', async () => {
     const adapterInstance = new ClientAdapterInstance(createAdapters(true));
     await adapterInstance.setStorageItem(PersistKey.AccessToken, 'value');

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -1,6 +1,8 @@
 import { type Requester } from '@logto/js';
 import { trySafe, type Nullable, conditional } from '@silverhand/essentials';
 
+import { createRequester, type CreateRequesterOptions } from '../utils/requester.js';
+
 import {
   type CacheKey,
   type Navigate,
@@ -27,10 +29,9 @@ const getRunningCacheGetterMap = (cache: Storage<CacheKey>) => {
   return newRunningGetterMap;
 };
 
-export class ClientAdapterInstance implements ClientAdapter {
+export class ClientAdapterInstance {
   /*
-   * Implement `ClientAdapter`. Its properties are assigned by
-   * `Object.assign()` in the constructor.
+   * Its properties are assigned by `Object.assign()` in the constructor.
    */
   requester!: Requester;
   storage!: Storage<StorageKey | PersistKey>;
@@ -41,9 +42,15 @@ export class ClientAdapterInstance implements ClientAdapter {
   generateCodeChallenge!: (codeVerifier: string) => string | Promise<string>;
   /* END OF IMPLEMENTATION */
 
-  constructor(adapter: ClientAdapter) {
+  constructor(adapter: ClientAdapter, requestOptions: CreateRequesterOptions = {}) {
+    const requester = adapter.fetch
+      ? createRequester(adapter.fetch, requestOptions)
+      : adapter.requester ?? createRequester(globalThis.fetch, requestOptions);
+
     // eslint-disable-next-line @silverhand/fp/no-mutating-assign
-    Object.assign(this, adapter);
+    Object.assign(this, adapter, {
+      requester,
+    });
   }
 
   async setStorageItem(key: InferStorageKey<typeof this.storage>, value: Nullable<string>) {

--- a/packages/client/src/adapter/types.ts
+++ b/packages/client/src/adapter/types.ts
@@ -62,21 +62,29 @@ export type JwtVerifier = {
   verifyIdToken(idToken: string): Promise<void>;
 };
 
+type ClientAdapterTransport = {
+  /**
+   * An optional fetch-like transport for network requests. The client uses the runtime's native
+   * `fetch` when this property is omitted and applies shared request policies and response parsing
+   * on top of either function.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * A fully configured requester for network requests.
+   *
+   * @deprecated Use `fetch` so the client can apply shared request policies. This property is
+   * ignored when `fetch` is provided.
+   */
+  requester?: Requester;
+};
+
 /**
  * The adapter object that allows the customizations of the client behavior
  * for different environments.
  */
-export type ClientAdapter = {
-  /**
-   * The fetch-like function for network requests.
-   *
-   * @see {@link Requester}
-   */
-  requester: Requester;
+export type ClientAdapter = ClientAdapterTransport & {
   /**
    * The storage for storing tokens and sessions. It is usually persistent.
-   *
-   * @see {@link Requester}
    */
   storage: Storage<StorageKey | PersistKey>;
   /**

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -146,7 +146,9 @@ export class StandardLogtoClient {
     buildJwtVerifier: (client: StandardLogtoClient) => JwtVerifier
   ) {
     this.logtoConfig = normalizeLogtoConfig(logtoConfig);
-    this.adapter = new ClientAdapterInstance(adapter);
+    this.adapter = new ClientAdapterInstance(adapter, {
+      requestTimeoutMs: this.logtoConfig.requestTimeoutMs,
+    });
     this.jwtVerifierInstance = buildJwtVerifier(this);
 
     void this.loadAccessTokenMap();

--- a/packages/client/src/index.sign-out.test.ts
+++ b/packages/client/src/index.sign-out.test.ts
@@ -9,7 +9,7 @@ import {
   postSignOutRedirectUri,
   revocationEndpoint,
   endSessionEndpoint,
-  failingRequester,
+  failingFetch,
   createAdapters,
   fetchOidcConfig,
 } from './mock.js';
@@ -58,14 +58,14 @@ describe('LogtoClient', () => {
         { endpoint, appId },
         {
           ...createAdapters(),
-          requester: failingRequester,
+          fetch: failingFetch,
           storage,
         }
       );
       vi.spyOn(logtoClient, 'getOidcConfig').mockReturnValue(fetchOidcConfig());
 
       await expect(logtoClient.signOut()).resolves.not.toThrow();
-      expect(failingRequester).toBeCalledTimes(1);
+      expect(failingFetch).toBeCalledTimes(1);
       await expect(storage.getItem('idToken')).resolves.toBeNull();
       await expect(storage.getItem('refreshToken')).resolves.toBeNull();
       await expect(storage.getItem('accessToken')).resolves.toBeNull();

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -344,7 +344,6 @@ describe('LogtoClient', () => {
         { endpoint, appId },
         {
           ...createAdapters(),
-          requester,
           storage: new MockedStorage({
             idToken: 'id_token_value',
             refreshToken: 'refresh_token_value',
@@ -374,7 +373,6 @@ describe('LogtoClient', () => {
         { endpoint, appId },
         {
           ...createAdapters(),
-          requester,
           storage: new MockedStorage({ idToken, refreshToken }),
         }
       );

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -3,7 +3,7 @@ import { conditional, type Nullable } from '@silverhand/essentials';
 import nock from 'nock';
 import { type Mock } from 'vitest';
 
-import type { Storage } from './adapter/index.js';
+import type { ClientAdapter, Storage } from './adapter/index.js';
 import type { AccessToken, LogtoConfig, LogtoSignInSessionItem } from './index.js';
 import LogtoClient from './index.js';
 
@@ -127,7 +127,12 @@ export const mockFetchOidcConfig: (delay?: number) => Mock<() => Promise<OidcCon
 
 export const fetchOidcConfig: Mock<() => Promise<OidcConfigResponse>> = mockFetchOidcConfig();
 export const requester = vi.fn();
-export const failingRequester = vi.fn().mockRejectedValue(new Error('Failed request'));
+export const fetchFunction = vi.fn(async (...args: Parameters<typeof fetch>) => {
+  const data: unknown = await requester(...args);
+
+  return Response.json(data ?? null);
+});
+export const failingFetch = vi.fn().mockRejectedValue(new Error('Failed request'));
 export const navigate = vi.fn();
 export const generateCodeChallenge = vi.fn(async () => mockCodeChallenge);
 export const generateCodeVerifier = vi.fn(() => mockedCodeVerifier);
@@ -135,14 +140,14 @@ export const generateState = vi.fn(() => mockedState);
 
 export const createAdapters = (withCache = false) =>
   ({
-    requester,
+    fetch: fetchFunction,
     storage: new MockedStorage(),
     unstable_cache: conditional(withCache && new MockedStorage()),
     navigate,
     generateCodeChallenge,
     generateCodeVerifier,
     generateState,
-  }) satisfies Partial<Record<keyof LogtoClient['adapter'], unknown>>;
+  }) satisfies ClientAdapter;
 
 export const createClient = (
   prompt?: Prompt,

--- a/packages/client/src/request-timeout.ts
+++ b/packages/client/src/request-timeout.ts
@@ -1,0 +1,12 @@
+const maximumRequestTimeout = 2_147_483_647;
+
+export const assertRequestTimeout = (requestTimeoutMs?: number): void => {
+  if (
+    requestTimeoutMs !== undefined &&
+    (!Number.isInteger(requestTimeoutMs) ||
+      requestTimeoutMs <= 0 ||
+      requestTimeoutMs > maximumRequestTimeout)
+  ) {
+    throw new TypeError('requestTimeoutMs must be an integer between 1 and 2147483647.');
+  }
+};

--- a/packages/client/src/shim.ts
+++ b/packages/client/src/shim.ts
@@ -28,6 +28,6 @@ export {
 export * from './errors.js';
 export type { Storage, StorageKey, ClientAdapter, JwtVerifier } from './adapter/index.js';
 export { PersistKey, CacheKey } from './adapter/index.js';
-export { createRequester } from './utils/index.js';
+export { createRequester, type CreateRequesterOptions } from './utils/index.js';
 export * from './types/index.js';
 export * from './client.js';

--- a/packages/client/src/types/index.test.ts
+++ b/packages/client/src/types/index.test.ts
@@ -3,6 +3,19 @@ import { ReservedResource, UserScope } from '@logto/js';
 import { normalizeLogtoConfig } from './index.js';
 
 describe('normalizeLogtoConfigs', () => {
+  it.each([0, -1, 0.5, 2_147_483_648, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid request timeout %s',
+    (requestTimeoutMs) => {
+      expect(() =>
+        normalizeLogtoConfig({
+          appId: '123',
+          endpoint: 'https://example.com',
+          requestTimeoutMs,
+        })
+      ).toThrow('requestTimeoutMs must be an integer between 1 and 2147483647.');
+    }
+  );
+
   it('should be able to add missing scopes', () => {
     const normalized = normalizeLogtoConfig({
       appId: '123',

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -7,6 +7,8 @@ import {
 } from '@logto/js';
 import { deduplicate } from '@silverhand/essentials';
 
+import { assertRequestTimeout } from '../request-timeout.js';
+
 /** The configuration object for the Logto client. */
 export type LogtoConfig = {
   /**
@@ -26,6 +28,16 @@ export type LogtoConfig = {
    * details page of the Logto Console.
    */
   appSecret?: string;
+  /**
+   * The timeout in milliseconds for each request to the Logto server.
+   *
+   * Must be an integer from 1 to 2,147,483,647. The timeout is not applied when an adapter uses
+   * the deprecated custom `requester` transport.
+   *
+   * If omitted, the client does not add a timeout to requests made through the configured fetch
+   * transport. The existing JSON Web Key Set request timeout remains unchanged.
+   */
+  requestTimeoutMs?: number;
   /**
    * The scopes (permissions) that your application needs to access.
    * Scopes that will be added by default: `openid`, `offline_access` and `profile`.
@@ -67,6 +79,8 @@ export type LogtoConfig = {
  * @returns The normalized Logto client configuration.
  */
 export const normalizeLogtoConfig = (config: LogtoConfig): LogtoConfig => {
+  assertRequestTimeout(config.requestTimeoutMs);
+
   const { prompt = Prompt.Consent, scopes = [], resources, ...rest } = config;
   const includeReservedScopes = config.includeReservedScopes ?? true;
 

--- a/packages/client/src/utils/requester.test.ts
+++ b/packages/client/src/utils/requester.test.ts
@@ -3,7 +3,27 @@ import { assert } from '@silverhand/essentials';
 
 import { createRequester } from './requester.js';
 
+const waitForAbort = async (signal: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        resolve();
+      },
+      { once: true }
+    );
+  });
+
 describe('createRequester', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('successful response', () => {
     test('should return data', async () => {
       const data = { foo: 'bar' };
@@ -13,6 +33,144 @@ describe('createRequester', () => {
       });
       const requester = createRequester(fetchFunction);
       await expect(requester('foo')).resolves.toEqual(data);
+    });
+  });
+
+  describe('request timeout', () => {
+    it.each([0, -1, 0.5, 2_147_483_648, Number.NaN, Number.POSITIVE_INFINITY])(
+      'rejects invalid timeout %s',
+      (requestTimeoutMs) => {
+        expect(() =>
+          createRequester(vi.fn(), {
+            requestTimeoutMs,
+          })
+        ).toThrow('requestTimeoutMs must be an integer between 1 and 2147483647.');
+      }
+    );
+
+    it('preserves Request referrer settings when adding the timeout signal', async () => {
+      const input = new Request('https://logto.example.com/token', {
+        referrer: 'https://logto.example.com/source',
+        referrerPolicy: 'origin',
+      });
+      const fetchFunction = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          expect(init).toMatchObject({
+            referrer: input.referrer,
+            referrerPolicy: input.referrerPolicy,
+          });
+
+          return Response.json('completed');
+        }
+      );
+      const requester = createRequester(fetchFunction, { requestTimeoutMs: 1000 });
+
+      await expect(requester(input)).resolves.toBe('completed');
+    });
+
+    it('preserves and propagates an existing request signal', async () => {
+      const sourceController = new AbortController();
+      const timeoutController = new AbortController();
+      const requestAbortReason = new Error('request aborted');
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      const fetchFunction = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          sourceController.abort(requestAbortReason);
+
+          expect(init?.signal?.aborted).toBe(true);
+          expect(init?.signal?.reason).toBe(requestAbortReason);
+
+          return Response.json('completed');
+        }
+      );
+      const requester = createRequester(fetchFunction, { requestTimeoutMs: 1000 });
+
+      await expect(
+        requester('https://logto.example.com', { signal: sourceController.signal })
+      ).rejects.toBe(requestAbortReason);
+    });
+
+    it('clears a signal inherited from a Request when signal is null', async () => {
+      const sourceController = new AbortController();
+      const timeoutController = new AbortController();
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      sourceController.abort();
+      const input = new Request('https://logto.example.com', {
+        signal: sourceController.signal,
+      });
+      const fetchFunction = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          expect(init?.signal).toBe(timeoutController.signal);
+
+          return Response.json('completed');
+        }
+      );
+      const requester = createRequester(fetchFunction, { requestTimeoutMs: 1000 });
+
+      await expect(requester(input, { signal: null })).resolves.toBe('completed');
+    });
+
+    it('waits for fetch to settle after aborting it on timeout', async () => {
+      const abortObserved = vi.fn();
+      const settleFetch = new AbortController();
+      const timeoutController = new AbortController();
+      const timeoutError = new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      );
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      const fetchFunction = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          init?.signal?.addEventListener('abort', abortObserved, { once: true });
+          await waitForAbort(settleFetch.signal);
+
+          return Response.json('completed');
+        }
+      );
+      const requester = createRequester(fetchFunction, { requestTimeoutMs: 100 });
+      const result = requester('https://logto.example.com');
+
+      timeoutController.abort(timeoutError);
+
+      const signal = fetchFunction.mock.calls[0]?.[1]?.signal;
+      expect(signal?.aborted).toBe(true);
+      expect(signal?.reason).toMatchObject({ name: 'TimeoutError' });
+      expect(abortObserved).toHaveBeenCalledOnce();
+      await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toBe('pending');
+
+      settleFetch.abort();
+      await expect(result).rejects.toMatchObject({ name: 'TimeoutError' });
+    });
+
+    it('keeps the timeout active while parsing the response', async () => {
+      const settleBody = new AbortController();
+      const timeoutController = new AbortController();
+      const timeoutError = new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      );
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      const fetchFunction = vi.fn(async () =>
+        Response.json('completed', {
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+      fetchFunction.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          await waitForAbort(settleBody.signal);
+
+          return 'completed';
+        },
+      } as Response);
+      const requester = createRequester(fetchFunction, { requestTimeoutMs: 100 });
+      const result = requester('https://logto.example.com');
+
+      timeoutController.abort(timeoutError);
+      await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toBe('pending');
+
+      settleBody.abort();
+      await expect(result).rejects.toMatchObject({ name: 'TimeoutError' });
     });
   });
 

--- a/packages/client/src/utils/requester.ts
+++ b/packages/client/src/utils/requester.ts
@@ -2,6 +2,13 @@ import type { Requester } from '@logto/js';
 import { LogtoError, LogtoRequestError, isLogtoRequestErrorJson } from '@logto/js';
 import { trySafe } from '@silverhand/essentials';
 
+import { assertRequestTimeout } from '../request-timeout.js';
+
+export type CreateRequesterOptions = Readonly<{
+  /** The timeout in milliseconds for each request. Must be an integer from 1 to 2,147,483,647. */
+  requestTimeoutMs?: number | undefined;
+}>;
+
 const parseErrorResponse = async (response: Response): Promise<never> => {
   const responseText = await response.clone().text();
   const responseJson = trySafe<unknown>(() => JSON.parse(responseText));
@@ -25,21 +32,54 @@ const parseErrorResponse = async (response: Response): Promise<never> => {
   throw new LogtoRequestError(code, message, response);
 };
 
+const getRequestSignal = (input: RequestInfo | URL, init?: RequestInit) => {
+  if (init?.signal === null) {
+    return;
+  }
+
+  if (init?.signal) {
+    return init.signal;
+  }
+
+  return typeof Request === 'undefined' || !(input instanceof Request) ? undefined : input.signal;
+};
+
+const parseResponse = async <T>(response: Response): Promise<T> =>
+  response.ok ? response.json() : parseErrorResponse(response);
+
 /**
  * A factory function that creates a requester by accepting a `fetch`-like function.
  *
  * @param fetchFunction A `fetch`-like function.
+ * @param options Request policies applied on top of the fetch-like function.
  * @returns A requester function.
  * @see {@link Requester}
  */
-export const createRequester = (fetchFunction: typeof fetch): Requester => {
-  return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
-    const response = await fetchFunction(...args);
+export const createRequester = (
+  fetchFunction: typeof fetch,
+  options: CreateRequesterOptions = {}
+): Requester => {
+  const { requestTimeoutMs } = options;
+  assertRequestTimeout(requestTimeoutMs);
 
-    if (!response.ok) {
-      return parseErrorResponse(response);
+  return async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
+    if (requestTimeoutMs === undefined) {
+      return parseResponse<T>(await fetchFunction(...args));
     }
 
-    return response.json();
+    const [input, init] = args;
+    const requestSignal = getRequestSignal(input, init);
+    const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+    const signal = requestSignal ? AbortSignal.any([requestSignal, timeoutSignal]) : timeoutSignal;
+    const requestInit =
+      init === undefined && typeof Request !== 'undefined' && input instanceof Request
+        ? { referrer: input.referrer, referrerPolicy: input.referrerPolicy }
+        : init;
+
+    try {
+      return await parseResponse<T>(await fetchFunction(input, { ...requestInit, signal }));
+    } finally {
+      signal.throwIfAborted();
+    }
   };
 };

--- a/packages/node/edge/index.test.ts
+++ b/packages/node/edge/index.test.ts
@@ -1,4 +1,5 @@
 import BaseClient, { type ClientAdapter } from '@logto/client';
+import { encode } from 'js-base64';
 
 import LogtoClient from './index.js';
 
@@ -15,7 +16,6 @@ const storage = {
 vi.mock('@logto/client', () => ({
   __esModule: true,
   default: vi.fn(),
-  createRequester: vi.fn(),
 }));
 
 const getLatestBaseClientAdapter = (): ClientAdapter => {
@@ -27,6 +27,41 @@ const getLatestBaseClientAdapter = (): ClientAdapter => {
 describe('LogtoClient (edge)', () => {
   beforeEach(() => {
     vi.mocked(BaseClient).mockClear();
+  });
+
+  it('uses the client native fetch fallback by default', () => {
+    expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
+    expect(getLatestBaseClientAdapter()).not.toHaveProperty('fetch');
+    expect(getLatestBaseClientAdapter()).not.toHaveProperty('requester');
+  });
+
+  it('preserves a custom requester when an app secret is configured', () => {
+    const requester = vi.fn() as unknown as NonNullable<ClientAdapter['requester']>;
+    expect(
+      new LogtoClient(
+        { endpoint, appId, appSecret: 'app_secret' },
+        { navigate, storage, requester }
+      )
+    ).toBeDefined();
+
+    expect(getLatestBaseClientAdapter().requester).toBe(requester);
+    expect(getLatestBaseClientAdapter()).not.toHaveProperty('fetch');
+  });
+
+  it('does not let an undefined fetch override the authenticated transport', async () => {
+    const fetchTransport = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(null));
+    expect(
+      new LogtoClient(
+        { endpoint, appId, appSecret: 'app_secret' },
+        { navigate, storage, fetch: undefined }
+      )
+    ).toBeDefined();
+
+    await getLatestBaseClientAdapter().fetch?.('https://logto.example.com');
+
+    expect(fetchTransport).toHaveBeenCalledOnce();
+    const request = new Request(fetchTransport.mock.calls[0]![0]);
+    expect(request.headers.get('Authorization')).toBe(`Basic ${encode(`${appId}:app_secret`)}`);
   });
 
   it('should provide endpoint-scoped cache storage by default', () => {

--- a/packages/node/edge/index.ts
+++ b/packages/node/edge/index.ts
@@ -1,40 +1,38 @@
 import type { LogtoConfig, ClientAdapter } from '@logto/client';
-import { createRequester } from '@logto/client';
 import { encode } from 'js-base64';
 
 import BaseClient from '../src/client.js';
+import {
+  createAuthenticatedFetch,
+  resolveAdapterTransport,
+} from '../src/utils/adapter-transport.js';
 import { createMemoryCache } from '../src/utils/cache.js';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators.js';
 
 export { PersistKey } from '@logto/client';
 
+type EdgeClientAdapter = Pick<ClientAdapter, 'navigate' | 'storage'> &
+  Partial<Pick<ClientAdapter, 'fetch' | 'requester'>>;
+
 // Used for edge runtime, currently only NextJS.
 export default class LogtoClient extends BaseClient {
-  constructor(config: LogtoConfig, adapter: Pick<ClientAdapter, 'navigate' | 'storage'>) {
+  constructor(config: LogtoConfig, adapter: EdgeClientAdapter) {
+    const { appId, appSecret } = config;
+    const { navigate, storage } = adapter;
+    const defaultFetch = appSecret
+      ? createAuthenticatedFetch(`Basic ${encode(`${appId}:${appSecret}`)}`)
+      : undefined;
+    const transport = resolveAdapterTransport(adapter, defaultFetch);
+
     super(config, {
-      ...adapter,
-      requester: createRequester(
-        config.appSecret
-          ? async (...args: Parameters<typeof fetch>) => {
-              const [input, init] = args;
-
-              const base64Credentials = encode(`${config.appId}:${config.appSecret ?? ''}`);
-
-              return fetch(input, {
-                ...init,
-                headers: {
-                  Authorization: `Basic ${base64Credentials}`,
-                  ...init?.headers,
-                },
-              });
-            }
-          : fetch
-      ),
+      navigate,
+      storage,
       generateCodeChallenge,
       generateCodeVerifier,
       generateState,
       unstable_cache: createMemoryCache(config.endpoint),
+      ...transport,
     });
   }
 }

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -27,7 +27,6 @@ vi.mock('@logto/client', () => ({
     isAuthenticated,
     fetchUserInfo,
   })),
-  createRequester: vi.fn(),
 }));
 
 const getLatestBaseClientAdapter = (): ClientAdapter => {
@@ -42,8 +41,72 @@ describe('LogtoClient', () => {
       vi.mocked(BaseClient).mockClear();
     });
 
-    it('constructor should not throw', () => {
-      expect(() => new LogtoClient({ endpoint, appId }, { navigate, storage })).not.toThrow();
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('uses the client native fetch fallback by default', () => {
+      expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
+      expect(getLatestBaseClientAdapter()).not.toHaveProperty('fetch');
+      expect(getLatestBaseClientAdapter()).not.toHaveProperty('requester');
+    });
+
+    it('provides an authenticated fetch transport when an app secret is configured', async () => {
+      const fetchTransport = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(null));
+      expect(
+        new LogtoClient({ endpoint, appId, appSecret: 'app_secret' }, { navigate, storage })
+      ).toBeDefined();
+
+      await getLatestBaseClientAdapter().fetch?.('https://logto.example.com');
+
+      expect(fetchTransport).toHaveBeenCalledOnce();
+      const request = new Request(fetchTransport.mock.calls[0]![0]);
+      expect(request.headers.get('Authorization')).toBe(
+        `Basic ${Buffer.from(`${appId}:app_secret`, 'utf8').toString('base64')}`
+      );
+    });
+
+    it('does not let an undefined fetch override the authenticated transport', async () => {
+      const fetchTransport = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(null));
+      expect(
+        new LogtoClient(
+          { endpoint, appId, appSecret: 'app_secret' },
+          { navigate, storage, fetch: undefined }
+        )
+      ).toBeDefined();
+
+      await getLatestBaseClientAdapter().fetch?.('https://logto.example.com');
+
+      expect(fetchTransport).toHaveBeenCalledOnce();
+      const request = new Request(fetchTransport.mock.calls[0]![0]);
+      expect(request.headers.get('Authorization')).toBe(
+        `Basic ${Buffer.from(`${appId}:app_secret`, 'utf8').toString('base64')}`
+      );
+    });
+
+    it('preserves a custom requester when an app secret is configured', () => {
+      const requester = vi.fn() as unknown as NonNullable<ClientAdapter['requester']>;
+      expect(
+        new LogtoClient(
+          { endpoint, appId, appSecret: 'app_secret' },
+          { navigate, storage, requester }
+        )
+      ).toBeDefined();
+
+      expect(getLatestBaseClientAdapter().requester).toBe(requester);
+      expect(getLatestBaseClientAdapter()).not.toHaveProperty('fetch');
+    });
+
+    it('preserves a custom fetch when an app secret is configured', () => {
+      const customFetch = vi.fn<typeof fetch>();
+      expect(
+        new LogtoClient(
+          { endpoint, appId, appSecret: 'app_secret' },
+          { navigate, storage, fetch: customFetch }
+        )
+      ).toBeDefined();
+
+      expect(getLatestBaseClientAdapter().fetch).toBe(customFetch);
     });
 
     it('should provide endpoint-scoped cache storage by default', () => {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,9 +1,9 @@
 import type { LogtoConfig, ClientAdapter, StandardLogtoClient, JwtVerifier } from '@logto/client';
-import { createRequester } from '@logto/client';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../edge/generators.js';
 
 import BaseClient from './client.js';
+import { createAuthenticatedFetch, resolveAdapterTransport } from './utils/adapter-transport.js';
 import { createMemoryCache } from './utils/cache.js';
 
 export * from './exports.js';
@@ -14,32 +14,23 @@ export default class LogtoClient extends BaseClient {
     adapter: Partial<ClientAdapter> & Pick<ClientAdapter, 'navigate' | 'storage'>,
     buildJwtVerifier?: (client: StandardLogtoClient) => JwtVerifier
   ) {
+    const { appId, appSecret } = config;
+    const defaultFetch = appSecret
+      ? createAuthenticatedFetch(
+          `Basic ${Buffer.from(`${appId}:${appSecret}`, 'utf8').toString('base64')}`
+        )
+      : undefined;
+    const transport = resolveAdapterTransport(adapter, defaultFetch);
+
     super(
       config,
       {
-        requester: createRequester(
-          config.appSecret
-            ? async (...args: Parameters<typeof fetch>) => {
-                const [input, init] = args;
-
-                return fetch(input, {
-                  ...init,
-                  headers: {
-                    Authorization: `Basic ${Buffer.from(
-                      `${config.appId}:${config.appSecret}`,
-                      'utf8'
-                    ).toString('base64')}`,
-                    ...init?.headers,
-                  },
-                });
-              }
-            : fetch
-        ),
         generateCodeChallenge,
         generateCodeVerifier,
         generateState,
         unstable_cache: createMemoryCache(config.endpoint),
         ...adapter,
+        ...transport,
       },
       buildJwtVerifier
     );

--- a/packages/node/src/utils/adapter-transport.test.ts
+++ b/packages/node/src/utils/adapter-transport.test.ts
@@ -1,0 +1,48 @@
+import { createAuthenticatedFetch } from './adapter-transport.js';
+
+describe('createAuthenticatedFetch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves a prepared request and its authorization', async () => {
+    const fetchTransport = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(null));
+    const input = new Request('https://logto.example.com/token', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer old-token',
+        'Content-Type': 'text/plain',
+        'X-Custom': 'custom-value',
+      },
+      body: 'request-body',
+      referrer: 'https://logto.example.com/source',
+      referrerPolicy: 'origin',
+    });
+
+    await createAuthenticatedFetch('Basic credentials')(input);
+
+    expect(fetchTransport).toHaveBeenCalledOnce();
+    const forwardedInput = fetchTransport.mock.calls[0]![0];
+    expect(forwardedInput).toBeInstanceOf(Request);
+
+    const forwardedRequest = new Request(forwardedInput);
+    expect(forwardedRequest.method).toBe('POST');
+    expect(forwardedRequest.headers.get('Authorization')).toBe('Bearer old-token');
+    expect(forwardedRequest.headers.get('Content-Type')).toBe('text/plain');
+    expect(forwardedRequest.headers.get('X-Custom')).toBe('custom-value');
+    expect(forwardedRequest.referrer).toBe('https://logto.example.com/source');
+    expect(forwardedRequest.referrerPolicy).toBe('origin');
+    await expect(forwardedRequest.text()).resolves.toBe('request-body');
+  });
+
+  it('sets authorization when the request does not provide it', async () => {
+    const fetchTransport = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(null));
+
+    await createAuthenticatedFetch('Basic credentials')('https://logto.example.com/token');
+
+    expect(fetchTransport).toHaveBeenCalledOnce();
+    const forwardedInput = fetchTransport.mock.calls[0]![0];
+    expect(forwardedInput).toBeInstanceOf(Request);
+    expect(new Request(forwardedInput).headers.get('Authorization')).toBe('Basic credentials');
+  });
+});

--- a/packages/node/src/utils/adapter-transport.ts
+++ b/packages/node/src/utils/adapter-transport.ts
@@ -1,0 +1,30 @@
+import type { ClientAdapter } from '@logto/client';
+
+type AdapterTransport = Pick<ClientAdapter, 'fetch' | 'requester'>;
+
+export const createAuthenticatedFetch =
+  (authorization: string): typeof globalThis.fetch =>
+  async (input, init) => {
+    const request = new Request(input, init);
+
+    if (!request.headers.has('Authorization')) {
+      request.headers.set('Authorization', authorization);
+    }
+
+    return fetch(request);
+  };
+
+export const resolveAdapterTransport = (
+  adapter: AdapterTransport,
+  defaultFetch?: typeof globalThis.fetch
+): AdapterTransport => {
+  if (adapter.fetch) {
+    return { fetch: adapter.fetch };
+  }
+
+  if (adapter.requester) {
+    return { requester: adapter.requester };
+  }
+
+  return defaultFetch ? { fetch: defaultFetch } : {};
+};

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -58,6 +58,7 @@ export const logto = createLogtoReactRouter(
     appId: process.env.LOGTO_APP_ID!,
     appSecret: process.env.LOGTO_APP_SECRET!,
     baseUrl: process.env.LOGTO_BASE_URL!,
+    requestTimeoutMs: 10_000,
   },
   { sessionStorage }
 );
@@ -241,6 +242,10 @@ For a multi-instance deployment, use both:
 
 The storage keeps session state shared. The coordinator provides mutual exclusion for refresh and
 persistence operations that use the same session ID.
+
+Set `requestTimeoutMs` in the Logto configuration to bound each request to the Logto server. When a
+request times out during a session checkpoint, the coordinator keeps the session lock until the
+aborted request settles.
 
 ## Migrating from 1.x
 

--- a/packages/react-router/src/middleware/create-middleware.spec.ts
+++ b/packages/react-router/src/middleware/create-middleware.spec.ts
@@ -1,57 +1,18 @@
-import type {
-  LoaderFunctionArgs,
-  MiddlewareFunction,
-  RouterContextProvider,
-  Session,
-  SessionData,
-  SessionStorage,
-} from 'react-router';
-import {
-  createSession,
-  createStaticHandler,
-  RouterContextProvider as ContextProvider,
-} from 'react-router';
-
 import { createLogtoReactRouter } from '../create-logto-react-router.js';
 
-const config = {
-  endpoint: 'https://logto.example.com',
-  appId: 'app-id',
-  appSecret: 'app-secret',
-  baseUrl: 'https://app.example.com',
-};
-
-const sessionCookie = 'logto-session=session-id';
+import type { RouteHandler } from './create-middleware.test-utils.js';
+import {
+  config,
+  createTestSessionStorage,
+  runRoute,
+  stubLogtoFetch,
+  waitForAbort,
+} from './create-middleware.test-utils.js';
 
 const delay = async (milliseconds: number) =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, milliseconds);
   });
-
-type RouteHandler = (
-  args: LoaderFunctionArgs<Readonly<RouterContextProvider>>
-) => Response | Promise<Response>;
-
-const createTestSessionStorage = (initialData: SessionData = {}) => {
-  const sessions = new Map<string, SessionData>([['session-id', structuredClone(initialData)]]);
-  const commitSession = vi.fn(async (session: Session) => {
-    sessions.set('session-id', structuredClone(session.data));
-
-    return `${sessionCookie}; Path=/; HttpOnly; SameSite=Lax`;
-  });
-  const sessionStorage: SessionStorage = {
-    getSession: async () =>
-      createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id'),
-    commitSession,
-    destroySession: async () => `${sessionCookie}; Max-Age=0`,
-  };
-
-  return {
-    commitSession,
-    sessionStorage,
-    getData: () => structuredClone(sessions.get('session-id') ?? {}),
-  };
-};
 
 const stubTokenRefresh = () => {
   const tokenRequest = vi.fn(async () => {
@@ -64,87 +25,14 @@ const stubTokenRefresh = () => {
       expires_in: 3600,
     });
   });
-  const fetchRequest = vi.fn(async (input: string | URL | Request) => {
-    const url = String(input);
-
-    if (url.endsWith('/oidc/.well-known/openid-configuration')) {
-      return Response.json({
-        authorization_endpoint: `${config.endpoint}/oidc/auth`,
-        token_endpoint: `${config.endpoint}/oidc/token`,
-        userinfo_endpoint: `${config.endpoint}/oidc/me`,
-        end_session_endpoint: `${config.endpoint}/oidc/session/end`,
-        revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
-        jwks_uri: `${config.endpoint}/oidc/jwks`,
-        issuer: `${config.endpoint}/oidc`,
-      });
-    }
-
-    if (url.endsWith('/oidc/token')) {
-      return tokenRequest();
-    }
-
-    return new Response('Not found', { status: 404 });
-  });
-
-  vi.stubGlobal('fetch', fetchRequest);
+  stubLogtoFetch(tokenRequest);
 
   return tokenRequest;
 };
 
-const runRoute = async (
-  middleware: MiddlewareFunction<Response>,
-  handler: RouteHandler,
-  method = 'GET',
-  path = '/'
-) => {
-  // `createStaticHandler` uses the Data Mode middleware type even when its response generator
-  // supplies the Framework Mode response pipeline exercised here.
-  const dataMiddleware: MiddlewareFunction = async (args, next) =>
-    middleware(args, async () => {
-      const result = await next();
-
-      if (!(result instanceof Response)) {
-        throw new TypeError('Expected downstream middleware to return a response.');
-      }
-
-      return result;
-    });
-  const staticHandler = createStaticHandler([
-    {
-      id: 'root',
-      path: '*',
-      middleware: [dataMiddleware],
-      loader: handler,
-      action: handler,
-    },
-  ]);
-  const request = new Request(`${config.baseUrl}${path}`, {
-    method,
-    headers: { Cookie: sessionCookie },
-  });
-  const response: unknown = await staticHandler.queryRoute(request, {
-    routeId: 'root',
-    requestContext: new ContextProvider(),
-    generateMiddlewareResponse: async (queryRoute) => {
-      try {
-        return await queryRoute(request);
-      } catch (error: unknown) {
-        return error instanceof Response
-          ? error
-          : new Response('Internal Server Error', { status: 500 });
-      }
-    },
-  });
-
-  if (!(response instanceof Response)) {
-    throw new TypeError('Expected the route to return a response.');
-  }
-
-  return response;
-};
-
 describe('middleware:createLogtoMiddleware', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -202,24 +90,7 @@ describe('middleware:createLogtoMiddleware', () => {
 
   it('runs an authentication route through the request middleware runtime', async () => {
     const store = createTestSessionStorage();
-    const fetchRequest = vi.fn(async (input: string | URL | Request) => {
-      const url = String(input);
-
-      if (url.endsWith('/oidc/.well-known/openid-configuration')) {
-        return Response.json({
-          authorization_endpoint: `${config.endpoint}/oidc/auth`,
-          token_endpoint: `${config.endpoint}/oidc/token`,
-          userinfo_endpoint: `${config.endpoint}/oidc/me`,
-          end_session_endpoint: `${config.endpoint}/oidc/session/end`,
-          revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
-          jwks_uri: `${config.endpoint}/oidc/jwks`,
-          issuer: `${config.endpoint}/oidc`,
-        });
-      }
-
-      return new Response('Not found', { status: 404 });
-    });
-    vi.stubGlobal('fetch', fetchRequest);
+    stubLogtoFetch();
     const logto = createLogtoReactRouter(config, { sessionStorage: store.sessionStorage });
     const authRoutes = logto.authRoutes({
       paths: {
@@ -266,6 +137,82 @@ describe('middleware:createLogtoMiddleware', () => {
       'access-token',
     ]);
     expect(tokenRequest).toHaveBeenCalledOnce();
+    expect(store.getData()).toMatchObject({ refreshToken: 'rotated' });
+    expect(store.commitSession).toHaveBeenCalledOnce();
+  });
+
+  it('holds the session lock until a timed-out token request settles', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'old' });
+    const abortObserved = vi.fn();
+    const firstRequestAborted = new AbortController();
+    const firstTokenRequestStarted = new AbortController();
+    const settleFirstRequest = new AbortController();
+    const firstTokenTimeoutController = new AbortController();
+    const timeoutError = new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError'
+    );
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation(() =>
+      firstTokenRequestStarted.signal.aborted
+        ? new AbortController().signal
+        : firstTokenTimeoutController.signal
+    );
+    const tokenRequest = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        if (tokenRequest.mock.calls.length === 1) {
+          const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+          signal?.addEventListener(
+            'abort',
+            () => {
+              abortObserved();
+              firstRequestAborted.abort();
+            },
+            { once: true }
+          );
+          firstTokenRequestStarted.abort();
+          await waitForAbort(settleFirstRequest.signal);
+
+          const abortReason: unknown = signal?.reason;
+          throw abortReason instanceof Error ? abortReason : new Error('Token request aborted.');
+        }
+
+        return Response.json({
+          access_token: 'access-token',
+          refresh_token: 'rotated',
+          scope: 'read',
+          expires_in: 3600,
+        });
+      }
+    );
+    stubLogtoFetch(tokenRequest);
+    const logto = createLogtoReactRouter(
+      { ...config, requestTimeoutMs: 100 },
+      { sessionStorage: store.sessionStorage }
+    );
+    const handler: RouteHandler = async ({ context }) => {
+      const accessToken = await context.get(logto.context).getAccessToken();
+
+      return new Response(accessToken);
+    };
+
+    const firstResponse = runRoute(logto.middleware, handler);
+    await waitForAbort(firstTokenRequestStarted.signal);
+    expect(tokenRequest).toHaveBeenCalledOnce();
+
+    const secondResponse = runRoute(logto.middleware, handler);
+    firstTokenTimeoutController.abort(timeoutError);
+    await waitForAbort(firstRequestAborted.signal);
+
+    expect(tokenRequest).toHaveBeenCalledOnce();
+    expect(abortObserved).toHaveBeenCalledOnce();
+
+    settleFirstRequest.abort();
+
+    const [first, second] = await Promise.all([firstResponse, secondResponse]);
+
+    expect(first.status).toBe(500);
+    await expect(second.text()).resolves.toBe('access-token');
+    expect(tokenRequest).toHaveBeenCalledTimes(2);
     expect(store.getData()).toMatchObject({ refreshToken: 'rotated' });
     expect(store.commitSession).toHaveBeenCalledOnce();
   });

--- a/packages/react-router/src/middleware/create-middleware.test-utils.ts
+++ b/packages/react-router/src/middleware/create-middleware.test-utils.ts
@@ -1,0 +1,149 @@
+import type {
+  LoaderFunctionArgs,
+  MiddlewareFunction,
+  RouterContextProvider,
+  Session,
+  SessionData,
+  SessionStorage,
+} from 'react-router';
+import {
+  createSession,
+  createStaticHandler,
+  RouterContextProvider as ContextProvider,
+} from 'react-router';
+
+export const config = {
+  endpoint: 'https://logto.example.com',
+  appId: 'app-id',
+  appSecret: 'app-secret',
+  baseUrl: 'https://app.example.com',
+};
+
+const sessionCookie = 'logto-session=session-id';
+
+type TestSessionStore = Readonly<{
+  commitSession: (session: Session) => Promise<string>;
+  sessionStorage: SessionStorage;
+  getData: () => SessionData;
+}>;
+
+type FetchFunction = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export type RouteHandler = (
+  args: LoaderFunctionArgs<Readonly<RouterContextProvider>>
+) => Response | Promise<Response>;
+
+export const waitForAbort = async (signal: AbortSignal) => {
+  if (signal.aborted) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    signal.addEventListener(
+      'abort',
+      () => {
+        resolve();
+      },
+      { once: true }
+    );
+  });
+};
+
+export const createTestSessionStorage = (initialData: SessionData = {}): TestSessionStore => {
+  const sessions = new Map<string, SessionData>([['session-id', structuredClone(initialData)]]);
+  const commitSession = vi.fn(async (session: Session) => {
+    sessions.set('session-id', structuredClone(session.data));
+
+    return `${sessionCookie}; Path=/; HttpOnly; SameSite=Lax`;
+  });
+  const sessionStorage: SessionStorage = {
+    getSession: async () =>
+      createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id'),
+    commitSession,
+    destroySession: async () => `${sessionCookie}; Max-Age=0`,
+  };
+
+  return {
+    commitSession,
+    sessionStorage,
+    getData: () => structuredClone(sessions.get('session-id') ?? {}),
+  };
+};
+
+export const stubLogtoFetch = (tokenRequest?: FetchFunction): void => {
+  const fetchRequest = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    if (url.endsWith('/oidc/.well-known/openid-configuration')) {
+      return Response.json({
+        authorization_endpoint: `${config.endpoint}/oidc/auth`,
+        token_endpoint: `${config.endpoint}/oidc/token`,
+        userinfo_endpoint: `${config.endpoint}/oidc/me`,
+        end_session_endpoint: `${config.endpoint}/oidc/session/end`,
+        revocation_endpoint: `${config.endpoint}/oidc/token/revocation`,
+        jwks_uri: `${config.endpoint}/oidc/jwks`,
+        issuer: `${config.endpoint}/oidc`,
+      });
+    }
+
+    if (url.endsWith('/oidc/token') && tokenRequest) {
+      return tokenRequest(input, init);
+    }
+
+    return new Response('Not found', { status: 404 });
+  });
+
+  vi.stubGlobal('fetch', fetchRequest);
+};
+
+export const runRoute = async (
+  middleware: MiddlewareFunction<Response>,
+  handler: RouteHandler,
+  method = 'GET',
+  path = '/'
+) => {
+  // `createStaticHandler` uses the Data Mode middleware type even when its response generator
+  // supplies the Framework Mode response pipeline exercised here.
+  const dataMiddleware: MiddlewareFunction = async (args, next) =>
+    middleware(args, async () => {
+      const result = await next();
+
+      if (!(result instanceof Response)) {
+        throw new TypeError('Expected downstream middleware to return a response.');
+      }
+
+      return result;
+    });
+  const staticHandler = createStaticHandler([
+    {
+      id: 'root',
+      path: '*',
+      middleware: [dataMiddleware],
+      loader: handler,
+      action: handler,
+    },
+  ]);
+  const request = new Request(`${config.baseUrl}${path}`, {
+    method,
+    headers: { Cookie: sessionCookie },
+  });
+  const response: unknown = await staticHandler.queryRoute(request, {
+    routeId: 'root',
+    requestContext: new ContextProvider(),
+    generateMiddlewareResponse: async (queryRoute) => {
+      try {
+        return await queryRoute(request);
+      } catch (error: unknown) {
+        return error instanceof Response
+          ? error
+          : new Response('Internal Server Error', { status: 500 });
+      }
+    },
+  });
+
+  if (!(response instanceof Response)) {
+    throw new TypeError('Expected the route to return a response.');
+  }
+
+  return response;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,10 +409,10 @@ importers:
     devDependencies:
       '@silverhand/eslint-config':
         specifier: ^6.0.1
-        version: 6.0.1(@types/eslint@9.6.1)(eslint@8.57.0)(prettier@3.0.0)(typescript@5.3.3)
+        version: 6.0.1(@types/eslint@9.6.1)(eslint@8.57.0)(prettier@3.0.0)(typescript@5.8.3)
       '@silverhand/ts-config':
         specifier: ^6.0.0
-        version: 6.0.0(typescript@5.3.3)
+        version: 6.0.0(typescript@5.8.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.10.0
@@ -435,8 +435,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^5.8.3
+        version: 5.8.3
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.10.0)(happy-dom@20.8.9)(jiti@2.7.0)(less@4.2.2)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.39.0)(yaml@2.9.0)


### PR DESCRIPTION
Stacked on #1177, this adds the opt-in `requestTimeoutMs` configuration across discovery, token exchange and refresh, revocation, user info, and remote JSON Web Key Set requests. The client composes timeout signals with existing request signals and waits for transport and response parsing to settle before a framework session lock can be released.

`ClientAdapter` now uses native `fetch` by default and accepts an optional custom `fetch` transport so shared request policies are applied consistently. Existing `requester` adapters remain supported but are deprecated, and `fetch` takes precedence when both are provided. Browser and Chrome no longer wire redundant transports. Node and edge runtimes add the client-secret authorization wrapper only when the caller has not supplied a custom transport.
