### PR TITLE
fix: clear local state before remote sign-out

### DIFF
--- a/.changeset/tough-bears-leave.md
+++ b/.changeset/tough-bears-leave.md
@@ -1,0 +1,11 @@
+---
+"@logto/angular": patch
+"@logto/client": patch
+"@logto/next": patch
+"@logto/react": patch
+"@logto/react-router": patch
+"@logto/remix": patch
+"@logto/vue": patch
+---
+
+clear local authentication state when remote sign-out cannot start

--- a/.changeset/tough-bears-leave.md
+++ b/.changeset/tough-bears-leave.md
@@ -1,10 +1,17 @@
 ---
 "@logto/angular": patch
+"@logto/browser": patch
+"@logto/capacitor": patch
+"@logto/chrome-extension": patch
 "@logto/client": patch
+"@logto/express": patch
 "@logto/next": patch
+"@logto/node": patch
+"@logto/nuxt": patch
 "@logto/react": patch
 "@logto/react-router": patch
 "@logto/remix": patch
+"@logto/sveltekit": patch
 "@logto/vue": patch
 ---
 

--- a/packages/angular/src/service.test.ts
+++ b/packages/angular/src/service.test.ts
@@ -295,4 +295,18 @@ describe('LogtoService', () => {
     expect(methods.signOut).toHaveBeenCalledWith('https://app.example/');
     expect(service.isLoading()).toBe(false);
   });
+
+  it('reflects cleared authentication state when remote sign-out fails', async () => {
+    const { client, methods } = createClient();
+    methods.isAuthenticated.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const service = new LogtoService(client);
+    await service.initialize();
+    const error = new Error('OIDC discovery failed');
+    methods.signOut.mockRejectedValueOnce(error);
+
+    await expect(service.signOut()).rejects.toBe(error);
+
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.error()).toBe(error);
+  });
 });

