### PR TITLE
chore!: require Node.js 22

### DIFF
--- a/.changeset/modern-nodes-run.md
+++ b/.changeset/modern-nodes-run.md
@@ -1,0 +1,11 @@
+---
+"@logto/express": major
+"@logto/next": major
+"@logto/node": major
+"@logto/nuxt": major
+"@logto/react-router": major
+"@logto/remix": major
+"@logto/sveltekit": major
+---
+
+require Node.js 22 or later for server-side SDKs

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v5
         with:
+          node-version: 22
           pnpm-version: 10
 
       - name: Commitlint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v5
         with:
+          node-version: 22
           pnpm-version: 10
 
       - name: Build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "root",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "changeset": "changeset",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/express",
   "version": "3.0.16",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -65,7 +68,7 @@
     "main": {
       "context": "node",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=22.0.0"
       }
     }
   }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/next",
   "version": "4.2.11",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "module": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/node",
   "version": "3.1.11",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "module": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/nuxt",
   "version": "1.2.11",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/react-router",
   "version": "1.0.5",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -57,7 +60,7 @@
     "main": {
       "context": "node",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     }
   }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/remix",
   "version": "3.0.15",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -57,7 +60,7 @@
     "main": {
       "context": "node",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=22.0.0"
       }
     }
   }

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@logto/sveltekit",
   "version": "0.3.24",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "main": "./lib/index.js",
   "module": "./lib/index.js",


### PR DESCRIPTION
Node.js 20 is EOL, so align the repository and published server-side SDKs with Node.js 22, the oldest maintained LTS line. This adds `engines.node` to Node, Express, Next, Nuxt, React Router, Remix, and SvelteKit, aligns existing Node build targets, and records major releases while leaving browser, mobile, and private sample packages unchanged.
