### PR TITLE
refactor(client): simplify response parsing

### DIFF
--- a/.changeset/calm-responses-read.md
+++ b/.changeset/calm-responses-read.md
@@ -1,0 +1,5 @@
+---
+"@logto/client": patch
+---
+
+simplify error response parsing while preserving the original response for callers

--- a/.changeset/fresh-nodes-fetch.md
+++ b/.changeset/fresh-nodes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@logto/node": patch
+---
+
+remove stale node-fetch documentation and declarations

--- a/packages/client/src/utils/requester.test.ts
+++ b/packages/client/src/utils/requester.test.ts
@@ -1,4 +1,5 @@
-import { LogtoError } from '@logto/js';
+import { LogtoError, LogtoRequestError } from '@logto/js';
+import { assert } from '@silverhand/essentials';
 
 import { createRequester } from './requester.js';
 
@@ -20,18 +21,24 @@ describe('createRequester', () => {
     const message = 'some error message';
 
     test('failing response json with code and message should throw LogtoRequestError with same code and message', async () => {
+      const body = { code, message };
       const fetchFunction = vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ code, message }), {
+        new Response(JSON.stringify(body), {
           status: 400,
           headers: { 'content-type': 'application/json' },
         })
       );
       const requester = createRequester(fetchFunction);
-      await expect(requester('foo')).rejects.toMatchObject({
+      const error: unknown = await requester('foo').catch((error: unknown) => error);
+
+      expect(error).toMatchObject({
         name: 'LogtoRequestError',
         code,
         message,
       });
+
+      assert(error instanceof LogtoRequestError, new TypeError('Expected a LogtoRequestError.'));
+      await expect(error.cause?.json()).resolves.toEqual(body);
     });
 
     test('failing response json with more than code and message should throw LogtoRequestError with same code and message', async () => {
@@ -92,17 +99,23 @@ describe('createRequester', () => {
     });
 
     test('failing response with non-json text should throw LogtoRequestError', async () => {
+      const body = 'not json content';
       const fetchFunction = vi.fn().mockResolvedValue(
-        new Response('not json content', {
+        new Response(body, {
           status: 400,
         })
       );
       const requester = createRequester(fetchFunction);
-      await expect(requester('foo')).rejects.toMatchObject({
+      const error: unknown = await requester('foo').catch((error: unknown) => error);
+
+      expect(error).toMatchObject({
         name: 'LogtoRequestError',
         code: 'http_error_400',
-        message: 'not json content',
+        message: body,
       });
+
+      assert(error instanceof LogtoRequestError, new TypeError('Expected a LogtoRequestError.'));
+      await expect(error.cause?.text()).resolves.toBe(body);
     });
 
     test('rate limited response with non-json text should throw LogtoRequestError', async () => {

--- a/packages/client/src/utils/requester.ts
+++ b/packages/client/src/utils/requester.ts
@@ -1,5 +1,29 @@
 import type { Requester } from '@logto/js';
 import { LogtoError, LogtoRequestError, isLogtoRequestErrorJson } from '@logto/js';
+import { trySafe } from '@silverhand/essentials';
+
+const parseErrorResponse = async (response: Response): Promise<never> => {
+  const responseText = await response.clone().text();
+  const responseJson = trySafe<unknown>(() => JSON.parse(responseText));
+
+  if (responseJson === undefined) {
+    console.error(`Logto requester error: [status=${response.status}]`, responseText);
+    throw new LogtoRequestError(
+      response.status === 429 ? 'rate_limited' : `http_error_${response.status}`,
+      responseText || response.statusText,
+      response
+    );
+  }
+
+  console.error(`Logto requester error: [status=${response.status}]`, responseJson);
+
+  if (!isLogtoRequestErrorJson(responseJson)) {
+    throw new LogtoError('unexpected_response_error', responseJson);
+  }
+
+  const { code, message } = responseJson;
+  throw new LogtoRequestError(code, message, response);
+};
 
 /**
  * A factory function that creates a requester by accepting a `fetch`-like function.
@@ -13,29 +37,7 @@ export const createRequester = (fetchFunction: typeof fetch): Requester => {
     const response = await fetchFunction(...args);
 
     if (!response.ok) {
-      const cloned = response.clone();
-      const responseJson: unknown = await response
-        .clone()
-        .json()
-        .catch(async () => {
-          const responseText = await response.text();
-          console.error(`Logto requester error: [status=${response.status}]`, responseText);
-          throw new LogtoRequestError(
-            response.status === 429 ? 'rate_limited' : `http_error_${response.status}`,
-            responseText || response.statusText,
-            cloned
-          );
-        });
-
-      console.error(`Logto requester error: [status=${response.status}]`, responseJson);
-
-      if (!isLogtoRequestErrorJson(responseJson)) {
-        throw new LogtoError('unexpected_response_error', responseJson);
-      }
-
-      // Expected request error from server
-      const { code, message } = responseJson;
-      throw new LogtoRequestError(code, message, cloned);
+      return parseErrorResponse(response);
     }
 
     return response.json();

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -36,7 +36,7 @@ pnpm add @logto/node
 
 As the name suggests, Logto Node.js SDK is the foundation of all Logto SDKs that run in Node.js (Express, Next.js, etc.). `@logto/node` extends `@logto/client` and provides a Node.js specific implementation of the client adapters:
 
-- Implements `requester` by using package `node-fetch`.
+- Uses the native Fetch API for HTTP requests.
 - Implements `generateCodeChallenge`, `generateCodeVerifier`, `generateState` methods by using `crypto`.
 
 Usually, you are not expected to use it directly in your application, but instead choosing a framework specific SDK that built on top of it. We have already released a set of official SDKs to accelerate your integration. [Check this out](https://docs.logto.io/integrate-logto) and get started!

--- a/packages/node/src/include.d/node-fetch.d.ts
+++ b/packages/node/src/include.d/node-fetch.d.ts
@@ -1,4 +1,0 @@
-declare module 'node-fetch' {
-  const nodeFetch: typeof fetch;
-  export = nodeFetch;
-}


### PR DESCRIPTION
The requester error path currently clones a response twice to support JSON parsing, text fallback, and an unread `Response` on `LogtoRequestError`.

This change reads one cloned body as text, parses it once, and keeps the original response available to callers. It also adds coverage for reading both JSON and text error responses from the error cause, and removes the stale `node-fetch` declaration and documentation from the Node SDK.