--- a/packages/angular/src/service.ts
+++ b/packages/angular/src/service.ts
@@ -110,7 +110,14 @@ export class LogtoService {
   /** Revoke local credentials and start the Logto sign-out redirect flow. */
   async signOut(postLogoutRedirectUri?: string): Promise<void> {
     // Keep authentication state stable while the redirect starts to avoid an intermediate UI state.
-    return this.run(async () => this.client.signOut(postLogoutRedirectUri));
+    return this.run(async () => {
+      try {
+        await this.client.signOut(postLogoutRedirectUri);
+      } catch (error: unknown) {
+        await this.syncAuthenticationState();
+        throw error;
+      }
+    });
   }
 
   /** Check whether the current URL is the redirect URI for an active sign-in session. */
@@ -187,6 +194,14 @@ export class LogtoService {
   /** Clear the latest SDK operation error. */
   clearError(): void {
     this.errorState.set(undefined);
+  }
+
+  private async syncAuthenticationState() {
+    try {
+      this.authenticatedState.set(await this.client.isAuthenticated());
+    } catch {
+      // Preserve the current state when storage cannot be read.
+    }
   }
 
   private startLoading() {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -390,7 +390,8 @@ export class StandardLogtoClient {
    * Start the sign-out flow with the specified redirect URI. The URI must be
    * registered in the Logto Console.
    *
-   * It will also revoke all the tokens and clean up the storage.
+   * It clears local authentication data before attempting token revocation and remote sign-out,
+   * so local cleanup is preserved when a network request or navigation fails.
    *
    * The user will be redirected that URI after the sign-out flow is completed.
    * If the `postLogoutRedirectUri` is not specified, the user will be redirected
@@ -398,8 +399,11 @@ export class StandardLogtoClient {
    */
   async signOut(postLogoutRedirectUri?: string): Promise<void> {
     const { appId: clientId } = this.logtoConfig;
-    const { endSessionEndpoint, revocationEndpoint } = await this.getOidcConfig();
     const refreshToken = await this.getRefreshToken();
+
+    await Promise.all([this.clearAllTokens(), this.setSignInSession(null)]);
+
+    const { endSessionEndpoint, revocationEndpoint } = await this.getOidcConfig();
 
     if (refreshToken) {
       try {
@@ -415,7 +419,6 @@ export class StandardLogtoClient {
       clientId,
     });
 
-    await this.clearAllTokens();
     await this.adapter.navigate(url, { redirectUri: postLogoutRedirectUri, for: 'sign-out' });
   }
 

--- a/packages/client/src/index.sign-out.test.ts
+++ b/packages/client/src/index.sign-out.test.ts
@@ -19,10 +19,12 @@ describe('LogtoClient', () => {
     const storage = new MockedStorage();
 
     beforeEach(() => {
+      vi.clearAllMocks();
       storage.reset({
         idToken: 'id_token_value',
         refreshToken: 'refresh_token_value',
         accessToken: 'access_token_map_json_string',
+        signInSession: 'sign_in_session_json_string',
       });
     });
 
@@ -33,13 +35,14 @@ describe('LogtoClient', () => {
       expect(requester).toHaveBeenCalledWith(revocationEndpoint, expect.anything());
     });
 
-    it('should clear id token, refresh token and access token from storage', async () => {
+    it('should clear all local authentication data from storage', async () => {
       const logtoClient = createClient(undefined, storage);
       await logtoClient.signOut(postSignOutRedirectUri);
 
       await expect(storage.getItem('idToken')).resolves.toBeNull();
       await expect(storage.getItem('refreshToken')).resolves.toBeNull();
       await expect(storage.getItem('accessToken')).resolves.toBeNull();
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
     });
 
     it('should redirect to post sign-out URI after signing out', async () => {
@@ -73,6 +76,34 @@ describe('LogtoClient', () => {
         redirectUri: undefined,
         for: 'sign-out',
       });
+    });
+
+    it('should clear local authentication data before OIDC discovery', async () => {
+      const discoveryError = new Error('OIDC discovery failed');
+      const logtoClient = createClient(undefined, storage);
+
+      vi.spyOn(logtoClient, 'getOidcConfig').mockRejectedValue(discoveryError);
+
+      await expect(logtoClient.signOut()).rejects.toBe(discoveryError);
+      await expect(storage.getItem('idToken')).resolves.toBeNull();
+      await expect(storage.getItem('refreshToken')).resolves.toBeNull();
+      await expect(storage.getItem('accessToken')).resolves.toBeNull();
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
+      expect(requester).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('should keep local authentication data cleared when navigation fails', async () => {
+      const navigationError = new Error('Navigation failed');
+      const logtoClient = createClient(undefined, storage);
+
+      navigate.mockRejectedValueOnce(navigationError);
+
+      await expect(logtoClient.signOut()).rejects.toBe(navigationError);
+      await expect(storage.getItem('idToken')).resolves.toBeNull();
+      await expect(storage.getItem('refreshToken')).resolves.toBeNull();
+      await expect(storage.getItem('accessToken')).resolves.toBeNull();
+      await expect(storage.getItem('signInSession')).resolves.toBeNull();
     });
   });
 });

--- a/packages/next/edge/index.test.ts
+++ b/packages/next/edge/index.test.ts
@@ -1,0 +1,75 @@
+import type { NextRequest } from 'next/server';
+
+import type { LogtoNextConfig } from '../src/types.js';
+
+import LogtoClient from './index.js';
+
+const signOut = vi.fn();
+const destroy = vi.fn();
+
+vi.mock('@logto/node', () => ({
+  CookieStorage: vi.fn(
+    (config: {
+      setCookie: (name: string, value: string, options: { maxAge: number }) => void;
+    }) => ({
+      init: vi.fn(),
+      destroy: async () => {
+        destroy();
+        config.setCookie('logto-session', '', { maxAge: 0 });
+      },
+    })
+  ),
+}));
+
+type Adapter = {
+  navigate: (url: string) => void;
+};
+
+vi.mock('@logto/node/edge', () => ({
+  default: vi.fn((_: unknown, { navigate }: Adapter) => ({
+    signOut: async () => {
+      await signOut();
+      navigate('https://logto.example.com/oidc/session/end');
+    },
+  })),
+}));
+
+const config: LogtoNextConfig = {
+  appId: 'app-id',
+  baseUrl: 'https://app.example.com',
+  cookieSecret: 'complex_password_at_least_32_characters_long',
+  cookieSecure: false,
+  endpoint: 'https://logto.example.com',
+};
+
+describe('Next (edge): sign-out', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the remote sign-out redirect with the destroyed session cookie', async () => {
+    const client = new LogtoClient(config);
+    const handler = client.handleSignOut();
+    const response = await handler(
+      new Request('https://app.example.com/api/logto/sign-out') as NextRequest
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe('https://logto.example.com/oidc/session/end');
+    expect(response.headers.get('Set-Cookie')).toContain('logto-session=');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('returns the clearing cookie when remote sign-out fails', async () => {
+    signOut.mockRejectedValueOnce(new Error('OIDC discovery failed'));
+    const client = new LogtoClient(config);
+    const handler = client.handleSignOut();
+    const response = await handler(
+      new Request('https://app.example.com/api/logto/sign-out') as NextRequest
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('Set-Cookie')).toContain('logto-session=');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/next/edge/index.test.ts
+++ b/packages/next/edge/index.test.ts
@@ -10,12 +10,13 @@ const destroy = vi.fn();
 vi.mock('@logto/node', () => ({
   CookieStorage: vi.fn(
     (config: {
+      cookieKey: string;
       setCookie: (name: string, value: string, options: { maxAge: number }) => void;
     }) => ({
       init: vi.fn(),
       destroy: async () => {
         destroy();
-        config.setCookie('logto-session', '', { maxAge: 0 });
+        config.setCookie(config.cookieKey, 'encrypted-empty-session', { maxAge: 14 * 24 * 3600 });
       },
     })
   ),
@@ -47,7 +48,7 @@ describe('Next (edge): sign-out', () => {
     vi.clearAllMocks();
   });
 
-  it('returns the remote sign-out redirect with the destroyed session cookie', async () => {
+  it('returns the remote sign-out redirect with the reset session cookie', async () => {
     const client = new LogtoClient(config);
     const handler = client.handleSignOut();
     const response = await handler(
@@ -56,12 +57,15 @@ describe('Next (edge): sign-out', () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get('Location')).toBe('https://logto.example.com/oidc/session/end');
-    expect(response.headers.get('Set-Cookie')).toContain('logto-session=');
+    expect(response.headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-empty-session');
+    expect(response.headers.get('Set-Cookie')).toContain('Max-Age=1209600');
     expect(destroy).toHaveBeenCalledOnce();
   });
 
-  it('returns the clearing cookie when remote sign-out fails', async () => {
-    signOut.mockRejectedValueOnce(new Error('OIDC discovery failed'));
+  it('reports the failure and returns the reset session cookie when remote sign-out fails', async () => {
+    const signOutError = new Error('OIDC discovery failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => true);
+    signOut.mockRejectedValueOnce(signOutError);
     const client = new LogtoClient(config);
     const handler = client.handleSignOut();
     const response = await handler(
@@ -69,7 +73,10 @@ describe('Next (edge): sign-out', () => {
     );
 
     expect(response.status).toBe(500);
-    expect(response.headers.get('Set-Cookie')).toContain('logto-session=');
+    expect(response.headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-empty-session');
+    expect(response.headers.get('Set-Cookie')).toContain('Max-Age=1209600');
     expect(destroy).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith('Logto sign-out failed.', signOutError);
+    consoleError.mockRestore();
   });
 });

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -56,8 +56,16 @@ export default class LogtoClient extends BaseClient {
       const { nodeClient, storage, headers, getNavigateUrl } = await this.createRequestScopedClient(
         request
       );
-      await nodeClient.signOut(redirectUri);
+      const didStartRemoteSignOut = await nodeClient.signOut(redirectUri).then(
+        () => true,
+        () => false
+      );
       await storage.destroy();
+
+      if (!didStartRemoteSignOut) {
+        // The response must carry the clearing cookie even when remote sign-out cannot start.
+        return new Response(null, { headers, status: 500, statusText: 'Sign-out failed' });
+      }
 
       const response = new Response(null, {
         headers,

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -56,14 +56,15 @@ export default class LogtoClient extends BaseClient {
       const { nodeClient, storage, headers, getNavigateUrl } = await this.createRequestScopedClient(
         request
       );
-      const didStartRemoteSignOut = await nodeClient.signOut(redirectUri).then(
-        () => true,
-        () => false
+      const signOutOutcome = await nodeClient.signOut(redirectUri).then(
+        () => ({ status: 'fulfilled' }) as const,
+        (error: unknown) => ({ status: 'rejected', error }) as const
       );
       await storage.destroy();
 
-      if (!didStartRemoteSignOut) {
-        // The response must carry the clearing cookie even when remote sign-out cannot start.
+      if (signOutOutcome.status === 'rejected') {
+        console.error('Logto sign-out failed.', signOutOutcome.error);
+        // The response must carry the session-reset cookie even when remote sign-out cannot start.
         return new Response(null, { headers, status: 500, statusText: 'Sign-out failed' });
       }
 

--- a/packages/next/server-actions/client.test.ts
+++ b/packages/next/server-actions/client.test.ts
@@ -21,12 +21,13 @@ const getIdTokenClaims = vi.fn(() => ({
 }));
 const signOut = vi.fn();
 const getContext = vi.fn(async () => ({ isAuthenticated: true }));
+const destroy = vi.fn();
 
 vi.mock('@logto/node', () => ({
   CookieStorage: vi.fn((_, cookie: string) => {
     return {
       init: vi.fn(),
-      destroy: vi.fn(),
+      destroy,
     };
   }),
 }));
@@ -47,15 +48,19 @@ vi.mock('@logto/node/edge', () => ({
     },
     getContext,
     getIdTokenClaims,
-    signOut: () => {
+    signOut: async () => {
+      await signOut();
       navigate(configs.baseUrl);
-      signOut();
     },
     isAuthenticated: true,
   })),
 }));
 
 describe('Next (server actions)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('creates an instance without crash', () => {
     expect(() => new LogtoClient(configs)).not.toThrow();
   });
@@ -82,6 +87,15 @@ describe('Next (server actions)', () => {
       const client = new LogtoClient(configs);
       const url = await client.handleSignOut('{}');
       expect(url).toEqual(configs.baseUrl);
+    });
+
+    it('should destroy storage when sign-out fails', async () => {
+      const signOutError = new Error('OIDC discovery failed');
+      signOut.mockRejectedValueOnce(signOutError);
+      const client = new LogtoClient(configs);
+
+      await expect(client.handleSignOut()).rejects.toBe(signOutError);
+      expect(destroy).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/next/server-actions/client.ts
+++ b/packages/next/server-actions/client.ts
@@ -69,8 +69,11 @@ export default class LogtoClient extends BaseClient {
    */
   async handleSignOut(redirectUri = this.config.baseUrl): Promise<string> {
     const { nodeClient, storage, getNavigateUrl } = await this.createRequestScopedClient();
-    await nodeClient.signOut(redirectUri);
-    await storage.destroy();
+    try {
+      await nodeClient.signOut(redirectUri);
+    } finally {
+      await storage.destroy();
+    }
 
     const navigateUrl = getNavigateUrl();
     if (!navigateUrl) {

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -1,4 +1,4 @@
-import { type SignInOptions } from '@logto/node';
+import { CookieStorage, type SignInOptions } from '@logto/node';
 import type { NextApiResponse } from 'next';
 import { testApiHandler } from 'next-test-api-route-handler';
 
@@ -59,9 +59,9 @@ vi.mock('@logto/node', async (importOriginal) => ({
     getOrganizationToken,
     getOrganizationTokenClaims,
     getIdTokenClaims,
-    signOut: () => {
+    signOut: async () => {
+      await signOut();
       navigate(configs.baseUrl);
-      signOut();
     },
     isAuthenticated: true,
   })),
@@ -70,6 +70,7 @@ vi.mock('@logto/node', async (importOriginal) => ({
 describe('Next', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('creates an instance without crash', () => {
@@ -278,6 +279,28 @@ describe('Next', () => {
         },
       });
       expect(signOut).toHaveBeenCalled();
+    });
+
+    it('should destroy storage when sign-out fails', async () => {
+      const signOutError = new Error('OIDC discovery failed');
+      const destroy = vi.spyOn(CookieStorage.prototype, 'destroy');
+      signOut.mockRejectedValueOnce(signOutError);
+      const client = new LogtoClient(configs);
+
+      await testApiHandler({
+        pagesHandler: client.handleSignOut(undefined, (_request, response, error) => {
+          expect(error).toBe(signOutError);
+          response.status(500).end();
+        }),
+        url: '/api/logto/sign-out',
+        test: async ({ fetch }) => {
+          const response = await fetch({ method: 'GET', redirect: 'manual' });
+          expect(response.status).toBe(500);
+          expect(response.headers.get('Set-Cookie')).toContain('logto_app_id_value=');
+        },
+      });
+
+      expect(destroy).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -123,9 +123,11 @@ export default class LogtoClient extends LogtoNextBaseClient {
         request,
         response
       );
-      await nodeClient.signOut(redirectUri);
-
-      await storage.destroy();
+      try {
+        await nodeClient.signOut(redirectUri);
+      } finally {
+        await storage.destroy();
+      }
 
       const navigateUrl = getNavigateUrl();
       if (navigateUrl) {

--- a/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
@@ -308,4 +308,22 @@ describe('infrastructure:session:SessionRuntime', () => {
       'Cannot update a destroyed session.'
     );
   });
+
+  it('destroys the session before rethrowing an operation error', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token' });
+    const runtime = await createRuntime(store.sessionStorage);
+    const signOutError = new Error('OIDC discovery failed');
+
+    await expect(
+      runtime.destroy(async (session) => {
+        session.unset('idToken');
+        throw signOutError;
+      })
+    ).rejects.toBe(signOutError);
+
+    expect(store.getData()).toEqual({});
+    expect(store.destroySession).toHaveBeenCalledOnce();
+    expect(runtime.session.data).toEqual({});
+    await expect(runtime.finalize()).resolves.toBe('logto-session=; Max-Age=0');
+  });
 });

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -162,8 +162,9 @@ export class SessionRuntime<
   }
 
   /**
-   * Runs an operation against the latest session, then destroys it under coordination. Once
-   * destroyed, further checkpoints and destruction fail and finalization performs no commit.
+   * Runs an operation against the latest session, then destroys it under coordination even when
+   * the operation rejects. Once destroyed, further checkpoints and destruction fail and
+   * finalization performs no commit.
    */
   public async destroy<Result>(
     operation: SessionOperation<Result, Data, FlashData>
@@ -177,7 +178,7 @@ export class SessionRuntime<
 
       this.session.applyPendingMutations(latestSession);
 
-      const result = await operation(new TrackedSession(latestSession));
+      const outcome = await settleSessionOperation(operation(new TrackedSession(latestSession)));
       const cookieHeader = await sessionStorage.destroySession(latestSession);
 
       this.currentCookieHeader = getRequestCookieHeader(cookieHeader);
@@ -185,7 +186,11 @@ export class SessionRuntime<
       this.destroyed = true;
       this.session.adopt(createSession<Data, FlashData>());
 
-      return result;
+      if (outcome.status === 'rejected') {
+        throw outcome.error;
+      }
+
+      return outcome.value;
     });
   }
 

--- a/packages/react-router/src/middleware/create-middleware.spec.ts
+++ b/packages/react-router/src/middleware/create-middleware.spec.ts
@@ -117,6 +117,43 @@ describe('middleware:createLogtoMiddleware', () => {
     expect(store.commitSession).toHaveBeenCalledOnce();
   });
 
+  it('returns the destroyed session cookie when remote sign-out fails', async () => {
+    const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'refresh-token' });
+    const discoveryError = new Error('OIDC discovery failed');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw discoveryError;
+      })
+    );
+    const logto = createLogtoReactRouter(
+      { ...config, endpoint: 'https://failed-logto.example.com' },
+      { sessionStorage: store.sessionStorage }
+    );
+    const authRoutes = logto.authRoutes({
+      paths: {
+        signIn: '/api/logto/sign-in',
+        signUp: '/api/logto/sign-up',
+        callback: '/api/logto/callback',
+        signOut: '/api/logto/sign-out',
+      },
+      postCallbackRedirectUri: '/',
+      postSignOutRedirectUri: '/',
+    });
+
+    const response = await runRoute(
+      logto.middleware,
+      authRoutes.action,
+      'POST',
+      '/api/logto/sign-out'
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('Set-Cookie')).toBe('logto-session=session-id; Max-Age=0');
+    expect(store.getData()).toEqual({});
+    expect(store.destroySession).toHaveBeenCalledOnce();
+  });
+
   it('coordinates access-token refreshes across concurrent requests', async () => {
     const store = createTestSessionStorage({ idToken: 'id-token', refreshToken: 'old' });
     const tokenRequest = stubTokenRefresh();

--- a/packages/react-router/src/middleware/create-middleware.test-utils.ts
+++ b/packages/react-router/src/middleware/create-middleware.test-utils.ts
@@ -23,6 +23,7 @@ const sessionCookie = 'logto-session=session-id';
 
 type TestSessionStore = Readonly<{
   commitSession: (session: Session) => Promise<string>;
+  destroySession: (session: Session) => Promise<string>;
   sessionStorage: SessionStorage;
   getData: () => SessionData;
 }>;
@@ -56,15 +57,21 @@ export const createTestSessionStorage = (initialData: SessionData = {}): TestSes
 
     return `${sessionCookie}; Path=/; HttpOnly; SameSite=Lax`;
   });
+  const destroySession = vi.fn(async () => {
+    sessions.delete('session-id');
+
+    return `${sessionCookie}; Max-Age=0`;
+  });
   const sessionStorage: SessionStorage = {
     getSession: async () =>
       createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id'),
     commitSession,
-    destroySession: async () => `${sessionCookie}; Max-Age=0`,
+    destroySession,
   };
 
   return {
     commitSession,
+    destroySession,
     sessionStorage,
     getData: () => structuredClone(sessions.get('session-id') ?? {}),
   };

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -12,6 +12,7 @@ const isSignInRedirected = vi.fn(async () => false);
 const handleSignInCallback = vi.fn().mockResolvedValue(undefined);
 const getAccessToken = vi.fn();
 const signIn = vi.fn();
+const signOut = vi.fn();
 
 vi.mock('@logto/browser', () => {
   return {
@@ -28,7 +29,7 @@ vi.mock('@logto/browser', () => {
         getIdToken: vi.fn(),
         getIdTokenClaims: vi.fn(),
         signIn,
-        signOut: vi.fn(),
+        signOut,
         fetchUserInfo: vi.fn(),
         clearAccessToken: vi.fn(),
         clearAllTokens: vi.fn(),
@@ -111,6 +112,28 @@ describe('useLogto', () => {
       expect(getIdTokenClaims).toBeDefined();
       expect(clearAccessToken).toBeDefined();
       expect(clearAllTokens).toBeDefined();
+    });
+  });
+
+  it('reflects cleared authentication state when remote sign-out fails', async () => {
+    const signOutError = new Error('OIDC discovery failed');
+    isAuthenticated.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    signOut.mockRejectedValueOnce(signOutError);
+    const { result } = renderHook(useLogto, {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.error).toBe(signOutError);
     });
   });
 

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -137,6 +137,27 @@ describe('useLogto', () => {
     });
   });
 
+  it('uses the sign-out operation name in fallback errors', async () => {
+    signOut.mockRejectedValueOnce('OIDC discovery failed');
+    const { result } = renderHook(useLogto, {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe(
+        'Unexpected error occurred while calling signOut.'
+      );
+    });
+  });
+
   it('should not call `handleSignInCallback` when logtoClient is not found in the context', async () => {
     // Mock `isSignInRedirected` to return true for triggering `useEffect`
     isSignInRedirected.mockResolvedValueOnce(true);

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -129,8 +129,22 @@ const useLogto = (): Logto => {
     [setIsLoading, handleError]
   );
 
-  const methods = useMemo(
-    () => ({
+  const methods = useMemo(() => {
+    const signOut = async (postLogoutRedirectUri?: string) => {
+      try {
+        await client.signOut(postLogoutRedirectUri);
+      } catch (error: unknown) {
+        const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
+
+        if (currentAuthenticationState !== undefined) {
+          setIsAuthenticated(currentAuthenticationState);
+        }
+
+        throw error;
+      }
+    };
+
+    return {
       getRefreshToken: proxy(client.getRefreshToken.bind(client)),
       getAccessToken: proxy(client.getAccessToken.bind(client)),
       getAccessTokenClaims: proxy(client.getAccessTokenClaims.bind(client)),
@@ -140,25 +154,12 @@ const useLogto = (): Logto => {
       getIdTokenClaims: proxy(client.getIdTokenClaims.bind(client)),
       // eslint-disable-next-line no-restricted-syntax -- TypeScript cannot infer the correct type.
       signIn: proxy(client.signIn.bind(client), false) as LogtoClient['signIn'],
-      signOut: proxy(async (postLogoutRedirectUri?: string) => {
-        try {
-          await client.signOut(postLogoutRedirectUri);
-        } catch (error: unknown) {
-          const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
-
-          if (currentAuthenticationState !== undefined) {
-            setIsAuthenticated(currentAuthenticationState);
-          }
-
-          throw error;
-        }
-      }),
+      signOut: proxy(signOut),
       fetchUserInfo: proxy(client.fetchUserInfo.bind(client)),
       clearAccessToken: proxy(client.clearAccessToken.bind(client)),
       clearAllTokens: proxy(client.clearAllTokens.bind(client)),
-    }),
-    [client, proxy, setIsAuthenticated]
-  );
+    };
+  }, [client, proxy, setIsAuthenticated]);
 
   return {
     isAuthenticated,

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -105,7 +105,8 @@ const useHandleSignInCallback = (callback?: () => void) => {
 };
 
 const useLogto = (): Logto => {
-  const { logtoClient, isAuthenticated, error, isLoading, setIsLoading } = useContext(LogtoContext);
+  const { logtoClient, isAuthenticated, error, isLoading, setIsAuthenticated, setIsLoading } =
+    useContext(LogtoContext);
   const { handleError } = useErrorHandler();
 
   const client = logtoClient ?? throwContextError();
@@ -139,16 +140,24 @@ const useLogto = (): Logto => {
       getIdTokenClaims: proxy(client.getIdTokenClaims.bind(client)),
       // eslint-disable-next-line no-restricted-syntax -- TypeScript cannot infer the correct type.
       signIn: proxy(client.signIn.bind(client), false) as LogtoClient['signIn'],
-      // We deliberately do NOT set isAuthenticated to false in the function below, because the app state
-      // may change immediately even before navigating to the oidc end session endpoint, which might cause
-      // rendering problems.
-      // Moreover, since the location will be redirected, the isAuthenticated state will not matter any more.
-      signOut: proxy(client.signOut.bind(client)),
+      signOut: proxy(async (postLogoutRedirectUri?: string) => {
+        try {
+          await client.signOut(postLogoutRedirectUri);
+        } catch (error: unknown) {
+          const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
+
+          if (currentAuthenticationState !== undefined) {
+            setIsAuthenticated(currentAuthenticationState);
+          }
+
+          throw error;
+        }
+      }),
       fetchUserInfo: proxy(client.fetchUserInfo.bind(client)),
       clearAccessToken: proxy(client.clearAccessToken.bind(client)),
       clearAllTokens: proxy(client.clearAllTokens.bind(client)),
     }),
-    [client, proxy]
+    [client, proxy, setIsAuthenticated]
   );
 
   return {

--- a/packages/remix/src/framework/mocks.ts
+++ b/packages/remix/src/framework/mocks.ts
@@ -53,7 +53,7 @@ export const createLogtoAdapter: CreateLogtoAdapter = vi.fn((session: Session) =
 
 // eslint-disable-next-line no-restricted-syntax
 export const commitSession = vi.fn(async (session: Session) => session.data as unknown as string);
-export const destroySession = vi.fn();
+export const destroySession = vi.fn(async () => 'logto-session=; Max-Age=0');
 export const getSession = vi.fn();
 
 export const sessionStorage: SessionStorage = {

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutController.spec.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutController.spec.ts
@@ -17,4 +17,30 @@ describe('useCases:handleSignOut:HandleSignOutController', () => {
 
     expect(controller.constructor.name).toBe('HandleSignOutController');
   });
+
+  it('throws an error response with the destroyed session cookie when sign-out fails', async () => {
+    const useCase = vi.fn(async () => ({
+      status: 'rejected' as const,
+      cookieHeader: 'logto-session=; Max-Age=0',
+    }));
+    const controller = HandleSignOutController.fromDto({
+      useCase,
+      redirectUri: '/',
+    });
+    const request = new Request('https://app.example.com/sign-out', {
+      headers: { Cookie: 'logto-session=session-id' },
+    });
+
+    try {
+      await controller.execute(request);
+      expect.fail('Expected sign-out to throw an error response.');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(Response);
+
+      if (error instanceof Response) {
+        expect(error.status).toBe(500);
+        expect(error.headers.get('Set-Cookie')).toBe('logto-session=; Max-Age=0');
+      }
+    }
+  });
 });

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutController.spec.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutController.spec.ts
@@ -19,9 +19,12 @@ describe('useCases:handleSignOut:HandleSignOutController', () => {
   });
 
   it('throws an error response with the destroyed session cookie when sign-out fails', async () => {
+    const signOutError = new Error('OIDC discovery failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => true);
     const useCase = vi.fn(async () => ({
       status: 'rejected' as const,
       cookieHeader: 'logto-session=; Max-Age=0',
+      error: signOutError,
     }));
     const controller = HandleSignOutController.fromDto({
       useCase,
@@ -41,6 +44,9 @@ describe('useCases:handleSignOut:HandleSignOutController', () => {
         expect(error.status).toBe(500);
         expect(error.headers.get('Set-Cookie')).toBe('logto-session=; Max-Age=0');
       }
+
+      expect(consoleError).toHaveBeenCalledWith('Logto sign-out failed.', signOutError);
+      consoleError.mockRestore();
     }
   });
 });

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
@@ -41,6 +41,7 @@ export class HandleSignOutController {
     });
 
     if (result.status === 'rejected') {
+      console.error('Logto sign-out failed.', result.error);
       // eslint-disable-next-line @typescript-eslint/no-throw-literal -- Remix response exceptions preserve the clearing cookie.
       throw new Response(null, {
         status: 500,

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutController.ts
@@ -40,6 +40,17 @@ export class HandleSignOutController {
       redirectUri: this.redirectUri,
     });
 
+    if (result.status === 'rejected') {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal -- Remix response exceptions preserve the clearing cookie.
+      throw new Response(null, {
+        status: 500,
+        statusText: 'Sign-out failed',
+        headers: {
+          'Set-Cookie': result.cookieHeader,
+        },
+      });
+    }
+
     return redirect(result.navigateToUrl, {
       headers: {
         'Set-Cookie': result.cookieHeader,

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.spec.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.spec.ts
@@ -38,7 +38,8 @@ describe('useCases:handleSignOut:makeHandleSignOutUseCase', () => {
       createLogtoAdapter,
       sessionStorage,
     });
-    handleSignOut.mockRejectedValueOnce(new Error('OIDC discovery failed'));
+    const signOutError = new Error('OIDC discovery failed');
+    handleSignOut.mockRejectedValueOnce(signOutError);
 
     await expect(
       execute({
@@ -48,6 +49,7 @@ describe('useCases:handleSignOut:makeHandleSignOutUseCase', () => {
     ).resolves.toEqual({
       status: 'rejected',
       cookieHeader: 'logto-session=; Max-Age=0',
+      error: signOutError,
     });
 
     expect(handleSignOut).toBeCalledTimes(1);

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.spec.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.spec.ts
@@ -1,10 +1,15 @@
-import { createLogtoAdapter, sessionStorage, handleSignOut } from '../../framework/mocks.js';
+import {
+  createLogtoAdapter,
+  destroySession,
+  sessionStorage,
+  handleSignOut,
+} from '../../framework/mocks.js';
 
 import { makeHandleSignOutUseCase } from './HandleSignOutUseCase.js';
 
 describe('useCases:handleSignOut:makeHandleSignOutUseCase', () => {
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
   });
 
   it('can make a use case executer', async () => {
@@ -13,11 +18,39 @@ describe('useCases:handleSignOut:makeHandleSignOutUseCase', () => {
       sessionStorage,
     });
 
-    await execute({
-      cookieHeader: 'abcd',
-      redirectUri: '/',
+    await expect(
+      execute({
+        cookieHeader: 'abcd',
+        redirectUri: '/',
+      })
+    ).resolves.toEqual({
+      status: 'fulfilled',
+      cookieHeader: 'logto-session=; Max-Age=0',
+      navigateToUrl: '/success-handle-sign-out',
     });
 
     expect(handleSignOut).toBeCalledTimes(1);
+    expect(destroySession).toBeCalledTimes(1);
+  });
+
+  it('destroys the session when Logto sign-out fails', async () => {
+    const execute = makeHandleSignOutUseCase({
+      createLogtoAdapter,
+      sessionStorage,
+    });
+    handleSignOut.mockRejectedValueOnce(new Error('OIDC discovery failed'));
+
+    await expect(
+      execute({
+        cookieHeader: 'abcd',
+        redirectUri: '/',
+      })
+    ).resolves.toEqual({
+      status: 'rejected',
+      cookieHeader: 'logto-session=; Max-Age=0',
+    });
+
+    expect(handleSignOut).toBeCalledTimes(1);
+    expect(destroySession).toBeCalledTimes(1);
   });
 });

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.ts
@@ -16,6 +16,7 @@ type SignOutResponse =
   | Readonly<{
       status: 'rejected';
       cookieHeader: string;
+      error: unknown;
     }>;
 
 export const makeHandleSignOutUseCase =
@@ -33,13 +34,13 @@ export const makeHandleSignOutUseCase =
       })
       .then(
         (response) => ({ status: 'fulfilled', response }) as const,
-        () => ({ status: 'rejected' }) as const
+        (error: unknown) => ({ status: 'rejected', error }) as const
       );
 
     const cookieHeader = await sessionStorage.destroySession(session);
 
     if (outcome.status === 'rejected') {
-      return { status: outcome.status, cookieHeader };
+      return { status: outcome.status, cookieHeader, error: outcome.error };
     }
 
     return {

--- a/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.ts
+++ b/packages/remix/src/useCases/handleSignOut/HandleSignOutUseCase.ts
@@ -7,10 +7,16 @@ type SignOutRequest = {
   redirectUri: string;
 };
 
-type SignOutResponse = {
-  cookieHeader: string;
-  readonly navigateToUrl: string;
-};
+type SignOutResponse =
+  | Readonly<{
+      status: 'fulfilled';
+      cookieHeader: string;
+      navigateToUrl: string;
+    }>
+  | Readonly<{
+      status: 'rejected';
+      cookieHeader: string;
+    }>;
 
 export const makeHandleSignOutUseCase =
   (deps: { createLogtoAdapter: CreateLogtoAdapter; sessionStorage: SessionStorage }) =>
@@ -21,15 +27,25 @@ export const makeHandleSignOutUseCase =
 
     const logto = createLogtoAdapter(session);
 
-    const response = await logto.handleSignOut({
-      redirectUri: request.redirectUri,
-    });
+    const outcome = await logto
+      .handleSignOut({
+        redirectUri: request.redirectUri,
+      })
+      .then(
+        (response) => ({ status: 'fulfilled', response }) as const,
+        () => ({ status: 'rejected' }) as const
+      );
 
     const cookieHeader = await sessionStorage.destroySession(session);
 
+    if (outcome.status === 'rejected') {
+      return { status: outcome.status, cookieHeader };
+    }
+
     return {
+      status: outcome.status,
       cookieHeader,
-      navigateToUrl: response.navigateToUrl,
+      navigateToUrl: outcome.response.navigateToUrl,
     };
   };
 

--- a/packages/vue/src/index.test.ts
+++ b/packages/vue/src/index.test.ts
@@ -14,6 +14,7 @@ const getAccessToken = vi.fn(() => {
   throw new Error('not authenticated');
 });
 const signIn = vi.fn();
+const signOut = vi.fn();
 const injectMock = vi.fn((key: string): unknown => {
   return undefined;
 });
@@ -42,7 +43,7 @@ vi.mock('@logto/browser', () => {
         getIdToken: vi.fn(),
         getIdTokenClaims: vi.fn(),
         signIn,
-        signOut: vi.fn(),
+        signOut,
         fetchUserInfo: mockedFetchUserInfo,
         clearAccessToken: vi.fn(),
         clearAllTokens: vi.fn(),
@@ -87,7 +88,7 @@ describe('useLogto', () => {
     const context = createContext(client);
     const { isAuthenticated, isLoading, error } = context;
 
-    injectMock.mockImplementationOnce(() => {
+    injectMock.mockImplementation(() => {
       return {
         isAuthenticated: readonly(isAuthenticated),
         isLoading: readonly(isLoading),
@@ -140,6 +141,24 @@ describe('useLogto', () => {
     await getAccessToken();
     expect(error.value).not.toBeUndefined();
     expect(error.value?.message).toBe('not authenticated');
+  });
+
+  it('reflects cleared authentication state when remote sign-out fails', async () => {
+    const signOutError = new Error('OIDC discovery failed');
+    isAuthenticated.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    signOut.mockRejectedValueOnce(signOutError);
+    const client = new LogtoClient({ appId, endpoint });
+    const context = createContext(client);
+
+    await vi.waitFor(() => {
+      expect(context.isAuthenticated.value).toBe(true);
+    });
+
+    const { signOut: wrappedSignOut } = createPluginMethods(context);
+    await wrappedSignOut();
+
+    expect(context.isAuthenticated.value).toBe(false);
+    expect(context.error.value).toBe(signOutError);
   });
 });
 

--- a/packages/vue/src/index.test.ts
+++ b/packages/vue/src/index.test.ts
@@ -160,6 +160,21 @@ describe('useLogto', () => {
     expect(context.isAuthenticated.value).toBe(false);
     expect(context.error.value).toBe(signOutError);
   });
+
+  it('uses the sign-out operation name in fallback errors', async () => {
+    signOut.mockRejectedValueOnce('OIDC discovery failed');
+    const client = new LogtoClient({ appId, endpoint });
+    const context = createContext(client);
+
+    await vi.waitFor(() => {
+      expect(context.isLoading.value).toBe(false);
+    });
+
+    const { signOut: wrappedSignOut } = createPluginMethods(context);
+    await wrappedSignOut();
+
+    expect(context.error.value?.message).toBe('Unexpected error occurred while calling signOut.');
+  });
 });
 
 describe('useHandleSignInCallback', () => {

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -27,6 +27,20 @@ export const createPluginMethods = (context: Context) => {
     };
   };
 
+  const signOut = async (postLogoutRedirectUri?: string) => {
+    try {
+      await client.signOut(postLogoutRedirectUri);
+    } catch (error: unknown) {
+      const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
+
+      if (currentAuthenticationState !== undefined) {
+        setIsAuthenticated(currentAuthenticationState);
+      }
+
+      throw error;
+    }
+  };
+
   const methods = {
     getRefreshToken: proxy(client.getRefreshToken.bind(client)),
     getAccessToken: proxy(client.getAccessToken.bind(client)),
@@ -37,19 +51,7 @@ export const createPluginMethods = (context: Context) => {
     getIdTokenClaims: proxy(client.getIdTokenClaims.bind(client)),
     // eslint-disable-next-line no-restricted-syntax
     signIn: proxy(client.signIn.bind(client), false) as LogtoClient['signIn'],
-    signOut: proxy(async (postLogoutRedirectUri?: string) => {
-      try {
-        await client.signOut(postLogoutRedirectUri);
-      } catch (error: unknown) {
-        const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
-
-        if (currentAuthenticationState !== undefined) {
-          setIsAuthenticated(currentAuthenticationState);
-        }
-
-        throw error;
-      }
-    }),
+    signOut: proxy(signOut),
     fetchUserInfo: proxy(client.fetchUserInfo.bind(client)),
     clearAccessToken: proxy(client.clearAccessToken.bind(client)),
     clearAllTokens: proxy(client.clearAllTokens.bind(client)),

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,5 +1,5 @@
 import type LogtoClient from '@logto/browser';
-import { type Optional } from '@silverhand/essentials';
+import { type Optional, trySafe } from '@silverhand/essentials';
 
 import type { Context } from './context.js';
 import { throwContextError } from './context.js';
@@ -37,11 +37,19 @@ export const createPluginMethods = (context: Context) => {
     getIdTokenClaims: proxy(client.getIdTokenClaims.bind(client)),
     // eslint-disable-next-line no-restricted-syntax
     signIn: proxy(client.signIn.bind(client), false) as LogtoClient['signIn'],
-    // We deliberately do NOT set isAuthenticated to false in the function below, because the app state
-    // may change immediately even before navigating to the oidc end session endpoint, which might cause
-    // rendering problems.
-    // Moreover, since the location will be redirected, the isAuthenticated state will not matter any more.
-    signOut: proxy(client.signOut.bind(client)),
+    signOut: proxy(async (postLogoutRedirectUri?: string) => {
+      try {
+        await client.signOut(postLogoutRedirectUri);
+      } catch (error: unknown) {
+        const currentAuthenticationState = await trySafe(async () => client.isAuthenticated());
+
+        if (currentAuthenticationState !== undefined) {
+          setIsAuthenticated(currentAuthenticationState);
+        }
+
+        throw error;
+      }
+    }),
     fetchUserInfo: proxy(client.fetchUserInfo.bind(client)),
     clearAccessToken: proxy(client.clearAccessToken.bind(client)),
     clearAllTokens: proxy(client.clearAllTokens.bind(client)),


### PR DESCRIPTION
Clear local authentication data before starting remote sign-out so discovery or navigation failures cannot leave a locally authenticated session.

- clear tokens and pending sign-in state before OIDC requests
- persist session destruction in React Router, Remix, and Next.js failure responses
- synchronize Angular, React, and Vue authentication state when sign-out fails
