### PR TITLE
feat: align token claim helpers across SDKs

### DIFF
--- a/.changeset/neat-tools-export.md
+++ b/.changeset/neat-tools-export.md
@@ -1,0 +1,16 @@
+---
+"@logto/angular": minor
+"@logto/browser": minor
+"@logto/capacitor": minor
+"@logto/express": minor
+"@logto/next": minor
+"@logto/node": minor
+"@logto/react": minor
+"@logto/react-router": minor
+"@logto/remix": minor
+"@logto/sveltekit": minor
+"@logto/vue": minor
+---
+
+export `decodeAccessToken`, `ReservedResource`, and `CacheKey` from applicable platform SDK package
+roots

--- a/.changeset/soft-cats-claim.md
+++ b/.changeset/soft-cats-claim.md
@@ -6,6 +6,8 @@
 "@logto/node": minor
 ---
 
-expose `getIdTokenClaims`, `getAccessTokenClaims`, and `getOrganizationTokenClaims` through the
-Next.js server APIs and React Router request context. Support the optional `organizationId`
-argument in platform `getAccessToken` and `getAccessTokenClaims` wrappers
+expose token claim APIs across platform SDKs
+
+Make `getIdTokenClaims`, `getAccessTokenClaims`, and `getOrganizationTokenClaims` available through
+Next.js and React Router. Forward the optional `organizationId` through platform access-token
+wrappers.

--- a/.changeset/soft-cats-claim.md
+++ b/.changeset/soft-cats-claim.md
@@ -1,6 +1,10 @@
 ---
 "@logto/next": minor
 "@logto/react-router": minor
+"@logto/angular": minor
+"@logto/client": minor
+"@logto/node": minor
 ---
 
-expose ID, access, and organization token claim helpers in server request APIs
+expose ID, access, and organization token claim helpers in server request APIs, including claims
+for access tokens scoped to both a resource and organization

--- a/.changeset/soft-cats-claim.md
+++ b/.changeset/soft-cats-claim.md
@@ -6,5 +6,6 @@
 "@logto/node": minor
 ---
 
-expose ID, access, and organization token claim helpers in server request APIs, including claims
-for access tokens scoped to both a resource and organization
+expose `getIdTokenClaims`, `getAccessTokenClaims`, and `getOrganizationTokenClaims` through the
+Next.js server APIs and React Router request context. Support the optional `organizationId`
+argument in platform `getAccessToken` and `getAccessTokenClaims` wrappers

--- a/.changeset/soft-cats-claim.md
+++ b/.changeset/soft-cats-claim.md
@@ -1,0 +1,6 @@
+---
+"@logto/next": minor
+"@logto/react-router": minor
+---
+
+expose ID, access, and organization token claim helpers in server request APIs

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -13,6 +13,7 @@ export type {
 
 export {
   BrowserStorage,
+  CacheKey,
   LogtoClientError,
   LogtoError,
   LogtoRequestError,
@@ -23,6 +24,7 @@ export {
   ReservedScope,
   UserScope,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
   isLogtoRequestError,
   organizationUrnPrefix,

--- a/packages/angular/src/service.test.ts
+++ b/packages/angular/src/service.test.ts
@@ -153,8 +153,10 @@ describe('LogtoService', () => {
     await service.initialize();
 
     await expect(service.getRefreshToken()).resolves.toBe('refresh-token');
-    await expect(service.getAccessToken('api-resource')).resolves.toBe('access-token');
-    await expect(service.getAccessTokenClaims('api-resource')).resolves.toEqual({
+    await expect(service.getAccessToken('api-resource', 'organization-id')).resolves.toBe(
+      'access-token'
+    );
+    await expect(service.getAccessTokenClaims('api-resource', 'organization-id')).resolves.toEqual({
       sub: 'access-sub',
     });
     await expect(service.getOrganizationToken('organization-id')).resolves.toBe(
@@ -167,8 +169,8 @@ describe('LogtoService', () => {
     await expect(service.getIdTokenClaims()).resolves.toMatchObject({ sub: 'id-sub' });
     await expect(service.fetchUserInfo()).resolves.toMatchObject({ sub: 'user-sub' });
 
-    expect(methods.getAccessToken).toHaveBeenCalledWith('api-resource');
-    expect(methods.getAccessTokenClaims).toHaveBeenCalledWith('api-resource');
+    expect(methods.getAccessToken).toHaveBeenCalledWith('api-resource', 'organization-id');
+    expect(methods.getAccessTokenClaims).toHaveBeenCalledWith('api-resource', 'organization-id');
     expect(methods.getOrganizationToken).toHaveBeenCalledWith('organization-id');
     expect(methods.getOrganizationTokenClaims).toHaveBeenCalledWith('organization-id');
   });

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -132,14 +132,17 @@ export class LogtoService {
     return this.run(async () => this.client.getRefreshToken());
   }
 
-  /** Get an access token for the OIDC or requested API resource. */
-  async getAccessToken(resource?: string): Promise<string> {
-    return this.run(async () => this.client.getAccessToken(resource));
+  /** Get an access token for the OIDC or requested API resource and organization. */
+  async getAccessToken(resource?: string, organizationId?: string): Promise<string> {
+    return this.run(async () => this.client.getAccessToken(resource, organizationId));
   }
 
-  /** Get decoded claims for an OIDC or API-resource access token. */
-  async getAccessTokenClaims(resource?: string): Promise<AccessTokenClaims> {
-    return this.run(async () => this.client.getAccessTokenClaims(resource));
+  /** Get decoded claims for an OIDC or API-resource and organization access token. */
+  async getAccessTokenClaims(
+    resource?: string,
+    organizationId?: string
+  ): Promise<AccessTokenClaims> {
+    return this.run(async () => this.client.getAccessTokenClaims(resource, organizationId));
   }
 
   /** Get an access token for a Logto organization. */

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -34,7 +34,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
   isLogtoRequestError,
 } from '@logto/client';

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -19,7 +19,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/browser';
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -199,14 +199,19 @@ export class StandardLogtoClient {
   }
 
   /**
-   * Get the access token claims for the specified resource.
+   * Get the access token claims for the specified resource and organization.
    *
    * @param resource The resource that the access token is granted for. If not
    * specified, the access token will be used for OpenID Connect or the default
    * resource, as specified in the Logto Console.
+   * @param organizationId The optional ID of the organization that the access token is granted
+   * for.
    */
-  async getAccessTokenClaims(resource?: string): Promise<AccessTokenClaims> {
-    const accessToken = await this.getAccessToken(resource);
+  async getAccessTokenClaims(
+    resource?: string,
+    organizationId?: string
+  ): Promise<AccessTokenClaims> {
+    const accessToken = await this.getAccessToken(resource, organizationId);
 
     return decodeAccessToken(accessToken);
   }

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -269,6 +269,40 @@ describe('LogtoClient', () => {
     });
   });
 
+  describe('getAccessTokenClaims', () => {
+    it('should return claims for a resource and organization access token', async () => {
+      requester.mockClear().mockResolvedValue({
+        accessToken: 'access_token_value',
+        expiresIn: 3600,
+      });
+
+      const logtoClient = createClient(
+        undefined,
+        new MockedStorage({
+          idToken: 'id_token_value',
+          refreshToken: 'refresh_token_value',
+        })
+      );
+
+      await expect(
+        logtoClient.getAccessTokenClaims('https://api.example.com', 'organization_id')
+      ).resolves.toEqual({});
+      expect(requester).toHaveBeenCalledWith(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: 'app_id_value',
+          refresh_token: 'refresh_token_value',
+          grant_type: 'refresh_token',
+          resource: 'https://api.example.com',
+          organization_id: 'organization_id',
+        }).toString(),
+      });
+    });
+  });
+
   describe('clearAccessToken', () => {
     it('should clear access token cache storage', async () => {
       const storage = new MockedStorage({

--- a/packages/client/src/shim.ts
+++ b/packages/client/src/shim.ts
@@ -22,6 +22,7 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
   isLogtoRequestError,
 } from '@logto/js';

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -19,7 +19,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/node';
 

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -21,6 +21,8 @@ export type {
   UserInfoResponse,
 } from '@logto/node';
 
+export { CacheKey, ReservedResource, decodeAccessToken } from '@logto/node/edge';
+
 export default class LogtoClient extends BaseClient {
   constructor(config: LogtoNextConfig) {
     super(config, {

--- a/packages/next/server-actions/index.test.ts
+++ b/packages/next/server-actions/index.test.ts
@@ -21,7 +21,9 @@ const accessTokenClaims: AccessTokenClaims = { sub: 'access-token-user-id' };
 const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-token-user-id' };
 
 const getIdTokenClaimsFromClient = vi.fn(async () => idTokenClaims);
-const getAccessTokenClaimsFromClient = vi.fn(async (_resource?: string) => accessTokenClaims);
+const getAccessTokenClaimsFromClient = vi.fn(
+  async (_resource?: string, _organizationId?: string) => accessTokenClaims
+);
 const getOrganizationTokenClaimsFromClient = vi.fn(
   async (_organizationId: string) => organizationTokenClaims
 );
@@ -57,30 +59,36 @@ describe('Next (server actions): token claims', () => {
   });
 
   it('gets access and organization token claims with cookie persistence enabled', async () => {
-    await expect(getAccessTokenClaims(config, 'https://api.example.com')).resolves.toEqual(
-      accessTokenClaims
-    );
+    await expect(
+      getAccessTokenClaims(config, 'https://api.example.com', 'org-id')
+    ).resolves.toEqual(accessTokenClaims);
     await expect(getOrganizationTokenClaims(config, 'org-id')).resolves.toEqual(
       organizationTokenClaims
     );
 
     expect(createNodeClient).toHaveBeenNthCalledWith(1);
     expect(createNodeClient).toHaveBeenNthCalledWith(2);
-    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith('https://api.example.com');
+    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith(
+      'https://api.example.com',
+      'org-id'
+    );
     expect(getOrganizationTokenClaimsFromClient).toHaveBeenCalledWith('org-id');
   });
 
   it('gets access and organization token claims without cookie writes in RSC', async () => {
-    await expect(getAccessTokenClaimsRSC(config, 'https://api.example.com')).resolves.toEqual(
-      accessTokenClaims
-    );
+    await expect(
+      getAccessTokenClaimsRSC(config, 'https://api.example.com', 'org-id')
+    ).resolves.toEqual(accessTokenClaims);
     await expect(getOrganizationTokenClaimsRSC(config, 'org-id')).resolves.toEqual(
       organizationTokenClaims
     );
 
     expect(createNodeClient).toHaveBeenNthCalledWith(1, { ignoreCookieChange: true });
     expect(createNodeClient).toHaveBeenNthCalledWith(2, { ignoreCookieChange: true });
-    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith('https://api.example.com');
+    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith(
+      'https://api.example.com',
+      'org-id'
+    );
     expect(getOrganizationTokenClaimsFromClient).toHaveBeenCalledWith('org-id');
   });
 });

--- a/packages/next/server-actions/index.test.ts
+++ b/packages/next/server-actions/index.test.ts
@@ -1,0 +1,86 @@
+import type { AccessTokenClaims, IdTokenClaims } from '@logto/node';
+
+import type { LogtoNextConfig } from '../src/types.js';
+
+import {
+  getAccessTokenClaims,
+  getAccessTokenClaimsRSC,
+  getIdTokenClaims,
+  getOrganizationTokenClaims,
+  getOrganizationTokenClaimsRSC,
+} from './index.js';
+
+const idTokenClaims: IdTokenClaims = {
+  aud: 'app-id',
+  exp: 1_700_000_000,
+  iat: 1_600_000_000,
+  iss: 'https://logto.example.com/oidc',
+  sub: 'user-id',
+};
+const accessTokenClaims: AccessTokenClaims = { sub: 'access-token-user-id' };
+const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-token-user-id' };
+
+const getIdTokenClaimsFromClient = vi.fn(async () => idTokenClaims);
+const getAccessTokenClaimsFromClient = vi.fn(async (_resource?: string) => accessTokenClaims);
+const getOrganizationTokenClaimsFromClient = vi.fn(
+  async (_organizationId: string) => organizationTokenClaims
+);
+const createNodeClient = vi.fn(async () => ({
+  getIdTokenClaims: getIdTokenClaimsFromClient,
+  getAccessTokenClaims: getAccessTokenClaimsFromClient,
+  getOrganizationTokenClaims: getOrganizationTokenClaimsFromClient,
+}));
+
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+vi.mock('./client', () => ({
+  default: vi.fn(() => ({ createNodeClient })),
+}));
+
+const config: LogtoNextConfig = {
+  appId: 'app-id',
+  baseUrl: 'https://app.example.com',
+  cookieSecret: 'complex_password_at_least_32_characters_long',
+  cookieSecure: false,
+  endpoint: 'https://logto.example.com',
+};
+
+describe('Next (server actions): token claims', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gets ID token claims without enabling cookie writes', async () => {
+    await expect(getIdTokenClaims(config)).resolves.toEqual(idTokenClaims);
+
+    expect(createNodeClient).toHaveBeenCalledWith({ ignoreCookieChange: true });
+    expect(getIdTokenClaimsFromClient).toHaveBeenCalledOnce();
+  });
+
+  it('gets access and organization token claims with cookie persistence enabled', async () => {
+    await expect(getAccessTokenClaims(config, 'https://api.example.com')).resolves.toEqual(
+      accessTokenClaims
+    );
+    await expect(getOrganizationTokenClaims(config, 'org-id')).resolves.toEqual(
+      organizationTokenClaims
+    );
+
+    expect(createNodeClient).toHaveBeenNthCalledWith(1);
+    expect(createNodeClient).toHaveBeenNthCalledWith(2);
+    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith('https://api.example.com');
+    expect(getOrganizationTokenClaimsFromClient).toHaveBeenCalledWith('org-id');
+  });
+
+  it('gets access and organization token claims without cookie writes in RSC', async () => {
+    await expect(getAccessTokenClaimsRSC(config, 'https://api.example.com')).resolves.toEqual(
+      accessTokenClaims
+    );
+    await expect(getOrganizationTokenClaimsRSC(config, 'org-id')).resolves.toEqual(
+      organizationTokenClaims
+    );
+
+    expect(createNodeClient).toHaveBeenNthCalledWith(1, { ignoreCookieChange: true });
+    expect(createNodeClient).toHaveBeenNthCalledWith(2, { ignoreCookieChange: true });
+    expect(getAccessTokenClaimsFromClient).toHaveBeenCalledWith('https://api.example.com');
+    expect(getOrganizationTokenClaimsFromClient).toHaveBeenCalledWith('org-id');
+  });
+});

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -153,16 +153,17 @@ export const getAccessToken = async (
 };
 
 /**
- * Get access token claims for the specified resource. This function can be used in server actions
- * or API routes.
+ * Get access token claims for the specified resource and organization. This function can be used
+ * in server actions or API routes.
  */
 export const getAccessTokenClaims = async (
   config: LogtoNextConfig,
-  resource?: string
+  resource?: string,
+  organizationId?: string
 ): Promise<AccessTokenClaims> => {
   const client = new LogtoClient(config);
   const nodeClient = await client.createNodeClient();
-  return nodeClient.getAccessTokenClaims(resource);
+  return nodeClient.getAccessTokenClaims(resource, organizationId);
 };
 
 /**
@@ -206,16 +207,17 @@ export const getAccessTokenRSC = async (
 };
 
 /**
- * Get access token claims for the specified resource in React Server Components. Refreshed tokens
- * cannot be persisted because cookies are not writable in a Server Component.
+ * Get access token claims for the specified resource and organization in React Server Components.
+ * Refreshed tokens cannot be persisted because cookies are not writable in a Server Component.
  */
 export const getAccessTokenClaimsRSC = async (
   config: LogtoNextConfig,
-  resource?: string
+  resource?: string,
+  organizationId?: string
 ): Promise<AccessTokenClaims> => {
   const client = new LogtoClient(config);
   const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
-  return nodeClient.getAccessTokenClaims(resource);
+  return nodeClient.getAccessTokenClaims(resource, organizationId);
 };
 
 /**

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -1,8 +1,10 @@
 'use server';
 
 import {
+  type AccessTokenClaims,
   type LogtoContext,
   type GetContextParameters,
+  type IdTokenClaims,
   type InteractionMode,
   type SignInOptions,
 } from '@logto/node';
@@ -12,7 +14,7 @@ import type { LogtoNextConfig } from '../src/types.js';
 
 import LogtoClient from './client';
 
-export type { LogtoContext, InteractionMode } from '@logto/node';
+export type { AccessTokenClaims, IdTokenClaims, LogtoContext, InteractionMode } from '@logto/node';
 
 /**
  * Init sign in process and redirect to the Logto sign-in page
@@ -101,6 +103,15 @@ export const getLogtoContext = async (
 };
 
 /**
+ * Get ID token claims from session. This function can also be used in React Server Components.
+ */
+export const getIdTokenClaims = async (config: LogtoNextConfig): Promise<IdTokenClaims> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
+  return nodeClient.getIdTokenClaims();
+};
+
+/**
  * Get organization tokens from session
  *
  * @deprecated Use getOrganizationToken instead
@@ -142,6 +153,19 @@ export const getAccessToken = async (
 };
 
 /**
+ * Get access token claims for the specified resource. This function can be used in server actions
+ * or API routes.
+ */
+export const getAccessTokenClaims = async (
+  config: LogtoNextConfig,
+  resource?: string
+): Promise<AccessTokenClaims> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient();
+  return nodeClient.getAccessTokenClaims(resource);
+};
+
+/**
  * Get organization token from session,
  * this function can be used in server actions or API routes
  */
@@ -150,6 +174,19 @@ export const getOrganizationToken = async (
   organizationId?: string
 ): Promise<string> => {
   return getAccessToken(config, undefined, organizationId);
+};
+
+/**
+ * Get organization token claims from session. This function can be used in server actions or API
+ * routes.
+ */
+export const getOrganizationTokenClaims = async (
+  config: LogtoNextConfig,
+  organizationId: string
+): Promise<AccessTokenClaims> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient();
+  return nodeClient.getOrganizationTokenClaims(organizationId);
 };
 
 /**
@@ -169,6 +206,19 @@ export const getAccessTokenRSC = async (
 };
 
 /**
+ * Get access token claims for the specified resource in React Server Components. Refreshed tokens
+ * cannot be persisted because cookies are not writable in a Server Component.
+ */
+export const getAccessTokenClaimsRSC = async (
+  config: LogtoNextConfig,
+  resource?: string
+): Promise<AccessTokenClaims> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
+  return nodeClient.getAccessTokenClaims(resource);
+};
+
+/**
  * Get organization token from session,
  * this function can be used in React Server Components (RSC)
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.
@@ -179,6 +229,19 @@ export const getOrganizationTokenRSC = async (
   organizationId?: string
 ): Promise<string> => {
   return getAccessTokenRSC(config, undefined, organizationId);
+};
+
+/**
+ * Get organization token claims in React Server Components. Refreshed tokens cannot be persisted
+ * because cookies are not writable in a Server Component.
+ */
+export const getOrganizationTokenClaimsRSC = async (
+  config: LogtoNextConfig,
+  organizationId: string
+): Promise<AccessTokenClaims> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient({ ignoreCookieChange: true });
+  return nodeClient.getOrganizationTokenClaims(organizationId);
 };
 
 export { default } from './client';

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -23,7 +23,9 @@ const getIdTokenClaims = vi.fn(() => ({
 const signOut = vi.fn();
 const getContext = vi.fn(async () => true);
 const getAccessToken = vi.fn();
+const getAccessTokenClaims = vi.fn();
 const getOrganizationToken = vi.fn();
+const getOrganizationTokenClaims = vi.fn();
 
 const mockResponse = (_: unknown, response: NextApiResponse) => {
   response.status(200).end();
@@ -53,7 +55,9 @@ vi.mock('@logto/node', async (importOriginal) => ({
     handleSignInCallback: (url: string) => handleSignInCallback(url, navigate),
     getContext,
     getAccessToken,
+    getAccessTokenClaims,
     getOrganizationToken,
+    getOrganizationTokenClaims,
     getIdTokenClaims,
     signOut: () => {
       navigate(configs.baseUrl);
@@ -156,6 +160,40 @@ describe('Next', () => {
     });
   });
 
+  describe('getAccessTokenClaims', () => {
+    it('should call client.getAccessTokenClaims', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.getAccessTokenClaims(request, response, 'resource');
+          response.end();
+        },
+        url: '/api/logto/get-access-token-claims',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(getAccessTokenClaims).toHaveBeenCalledWith('resource');
+        },
+      });
+    });
+  });
+
+  describe('getIdTokenClaims', () => {
+    it('should call client.getIdTokenClaims', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.getIdTokenClaims(request, response);
+          response.end();
+        },
+        url: '/api/logto/get-id-token-claims',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(getIdTokenClaims).toHaveBeenCalledOnce();
+        },
+      });
+    });
+  });
+
   describe('getOrganizationToken', () => {
     it('should call client.getOrganizationToken', async () => {
       const client = new LogtoClient(configs);
@@ -168,6 +206,23 @@ describe('Next', () => {
         test: async ({ fetch }) => {
           await fetch({ method: 'GET' });
           expect(getOrganizationToken).toHaveBeenCalledWith('organization_id');
+        },
+      });
+    });
+  });
+
+  describe('getOrganizationTokenClaims', () => {
+    it('should call client.getOrganizationTokenClaims', async () => {
+      const client = new LogtoClient(configs);
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client.getOrganizationTokenClaims(request, response, 'organization_id');
+          response.end();
+        },
+        url: '/api/logto/get-organization-token-claims',
+        test: async ({ fetch }) => {
+          await fetch({ method: 'GET' });
+          expect(getOrganizationTokenClaims).toHaveBeenCalledWith('organization_id');
         },
       });
     });

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -148,13 +148,13 @@ describe('Next', () => {
       const client = new LogtoClient(configs);
       await testApiHandler({
         pagesHandler: async (request, response) => {
-          await client.getAccessToken(request, response, 'resource');
+          await client.getAccessToken(request, response, 'resource', 'organization_id');
           response.end();
         },
         url: '/api/logto/get-access-token',
         test: async ({ fetch }) => {
           await fetch({ method: 'GET' });
-          expect(getAccessToken).toHaveBeenCalledWith('resource');
+          expect(getAccessToken).toHaveBeenCalledWith('resource', 'organization_id');
         },
       });
     });
@@ -165,13 +165,13 @@ describe('Next', () => {
       const client = new LogtoClient(configs);
       await testApiHandler({
         pagesHandler: async (request, response) => {
-          await client.getAccessTokenClaims(request, response, 'resource');
+          await client.getAccessTokenClaims(request, response, 'resource', 'organization_id');
           response.end();
         },
         url: '/api/logto/get-access-token-claims',
         test: async ({ fetch }) => {
           await fetch({ method: 'GET' });
-          expect(getAccessTokenClaims).toHaveBeenCalledWith('resource');
+          expect(getAccessTokenClaims).toHaveBeenCalledWith('resource', 'organization_id');
         },
       });
     });

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -35,7 +35,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/node';
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2,8 +2,10 @@ import { type IncomingMessage, type ServerResponse } from 'node:http';
 
 import NodeClient, {
   CookieStorage,
+  type AccessTokenClaims,
   type SignInOptions,
   type GetContextParameters,
+  type IdTokenClaims,
   type InteractionMode,
 } from '@logto/node';
 import { serialize } from 'cookie';
@@ -175,6 +177,23 @@ export default class LogtoClient extends LogtoNextBaseClient {
     return nodeClient.getAccessToken(resource);
   };
 
+  getAccessTokenClaims = async (
+    request: NextApiRequest,
+    response: NextApiResponse,
+    resource?: string
+  ): Promise<AccessTokenClaims> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    return nodeClient.getAccessTokenClaims(resource);
+  };
+
+  getIdTokenClaims = async (
+    request: NextApiRequest,
+    response: NextApiResponse
+  ): Promise<IdTokenClaims> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    return nodeClient.getIdTokenClaims();
+  };
+
   getOrganizationToken = async (
     request: NextApiRequest,
     response: NextApiResponse,
@@ -182,6 +201,15 @@ export default class LogtoClient extends LogtoNextBaseClient {
   ): Promise<string> => {
     const nodeClient = await this.createNodeClientFromNextApi(request, response);
     return nodeClient.getOrganizationToken(organizationId);
+  };
+
+  getOrganizationTokenClaims = async (
+    request: NextApiRequest,
+    response: NextApiResponse,
+    organizationId: string
+  ): Promise<AccessTokenClaims> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    return nodeClient.getOrganizationTokenClaims(organizationId);
   };
 
   withLogtoApiRoute = (

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -171,19 +171,21 @@ export default class LogtoClient extends LogtoNextBaseClient {
   getAccessToken = async (
     request: NextApiRequest,
     response: NextApiResponse,
-    resource: string
+    resource?: string,
+    organizationId?: string
   ): Promise<string> => {
     const nodeClient = await this.createNodeClientFromNextApi(request, response);
-    return nodeClient.getAccessToken(resource);
+    return nodeClient.getAccessToken(resource, organizationId);
   };
 
   getAccessTokenClaims = async (
     request: NextApiRequest,
     response: NextApiResponse,
-    resource?: string
+    resource?: string,
+    organizationId?: string
   ): Promise<AccessTokenClaims> => {
     const nodeClient = await this.createNodeClientFromNextApi(request, response);
-    return nodeClient.getAccessTokenClaims(resource);
+    return nodeClient.getAccessTokenClaims(resource, organizationId);
   };
 
   getIdTokenClaims = async (

--- a/packages/node/edge/index.ts
+++ b/packages/node/edge/index.ts
@@ -10,7 +10,7 @@ import { createMemoryCache } from '../src/utils/cache.js';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators.js';
 
-export { PersistKey } from '@logto/client';
+export { CacheKey, PersistKey, ReservedResource, decodeAccessToken } from '@logto/client';
 
 type EdgeClientAdapter = Pick<ClientAdapter, 'navigate' | 'storage'> &
   Partial<Pick<ClientAdapter, 'fetch' | 'requester'>>;

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -46,7 +46,9 @@ export default class LogtoNodeBaseClient extends BaseClient {
     const { accessToken, accessTokenClaims } = getAccessToken
       ? {
           accessToken: await trySafe(async () => this.getAccessToken(resource, organizationId)),
-          accessTokenClaims: await trySafe(async () => this.getAccessTokenClaims(resource)),
+          accessTokenClaims: await trySafe(async () =>
+            this.getAccessTokenClaims(resource, organizationId)
+          ),
         }
       : { accessToken: undefined, accessTokenClaims: undefined };
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,4 +1,4 @@
-import BaseClient from '@logto/client';
+import BaseClient, { decodeAccessToken } from '@logto/client';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import type { GetContextParameters, LogtoContext } from './types.js';
@@ -43,14 +43,9 @@ export default class LogtoNodeBaseClient extends BaseClient {
 
     const claims = await this.getIdTokenClaims();
 
-    const { accessToken, accessTokenClaims } = getAccessToken
-      ? {
-          accessToken: await trySafe(async () => this.getAccessToken(resource, organizationId)),
-          accessTokenClaims: await trySafe(async () =>
-            this.getAccessTokenClaims(resource, organizationId)
-          ),
-        }
-      : { accessToken: undefined, accessTokenClaims: undefined };
+    const accessToken = getAccessToken
+      ? await trySafe(async () => this.getAccessToken(resource, organizationId))
+      : undefined;
 
     if (getAccessToken && !accessToken) {
       // Failed to get access token, the user is not authenticated
@@ -58,6 +53,10 @@ export default class LogtoNodeBaseClient extends BaseClient {
         isAuthenticated: false,
       };
     }
+
+    const accessTokenClaims = accessToken
+      ? await trySafe(async () => decodeAccessToken(accessToken))
+      : undefined;
 
     const organizationTokens = conditional(
       getOrganizationToken &&

--- a/packages/node/src/exports.ts
+++ b/packages/node/src/exports.ts
@@ -30,7 +30,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
   StandardLogtoClient,
 } from '@logto/client';

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -12,8 +12,10 @@ const storage = {
   removeItem: vi.fn(),
 };
 
-const getAccessToken = vi.fn(async () => true);
-const getAccessTokenClaims = vi.fn(async () => ({ scope: 'read' }));
+const { decodeAccessToken } = vi.hoisted(() => ({
+  decodeAccessToken: vi.fn(() => ({ scope: 'read' })),
+}));
+const getAccessToken = vi.fn(async () => 'access-token');
 const getOrganizationToken = vi.fn(async () => 'token');
 const fetchUserInfo = vi.fn(async () => ({ name: 'name' }));
 const mockIdTokenClaims = { sub: 'sub', organizations: ['org1'] };
@@ -21,9 +23,9 @@ const getIdTokenClaims = vi.fn(async () => mockIdTokenClaims);
 const isAuthenticated = vi.fn(async () => true);
 vi.mock('@logto/client', () => ({
   __esModule: true,
+  decodeAccessToken,
   default: vi.fn(() => ({
     getAccessToken,
-    getAccessTokenClaims,
     getOrganizationToken,
     getIdTokenClaims,
     isAuthenticated,
@@ -143,7 +145,7 @@ describe('LogtoClient', () => {
   describe('getContext', () => {
     beforeEach(() => {
       getAccessToken.mockClear();
-      getAccessTokenClaims.mockClear();
+      decodeAccessToken.mockClear();
       getOrganizationToken.mockClear();
       fetchUserInfo.mockClear();
     });
@@ -171,7 +173,8 @@ describe('LogtoClient', () => {
         isAuthenticated: true,
       });
       expect(getAccessToken).toHaveBeenCalledWith('resource', 'org1');
-      expect(getAccessTokenClaims).toHaveBeenCalledWith('resource', 'org1');
+      expect(getAccessToken).toHaveBeenCalledOnce();
+      expect(decodeAccessToken).toHaveBeenCalledWith('access-token');
     });
 
     it('should get organization tokens', async () => {

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -13,6 +13,7 @@ const storage = {
 };
 
 const getAccessToken = vi.fn(async () => true);
+const getAccessTokenClaims = vi.fn(async () => ({ scope: 'read' }));
 const getOrganizationToken = vi.fn(async () => 'token');
 const fetchUserInfo = vi.fn(async () => ({ name: 'name' }));
 const mockIdTokenClaims = { sub: 'sub', organizations: ['org1'] };
@@ -22,6 +23,7 @@ vi.mock('@logto/client', () => ({
   __esModule: true,
   default: vi.fn(() => ({
     getAccessToken,
+    getAccessTokenClaims,
     getOrganizationToken,
     getIdTokenClaims,
     isAuthenticated,
@@ -141,6 +143,7 @@ describe('LogtoClient', () => {
   describe('getContext', () => {
     beforeEach(() => {
       getAccessToken.mockClear();
+      getAccessTokenClaims.mockClear();
       getOrganizationToken.mockClear();
       fetchUserInfo.mockClear();
     });
@@ -168,6 +171,7 @@ describe('LogtoClient', () => {
         isAuthenticated: true,
       });
       expect(getAccessToken).toHaveBeenCalledWith('resource', 'org1');
+      expect(getAccessTokenClaims).toHaveBeenCalledWith('resource', 'org1');
     });
 
     it('should get organization tokens', async () => {

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -222,7 +222,11 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 };
 ```
 
-Use `getOrganizationToken(organizationId)` when you need an organization token.
+Use `getOrganizationToken(organizationId)` when you need an organization token. The request
+context also exposes `getIdTokenClaims()`, `getAccessTokenClaims(resource)`, and
+`getOrganizationTokenClaims(organizationId)`. Access-token and organization-token claim lookups
+use the same coordinated session checkpoints as their token counterparts because they may refresh
+and rotate session credentials.
 
 ## Session coordination
 

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -223,10 +223,11 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 ```
 
 Use `getOrganizationToken(organizationId)` when you need an organization token. The request
-context also exposes `getIdTokenClaims()`, `getAccessTokenClaims(resource)`, and
-`getOrganizationTokenClaims(organizationId)`. Access-token and organization-token claim lookups
-use the same coordinated session checkpoints as their token counterparts because they may refresh
-and rotate session credentials.
+context also exposes `getIdTokenClaims()`, `getAccessTokenClaims(resource, organizationId)`, and
+`getOrganizationTokenClaims(organizationId)`. Pass both arguments when the token is scoped to an
+API resource within an organization. Access-token and organization-token claim lookups use the
+same coordinated session checkpoints as their token counterparts because they may refresh and
+rotate session credentials.
 
 ## Session coordination
 

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -40,9 +40,12 @@ export {
   OidcError,
   Prompt,
   ReservedScope,
+  ReservedResource,
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/node';

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -1,4 +1,4 @@
-import type { LogtoContext } from '@logto/node';
+import type { AccessTokenClaims, IdTokenClaims, LogtoContext } from '@logto/node';
 import type { Session, SessionData, SessionStorage } from 'react-router';
 import { createSession } from 'react-router';
 
@@ -41,15 +41,23 @@ const createTestSessionStorage = (initialData: SessionData = {}) => {
   };
 };
 
+const idTokenClaims: IdTokenClaims = {
+  aud: 'app-id',
+  exp: 1_700_000_000,
+  iat: 1_600_000_000,
+  iss: 'https://logto.example.com/oidc',
+  sub: 'user-id',
+};
+const accessTokenClaims: AccessTokenClaims = { sub: 'access-token-user-id' };
+const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-token-user-id' };
+const defaultClaimsClientMethods = {
+  getIdTokenClaims: async () => idTokenClaims,
+  getAccessTokenClaims: async (_resource?: string) => accessTokenClaims,
+  getOrganizationTokenClaims: async (_organizationId: string) => organizationTokenClaims,
+};
 const authenticatedContext: LogtoContext = {
   isAuthenticated: true,
-  claims: {
-    aud: 'app-id',
-    exp: 1_700_000_000,
-    iat: 1_600_000_000,
-    iss: 'https://logto.example.com/oidc',
-    sub: 'user-id',
-  },
+  claims: idTokenClaims,
 };
 
 describe('middleware:createLogtoRequestContext', () => {
@@ -57,7 +65,7 @@ describe('middleware:createLogtoRequestContext', () => {
     vi.useRealTimers();
   });
 
-  it('reads the authentication context without committing the session', async () => {
+  it('reads authentication and ID token claims without committing the session', async () => {
     const store = createTestSessionStorage({ idToken: 'id-token' });
     const runtime = await SessionRuntime.create({
       cookieHeader: sessionCookie,
@@ -67,15 +75,20 @@ describe('middleware:createLogtoRequestContext', () => {
     const getContext = vi.fn(
       async (_options?: { fetchUserInfo?: boolean }) => authenticatedContext
     );
+    const getIdTokenClaims = vi.fn(async () => idTokenClaims);
     const createClient: CreateLogtoRequestClient = () => ({
+      ...defaultClaimsClientMethods,
       getContext,
+      getIdTokenClaims,
       getAccessToken: async () => 'access-token',
       getOrganizationToken: async () => 'organization-token',
     });
     const context = createLogtoRequestContext(runtime, createClient);
 
     await expect(context.getContext()).resolves.toEqual(authenticatedContext);
+    await expect(context.getIdTokenClaims()).resolves.toEqual(idTokenClaims);
     expect(getContext).toHaveBeenCalledWith();
+    expect(getIdTokenClaims).toHaveBeenCalledOnce();
     expect(store.commitSession).not.toHaveBeenCalled();
   });
 
@@ -91,6 +104,7 @@ describe('middleware:createLogtoRequestContext', () => {
     );
     const getAccessToken = vi.fn(async () => 'access-token');
     const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
       getContext,
       getAccessToken: async () => {
         session.set('refreshToken', 'rotated');
@@ -119,6 +133,7 @@ describe('middleware:createLogtoRequestContext', () => {
     });
     const userInfoError = new Error('userinfo unavailable');
     const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
       getContext: async (options) => {
         if (options?.fetchUserInfo) {
           throw userInfoError;
@@ -151,6 +166,7 @@ describe('middleware:createLogtoRequestContext', () => {
     );
     const getOrganizationToken = vi.fn(async (_organizationId: string) => 'organization-token');
     const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
       getContext: async () => authenticatedContext,
       getAccessToken: async (resource, organizationId) => {
         session.set('accessToken', 'cached-access-token');
@@ -177,6 +193,46 @@ describe('middleware:createLogtoRequestContext', () => {
     expect(store.commitSession).toHaveBeenCalledTimes(2);
   });
 
+  it('passes claim parameters through session checkpoints', async () => {
+    const store = createTestSessionStorage({ refreshToken: 'old' });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const getAccessTokenClaims = vi.fn(async (_resource?: string) => accessTokenClaims);
+    const getOrganizationTokenClaims = vi.fn(
+      async (_organizationId: string) => organizationTokenClaims
+    );
+    const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
+      getContext: async () => authenticatedContext,
+      getAccessToken: async () => 'access-token',
+      getAccessTokenClaims: async (resource) => {
+        session.set('refreshToken', 'rotated-for-access-token');
+        return getAccessTokenClaims(resource);
+      },
+      getOrganizationToken: async () => 'organization-token',
+      getOrganizationTokenClaims: async (organizationId) => {
+        session.set('refreshToken', 'rotated-for-organization-token');
+        return getOrganizationTokenClaims(organizationId);
+      },
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await expect(context.getAccessTokenClaims('https://api.example.com')).resolves.toEqual(
+      accessTokenClaims
+    );
+    await expect(context.getOrganizationTokenClaims('org-id')).resolves.toEqual(
+      organizationTokenClaims
+    );
+
+    expect(getAccessTokenClaims).toHaveBeenCalledWith('https://api.example.com');
+    expect(getOrganizationTokenClaims).toHaveBeenCalledWith('org-id');
+    expect(store.getData()).toEqual({ refreshToken: 'rotated-for-organization-token' });
+    expect(store.commitSession).toHaveBeenCalledTimes(2);
+  });
+
   it('persists token mutations before propagating a token acquisition error', async () => {
     const store = createTestSessionStorage({ refreshToken: 'old' });
     const runtime = await SessionRuntime.create({
@@ -186,6 +242,7 @@ describe('middleware:createLogtoRequestContext', () => {
     });
     const verificationError = new Error('ID token verification failed');
     const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
       getContext: async () => authenticatedContext,
       getAccessToken: async () => {
         session.set('refreshToken', 'rotated');
@@ -220,6 +277,7 @@ describe('middleware:createLogtoRequestContext', () => {
       session.set('refreshToken', 'rotated');
     });
     const createClient: CreateLogtoRequestClient = (session) => ({
+      ...defaultClaimsClientMethods,
       getContext: async () => authenticatedContext,
       getAccessToken: async () => {
         if (session.get('refreshToken') === 'old') {

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -52,7 +52,7 @@ const accessTokenClaims: AccessTokenClaims = { sub: 'access-token-user-id' };
 const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-token-user-id' };
 const defaultClaimsClientMethods = {
   getIdTokenClaims: async () => idTokenClaims,
-  getAccessTokenClaims: async (_resource?: string) => accessTokenClaims,
+  getAccessTokenClaims: async (_resource?: string, _organizationId?: string) => accessTokenClaims,
   getOrganizationTokenClaims: async (_organizationId: string) => organizationTokenClaims,
 };
 const authenticatedContext: LogtoContext = {
@@ -200,7 +200,9 @@ describe('middleware:createLogtoRequestContext', () => {
       sessionStorage: store.sessionStorage,
       sessionCoordinator: createProcessLocalSessionCoordinator(),
     });
-    const getAccessTokenClaims = vi.fn(async (_resource?: string) => accessTokenClaims);
+    const getAccessTokenClaims = vi.fn(
+      async (_resource?: string, _organizationId?: string) => accessTokenClaims
+    );
     const getOrganizationTokenClaims = vi.fn(
       async (_organizationId: string) => organizationTokenClaims
     );
@@ -208,9 +210,9 @@ describe('middleware:createLogtoRequestContext', () => {
       ...defaultClaimsClientMethods,
       getContext: async () => authenticatedContext,
       getAccessToken: async () => 'access-token',
-      getAccessTokenClaims: async (resource) => {
+      getAccessTokenClaims: async (resource, organizationId) => {
         session.set('refreshToken', 'rotated-for-access-token');
-        return getAccessTokenClaims(resource);
+        return getAccessTokenClaims(resource, organizationId);
       },
       getOrganizationToken: async () => 'organization-token',
       getOrganizationTokenClaims: async (organizationId) => {
@@ -220,14 +222,14 @@ describe('middleware:createLogtoRequestContext', () => {
     });
     const context = createLogtoRequestContext(runtime, createClient);
 
-    await expect(context.getAccessTokenClaims('https://api.example.com')).resolves.toEqual(
-      accessTokenClaims
-    );
+    await expect(
+      context.getAccessTokenClaims('https://api.example.com', 'org-id')
+    ).resolves.toEqual(accessTokenClaims);
     await expect(context.getOrganizationTokenClaims('org-id')).resolves.toEqual(
       organizationTokenClaims
     );
 
-    expect(getAccessTokenClaims).toHaveBeenCalledWith('https://api.example.com');
+    expect(getAccessTokenClaims).toHaveBeenCalledWith('https://api.example.com', 'org-id');
     expect(getOrganizationTokenClaims).toHaveBeenCalledWith('org-id');
     expect(store.getData()).toEqual({ refreshToken: 'rotated-for-organization-token' });
     expect(store.commitSession).toHaveBeenCalledTimes(2);

--- a/packages/react-router/src/middleware/request-context.ts
+++ b/packages/react-router/src/middleware/request-context.ts
@@ -1,4 +1,9 @@
-import type { GetContextParameters, LogtoContext } from '@logto/node';
+import type {
+  AccessTokenClaims,
+  GetContextParameters,
+  IdTokenClaims,
+  LogtoContext,
+} from '@logto/node';
 import type { Session } from 'react-router';
 
 import type { SessionRuntime } from '../infrastructure/session/index.js';
@@ -17,14 +22,20 @@ export type LogtoAuthenticationContext = Readonly<
 export type LogtoRequestContext = Readonly<{
   session: Session;
   getContext: (options?: GetLogtoContextOptions) => Promise<LogtoAuthenticationContext>;
+  getIdTokenClaims: () => Promise<IdTokenClaims>;
   getAccessToken: (options?: GetAccessTokenOptions) => Promise<string>;
+  getAccessTokenClaims: (resource?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
+  getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
 }>;
 
 type LogtoRequestClient = {
   getContext: (options?: GetContextParameters) => Promise<LogtoContext>;
+  getIdTokenClaims: () => Promise<IdTokenClaims>;
   getAccessToken: (resource?: string, organizationId?: string) => Promise<string>;
+  getAccessTokenClaims: (resource?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
+  getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
 };
 
 export type CreateLogtoRequestClient = (session: Session) => LogtoRequestClient;
@@ -37,6 +48,9 @@ export const createLogtoRequestContext = (
     runtime.checkpoint(async (session) =>
       createClient(session).getAccessToken(resource, organizationId)
     );
+
+  const getAccessTokenClaims = async (resource?: string) =>
+    runtime.checkpoint(async (session) => createClient(session).getAccessTokenClaims(resource));
 
   const getContext = async (options: GetLogtoContextOptions = {}) => {
     const context = await createClient(runtime.session).getContext();
@@ -55,10 +69,18 @@ export const createLogtoRequestContext = (
       createClient(session).getOrganizationToken(organizationId)
     );
 
+  const getOrganizationTokenClaims = async (organizationId: string) =>
+    runtime.checkpoint(async (session) =>
+      createClient(session).getOrganizationTokenClaims(organizationId)
+    );
+
   return Object.freeze({
     session: runtime.session,
     getContext,
+    getIdTokenClaims: async () => createClient(runtime.session).getIdTokenClaims(),
     getAccessToken,
+    getAccessTokenClaims,
     getOrganizationToken,
+    getOrganizationTokenClaims,
   });
 };

--- a/packages/react-router/src/middleware/request-context.ts
+++ b/packages/react-router/src/middleware/request-context.ts
@@ -24,7 +24,7 @@ export type LogtoRequestContext = Readonly<{
   getContext: (options?: GetLogtoContextOptions) => Promise<LogtoAuthenticationContext>;
   getIdTokenClaims: () => Promise<IdTokenClaims>;
   getAccessToken: (options?: GetAccessTokenOptions) => Promise<string>;
-  getAccessTokenClaims: (resource?: string) => Promise<AccessTokenClaims>;
+  getAccessTokenClaims: (resource?: string, organizationId?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
   getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
 }>;
@@ -33,7 +33,7 @@ type LogtoRequestClient = {
   getContext: (options?: GetContextParameters) => Promise<LogtoContext>;
   getIdTokenClaims: () => Promise<IdTokenClaims>;
   getAccessToken: (resource?: string, organizationId?: string) => Promise<string>;
-  getAccessTokenClaims: (resource?: string) => Promise<AccessTokenClaims>;
+  getAccessTokenClaims: (resource?: string, organizationId?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
   getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
 };
@@ -49,8 +49,10 @@ export const createLogtoRequestContext = (
       createClient(session).getAccessToken(resource, organizationId)
     );
 
-  const getAccessTokenClaims = async (resource?: string) =>
-    runtime.checkpoint(async (session) => createClient(session).getAccessTokenClaims(resource));
+  const getAccessTokenClaims = async (resource?: string, organizationId?: string) =>
+    runtime.checkpoint(async (session) =>
+      createClient(session).getAccessTokenClaims(resource, organizationId)
+    );
 
   const getContext = async (options: GetLogtoContextOptions = {}) => {
     const context = await createClient(runtime.session).getContext();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,7 +21,9 @@ export {
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/browser';
 

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -52,9 +52,12 @@ export {
   OidcError,
   Prompt,
   ReservedScope,
+  ReservedResource,
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/node';

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -28,6 +28,7 @@ export {
   LogtoError,
   LogtoRequestError,
   OidcError,
+  CacheKey,
   PersistKey,
   Prompt,
   ReservedResource,
@@ -35,6 +36,7 @@ export {
   StandardLogtoClient,
   UserScope,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
   organizationUrnPrefix,
 } from '@logto/node';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -26,10 +26,13 @@ export {
   OidcError,
   Prompt,
   ReservedScope,
+  ReservedResource,
   UserScope,
   organizationUrnPrefix,
   buildOrganizationUrn,
+  decodeAccessToken,
   getOrganizationIdFromUrn,
+  CacheKey,
   PersistKey,
 } from '@logto/browser';
 


### PR DESCRIPTION
Aligns token and decoded-claim access across the core, Angular, React Router, and Next.js SDKs. Access-token claims now accept an optional resource and organization ID together, while React Router coordinates session persistence and Next.js Server Actions includes read-only RSC variants.
