### PR TITLE
feat(client): stabilize cache configuration

### DIFF
--- a/.changeset/stable-cache-adapters.md
+++ b/.changeset/stable-cache-adapters.md
@@ -1,0 +1,20 @@
+---
+"@logto/angular": minor
+"@logto/browser": minor
+"@logto/capacitor": minor
+"@logto/chrome-extension": minor
+"@logto/client": minor
+"@logto/node": minor
+"@logto/react": minor
+"@logto/vue": minor
+---
+
+stabilize cache configuration across JavaScript SDKs
+
+Use the stable `cache` client adapter property. The deprecated `unstable_cache` alias remains
+supported, with the stable property taking precedence. Node and edge clients continue to use an
+endpoint-scoped process-local cache by default.
+
+Browser, React, Angular, Vue, Capacitor, and Chrome Extension clients can opt in through the stable
+`enableCache` option. Browser caches are isolated by endpoint and application, and cache storage
+failures no longer discard successful discovery responses.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -21,16 +21,22 @@ import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideLogto({
-      endpoint: 'https://your-tenant.logto.app',
-      appId: 'your-app-id',
-      scopes: [UserScope.Email, UserScope.Organizations],
-      resources: ['https://api.example.com'],
-    }),
+    provideLogto(
+      {
+        endpoint: 'https://your-tenant.logto.app',
+        appId: 'your-app-id',
+        scopes: [UserScope.Email, UserScope.Organizations],
+        resources: ['https://api.example.com'],
+      },
+      { enableCache: true }
+    ),
     provideRouter(routes),
   ],
 };
 ```
+
+OIDC discovery caching is disabled by default. The deprecated `unstable_enableCache` option remains
+supported, and `enableCache` takes precedence when both are provided.
 
 ## Sign in and sign out
 

--- a/packages/angular/src/provider.test.ts
+++ b/packages/angular/src/provider.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import LogtoClient from '@logto/browser';
 
-import { LOGTO_CLIENT, provideLogto } from './provider.js';
+import { LOGTO_CLIENT, provideLogto, type LogtoAngularOptions } from './provider.js';
 import { LogtoService } from './service.js';
 
 const config = {
@@ -21,12 +21,12 @@ const config = {
 
 const platform = platformCore();
 const platformInjector = platform.injector as EnvironmentInjector;
-const createInjector = (additionalProviders: Provider[] = []) =>
+const createInjector = (additionalProviders: Provider[] = [], options?: LogtoAngularOptions) =>
   createEnvironmentInjector(
     [
       { provide: ɵINJECTOR_SCOPE, useValue: 'root' },
       provideZonelessChangeDetection(),
-      provideLogto(config, { unstable_enableCache: true }),
+      provideLogto(config, options ?? { enableCache: true }),
       ...additionalProviders,
     ],
     platformInjector
@@ -49,10 +49,30 @@ describe('provideLogto', () => {
 
     expect(client).toBeInstanceOf(LogtoClient);
     expect(client.logtoConfig).toMatchObject(config);
-    expect(client.adapter.unstable_cache).toBeDefined();
+    expect(client.adapter.cache).toBeDefined();
     expect(injector.get(LOGTO_CLIENT)).toBe(client);
     expect(injector.get(LogtoService)).toBe(service);
     injector.destroy();
+  });
+
+  it('keeps cache disabled by default', () => {
+    const injector = createInjector([], {});
+
+    expect(injector.get(LOGTO_CLIENT).adapter.cache).toBeUndefined();
+    injector.destroy();
+  });
+
+  it('supports the deprecated cache option with stable precedence', () => {
+    const legacyInjector = createInjector([], { unstable_enableCache: true });
+    expect(legacyInjector.get(LOGTO_CLIENT).adapter.cache).toBeDefined();
+    legacyInjector.destroy();
+
+    const stableInjector = createInjector([], {
+      enableCache: false,
+      unstable_enableCache: true,
+    });
+    expect(stableInjector.get(LOGTO_CLIENT).adapter.cache).toBeUndefined();
+    stableInjector.destroy();
   });
 
   it('uses an Angular DI override for the underlying client', async () => {

--- a/packages/angular/src/provider.ts
+++ b/packages/angular/src/provider.ts
@@ -17,6 +17,12 @@ export type LogtoAngularOptions = {
    *
    * @default false
    */
+  enableCache?: boolean;
+  /**
+   * Whether to cache OIDC discovery metadata in session storage.
+   *
+   * @deprecated Use {@link enableCache} instead.
+   */
   unstable_enableCache?: boolean;
 };
 
@@ -43,9 +49,9 @@ export const provideLogto = (
       provide: LOGTO_CLIENT,
       useFactory: () => {
         const logtoConfig = inject(LOGTO_CONFIG);
-        const { unstable_enableCache = false } = inject(LOGTO_OPTIONS);
+        const { enableCache, unstable_enableCache } = inject(LOGTO_OPTIONS);
 
-        return new LogtoClient(logtoConfig, unstable_enableCache);
+        return new LogtoClient(logtoConfig, enableCache ?? unstable_enableCache ?? false);
       },
     },
     {

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -39,6 +39,15 @@ Usually you are not expected to use it directly in your application, but instead
 
 If Logto does not support your front-end framework and you want to create your own SDK from scratch, we recommend checking out the [SDK convention](https://docs.logto.io/docs/references/sdk-convention/) first. You can also refer to our [React SDK](https://github.com/logto-io/js/tree/master/packages/react) and [Vue SDK](https://github.com/logto-io/js/tree/master/packages/vue) to learn more about the implementation details.
 
+### Discovery cache
+
+OIDC discovery caching is disabled by default. Pass `true` as the second constructor argument to use
+session storage scoped by the normalized Logto endpoint and application ID.
+
+```ts
+const client = new LogtoClient(config, true);
+```
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/packages/browser/src/cache.test.ts
+++ b/packages/browser/src/cache.test.ts
@@ -4,21 +4,26 @@ import { CacheStorage } from './cache.js';
 
 describe('CacheStorage', () => {
   it('should be able to generate correct cache keys', () => {
-    const cache = new CacheStorage('test');
+    const cache = new CacheStorage('https://example.logto.app/', 'test');
 
-    expect(cache.getKey()).toBe('logto_cache:test');
-    expect(cache.getKey('test')).toBe('logto_cache:test:test');
+    expect(cache.getKey()).toBe('logto_cache:https%3A%2F%2Fexample.logto.app:test');
+    expect(cache.getKey('test')).toBe('logto_cache:https%3A%2F%2Fexample.logto.app:test:test');
+    expect(new CacheStorage('https://example.logto.app', 'test').getKey()).toBe(cache.getKey());
+    expect(new CacheStorage('https://another.logto.app', 'test').getKey()).not.toBe(cache.getKey());
+    expect(new CacheStorage('https://example.logto.app', 'another').getKey()).not.toBe(
+      cache.getKey()
+    );
   });
 
   it('should be able to set and get cache', async () => {
-    const cache = new CacheStorage('test');
+    const cache = new CacheStorage('https://example.logto.app', 'test');
 
     await cache.setItem(CacheKey.Jwks, '{}');
     expect(await cache.getItem(CacheKey.Jwks)).toBe('{}');
   });
 
   it('should be able to remove cache', async () => {
-    const cache = new CacheStorage('test');
+    const cache = new CacheStorage('https://example.logto.app', 'test');
     await cache.setItem(CacheKey.Jwks, '{}');
     await cache.removeItem(CacheKey.Jwks);
     expect(await cache.getItem(CacheKey.Jwks)).toBeNull();

--- a/packages/browser/src/cache.ts
+++ b/packages/browser/src/cache.ts
@@ -2,16 +2,24 @@ import type { Storage, CacheKey } from '@logto/client';
 import type { Nullable } from '@silverhand/essentials';
 
 const keyPrefix = `logto_cache`;
+const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, '');
 
 export class CacheStorage implements Storage<CacheKey> {
-  constructor(public readonly appId: string) {}
+  constructor(
+    public readonly endpoint: string,
+    public readonly appId: string
+  ) {}
 
   getKey(item?: string) {
+    const namespace = `${keyPrefix}:${encodeURIComponent(normalizeEndpoint(this.endpoint))}:${
+      this.appId
+    }`;
+
     if (item === undefined) {
-      return `${keyPrefix}:${this.appId}`;
+      return namespace;
     }
 
-    return `${keyPrefix}:${this.appId}:${item}`;
+    return `${namespace}:${item}`;
   }
 
   async getItem(key: CacheKey): Promise<Nullable<string>> {

--- a/packages/browser/src/index.test.ts
+++ b/packages/browser/src/index.test.ts
@@ -7,4 +7,9 @@ describe('Browser', () => {
   it('creates an instance without crash', () => {
     expect(() => new LogtoClient({ endpoint, appId })).not.toThrow();
   });
+
+  it('keeps cache disabled by default and enables it through the positional option', () => {
+    expect(new LogtoClient({ endpoint, appId }).adapter.cache).toBeUndefined();
+    expect(new LogtoClient({ endpoint, appId }, true).adapter.cache).toBeDefined();
+  });
 });

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -50,14 +50,14 @@ const navigate = (url: string) => {
 export default class LogtoClient extends BaseClient {
   /**
    * @param config The configuration object for the client.
-   * @param [unstable_enableCache=false] Whether to enable cache for well-known data.
+   * @param [enableCache=false] Whether to enable cache for well-known data.
    * Use sessionStorage by default.
    */
-  constructor(config: LogtoConfig, unstable_enableCache = false) {
+  constructor(config: LogtoConfig, enableCache = false) {
     super(config, {
       navigate,
       storage: new BrowserStorage(config.appId),
-      unstable_cache: conditional(unstable_enableCache && new CacheStorage(config.appId)),
+      cache: conditional(enableCache && new CacheStorage(config.endpoint, config.appId)),
       generateCodeChallenge,
       generateCodeVerifier,
       generateState,

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -29,6 +29,12 @@ pnpm add @logto/capacitor @capacitor/app @capacitor/browser @capacitor/preferenc
 
 See [Integrate Logto in your application](https://docs.logto.io/docs/recipes/integrate-logto/) for more information.
 
+OIDC discovery caching is disabled by default. Enable it through the Capacitor options:
+
+```ts
+const client = new LogtoClient(config, { enableCache: true });
+```
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/packages/capacitor/src/index.test.ts
+++ b/packages/capacitor/src/index.test.ts
@@ -69,11 +69,16 @@ class CapacitorLogtoClientTest extends CapacitorLogtoClient {
   }
 }
 
-const createClient = () =>
-  new CapacitorLogtoClientTest({
-    endpoint: 'https://your.logto.endpoint',
-    appId: 'your-app-id',
-  });
+const createClient = (
+  capacitorConfig?: ConstructorParameters<typeof CapacitorLogtoClientTest>[1]
+) =>
+  new CapacitorLogtoClientTest(
+    {
+      endpoint: 'https://your.logto.endpoint',
+      appId: 'your-app-id',
+    },
+    capacitorConfig
+  );
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,6 +87,11 @@ beforeEach(() => {
 });
 
 describe('CapacitorLogtoClient', () => {
+  it('keeps cache disabled by default and supports opting in', () => {
+    expect(createClient().getAdapter().cache).toBeUndefined();
+    expect(createClient({ enableCache: true }).getAdapter().cache).toBeDefined();
+  });
+
   it('should override navigate', async () => {
     const client = createClient();
     expect(client.getAdapter().navigate).toBeDefined();

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -35,6 +35,12 @@ export type {
 
 export type CapacitorConfig = {
   /**
+   * Whether to cache OIDC discovery metadata in session storage.
+   *
+   * @default false
+   */
+  enableCache?: boolean;
+  /**
    * The options to pass to the `open` method of the Capacitor Browser plugin.
    * @default { windowName: '_self', presentationStyle: 'popover' }
    */
@@ -51,8 +57,8 @@ const swallowError = (): void => {
 
 export default class CapacitorLogtoClient extends LogtoBaseClient {
   constructor(config: LogtoConfig, capacitorConfig: CapacitorConfig = {}) {
-    const { openOptions } = capacitorConfig;
-    super(config);
+    const { enableCache = false, openOptions } = capacitorConfig;
+    super(config, enableCache);
 
     // Use the Capacitor Browser plugin to open the sign-in and sign-out pages
     // since the default location assignment method will open the pages in a

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -10,6 +10,13 @@ Check out our [docs](https://docs.logto.io/sdk/chrome-extension/) for more infor
 > [!Note]
 > This package is ESM-only.
 
+OIDC discovery caching is disabled by default. Enable it through the constructor options to use
+endpoint- and application-scoped `chrome.storage.session` storage:
+
+```ts
+const client = new LogtoClient(config, { enableCache: true });
+```
+
 ## Installation
 
 ### Using npm

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -17,8 +17,10 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "build": "rm -rf lib && tsc",
+    "check": "tsc --noEmit",
+    "build": "rm -rf lib && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts --ext .tsx src",
+    "test": "vitest",
     "prepack": "pnpm build"
   },
   "keywords": [],
@@ -38,7 +40,8 @@
     "eslint": "^8.57.0",
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
   },
   "eslintConfig": {
     "extends": "@silverhand/react"

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -21,7 +21,8 @@
     "build": "rm -rf lib && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts --ext .tsx src",
     "test": "vitest",
-    "prepack": "pnpm build"
+    "test:coverage": "vitest --silent --coverage",
+    "prepack": "pnpm build && pnpm test"
   },
   "keywords": [],
   "license": "MIT",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@silverhand/eslint-config": "^6.0.1",
     "@silverhand/ts-config": "^6.0.0",
+    "@vitest/coverage-v8": "3.2.6",
     "chrome-types": "^0.1.276",
     "eslint": "^8.57.0",
     "lint-staged": "^15.0.0",

--- a/packages/chrome-extension/src/index.test.ts
+++ b/packages/chrome-extension/src/index.test.ts
@@ -1,0 +1,30 @@
+import LogtoClient from './index.js';
+import { ChromeExtensionCacheStorage } from './storage.js';
+
+const config = {
+  endpoint: 'https://example.logto.app',
+  appId: 'app-id',
+};
+
+beforeEach(() => {
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('LogtoClient', () => {
+  it('keeps cache disabled by default and supports opting in', () => {
+    expect(new LogtoClient(config).adapter.cache).toBeUndefined();
+    expect(new LogtoClient(config, { enableCache: true }).adapter.cache).toBeInstanceOf(
+      ChromeExtensionCacheStorage
+    );
+  });
+});

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -8,16 +8,25 @@ import {
   generateState,
 } from '@logto/browser';
 
-import { ChromeExtensionStorage } from './storage.js';
+import { ChromeExtensionCacheStorage, ChromeExtensionStorage } from './storage.js';
 
 export * from '@logto/browser';
-export { ChromeExtensionStorage } from './storage.js';
+export { ChromeExtensionCacheStorage, ChromeExtensionStorage } from './storage.js';
+
+export type ChromeExtensionOptions = {
+  /**
+   * Whether to cache OIDC discovery metadata in Chrome's session storage.
+   *
+   * @default false
+   */
+  enableCache?: boolean;
+};
 
 export default class LogtoClient extends BaseClient {
   /**
    * @param config The configuration object for the client.
    */
-  constructor(config: LogtoConfig) {
+  constructor(config: LogtoConfig, { enableCache = false }: ChromeExtensionOptions = {}) {
     // eslint-disable-next-line unicorn/consistent-function-scoping -- we use `this` in the function
     const navigate: ClientAdapter['navigate'] = async (url, params) => {
       switch (params.for) {
@@ -50,6 +59,9 @@ export default class LogtoClient extends BaseClient {
     super(config, {
       navigate,
       storage: new ChromeExtensionStorage(config.appId),
+      cache: enableCache
+        ? new ChromeExtensionCacheStorage(config.endpoint, config.appId)
+        : undefined,
       generateCodeChallenge,
       generateCodeVerifier,
       generateState,

--- a/packages/chrome-extension/src/storage.test.ts
+++ b/packages/chrome-extension/src/storage.test.ts
@@ -1,0 +1,63 @@
+import { CacheKey } from '@logto/browser';
+
+import { ChromeExtensionCacheStorage } from './storage.js';
+
+const sessionStorage = {
+  get: vi.fn(),
+  set: vi.fn(),
+  remove: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('chrome', {
+    storage: {
+      session: sessionStorage,
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ChromeExtensionCacheStorage', () => {
+  it('isolates cache keys by normalized endpoint and application', () => {
+    const cache = new ChromeExtensionCacheStorage('https://example.logto.app/', 'app-id');
+
+    expect(cache.getKey(CacheKey.OpenidConfig)).toBe(
+      'logto_cache:https%3A%2F%2Fexample.logto.app:app-id:openidConfiguration'
+    );
+    expect(
+      new ChromeExtensionCacheStorage('https://example.logto.app', 'app-id').getKey(
+        CacheKey.OpenidConfig
+      )
+    ).toBe(cache.getKey(CacheKey.OpenidConfig));
+    expect(
+      new ChromeExtensionCacheStorage('https://another.logto.app', 'app-id').getKey(
+        CacheKey.OpenidConfig
+      )
+    ).not.toBe(cache.getKey(CacheKey.OpenidConfig));
+    expect(
+      new ChromeExtensionCacheStorage('https://example.logto.app', 'another-app').getKey(
+        CacheKey.OpenidConfig
+      )
+    ).not.toBe(cache.getKey(CacheKey.OpenidConfig));
+  });
+
+  it('reads, writes, and removes values through chrome.storage.session', async () => {
+    const cache = new ChromeExtensionCacheStorage('https://example.logto.app', 'app-id');
+    const key = cache.getKey(CacheKey.OpenidConfig);
+    sessionStorage.get.mockResolvedValue({ [key]: '{"issuer":"https://example.logto.app"}' });
+
+    await expect(cache.getItem(CacheKey.OpenidConfig)).resolves.toBe(
+      '{"issuer":"https://example.logto.app"}'
+    );
+    await cache.setItem(CacheKey.OpenidConfig, '{}');
+    await cache.removeItem(CacheKey.OpenidConfig);
+
+    expect(sessionStorage.get).toHaveBeenCalledWith(key);
+    expect(sessionStorage.set).toHaveBeenCalledWith({ [key]: '{}' });
+    expect(sessionStorage.remove).toHaveBeenCalledWith(key);
+  });
+});

--- a/packages/chrome-extension/src/storage.ts
+++ b/packages/chrome-extension/src/storage.ts
@@ -1,4 +1,4 @@
-import { type PersistKey, type Storage } from '@logto/browser';
+import { type CacheKey, type PersistKey, type Storage } from '@logto/browser';
 
 const keyPrefix = `logto`;
 
@@ -26,5 +26,35 @@ export class ChromeExtensionStorage implements Storage<PersistKey> {
 
   async removeItem(key: PersistKey): Promise<void> {
     await chrome.storage.local.remove(this.getKey(key));
+  }
+}
+
+const cacheKeyPrefix = `logto_cache`;
+const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, '');
+
+export class ChromeExtensionCacheStorage implements Storage<CacheKey> {
+  constructor(
+    public readonly endpoint: string,
+    public readonly appId: string
+  ) {}
+
+  getKey(key: CacheKey) {
+    return `${cacheKeyPrefix}:${encodeURIComponent(normalizeEndpoint(this.endpoint))}:${
+      this.appId
+    }:${key}`;
+  }
+
+  async getItem(key: CacheKey) {
+    const storageKey = this.getKey(key);
+    const object = await chrome.storage.session.get(storageKey);
+    return object[storageKey] ? String(object[storageKey]) : null;
+  }
+
+  async setItem(key: CacheKey, value: string): Promise<void> {
+    await chrome.storage.session.set({ [this.getKey(key)]: value });
+  }
+
+  async removeItem(key: CacheKey): Promise<void> {
+    await chrome.storage.session.remove(this.getKey(key));
   }
 }

--- a/packages/chrome-extension/tsconfig.build.json
+++ b/packages/chrome-extension/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig",
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/chrome-extension/tsconfig.json
+++ b/packages/chrome-extension/tsconfig.json
@@ -4,9 +4,10 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "outDir": "lib",
-    "types": ["chrome-types"]
+    "types": ["chrome-types", "vitest/globals"]
   },
   "include": [
-    "src"
+    "src",
+    "vitest.config.ts"
   ]
 }

--- a/packages/chrome-extension/vitest.config.ts
+++ b/packages/chrome-extension/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -40,9 +40,14 @@ To implement a platform-specific SDK, you should implement the following adapter
 3. generateState: generate state.
 4. generateCodeVerifier: generate code verifier.
 5. generateCodeChallenge: generate code challenge.
+6. cache: optionally cache well-known data.
 
 The client uses the runtime's native `fetch` by default. Set the optional `fetch` adapter only when
 the platform needs a custom transport.
+
+The optional `cache` adapter stores well-known data. Cache reads and writes are best-effort and do
+not make an otherwise successful request fail. The deprecated `unstable_cache` property remains
+supported; `cache` takes precedence when both are provided.
 
 See the [adapters](./src/adapter/index.ts) for more information.
 

--- a/packages/client/src/adapter/index.test.ts
+++ b/packages/client/src/adapter/index.test.ts
@@ -1,6 +1,6 @@
 import type { Requester } from '@logto/js';
 
-import { createAdapters } from '../mock.js';
+import { createAdapters, MockedStorage } from '../mock.js';
 
 import { CacheKey, type ClientAdapter, ClientAdapterInstance, PersistKey } from './index.js';
 
@@ -77,11 +77,43 @@ describe('ClientAdapterInstance', () => {
 
   it('should be able get cached object', async () => {
     const adapterInstance = new ClientAdapterInstance(createAdapters(true));
-    await adapterInstance.unstable_cache?.setItem(
-      CacheKey.OpenidConfig,
-      JSON.stringify({ test: 'test' })
-    );
+    await adapterInstance.cache?.setItem(CacheKey.OpenidConfig, JSON.stringify({ test: 'test' }));
     expect(await adapterInstance.getCachedObject(CacheKey.OpenidConfig)).toEqual({ test: 'test' });
+  });
+
+  it('treats malformed cached JSON as a miss', async () => {
+    const adapterInstance = new ClientAdapterInstance(createAdapters(true));
+    await adapterInstance.cache?.setItem(CacheKey.OpenidConfig, 'not-json');
+    const getter = vi.fn(async () => ({ test: 'recovered' }));
+
+    await expect(adapterInstance.getWithCache(CacheKey.OpenidConfig, getter)).resolves.toEqual({
+      test: 'recovered',
+    });
+    expect(getter).toHaveBeenCalledOnce();
+  });
+
+  it('supports the deprecated cache alias', () => {
+    const unstableCache = new MockedStorage();
+    const adapterInstance = new ClientAdapterInstance({
+      ...createAdapters(),
+      cache: undefined,
+      unstable_cache: unstableCache,
+    });
+
+    expect(adapterInstance.cache).toBe(unstableCache);
+    expect(adapterInstance.unstable_cache).toBe(unstableCache);
+  });
+
+  it('prefers the stable cache when both cache properties are provided', () => {
+    const cache = new MockedStorage();
+    const adapterInstance = new ClientAdapterInstance({
+      ...createAdapters(),
+      cache,
+      unstable_cache: new MockedStorage(),
+    });
+
+    expect(adapterInstance.cache).toBe(cache);
+    expect(adapterInstance.unstable_cache).toBe(cache);
   });
 
   it('should be able get with cache and directly return the cached value when needed', async () => {
@@ -94,7 +126,7 @@ describe('ClientAdapterInstance', () => {
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getter).toHaveBeenCalledTimes(1);
-    expect(await adapterInstance.unstable_cache?.getItem(CacheKey.OpenidConfig)).toBe(
+    expect(await adapterInstance.cache?.getItem(CacheKey.OpenidConfig)).toBe(
       JSON.stringify({
         test: 'test',
       })
@@ -125,7 +157,7 @@ describe('ClientAdapterInstance', () => {
     await expect(firstCall).rejects.toThrow('transient failure');
     await expect(secondCall).resolves.toEqual({ test: 'recovered' });
     expect(secondGetter).toHaveBeenCalledTimes(1);
-    expect(await adapters.unstable_cache?.getItem(CacheKey.OpenidConfig)).toBe(
+    expect(await adapters.cache?.getItem(CacheKey.OpenidConfig)).toBe(
       JSON.stringify({ test: 'recovered' })
     );
 
@@ -149,6 +181,23 @@ describe('ClientAdapterInstance', () => {
 
       return { test: 'test' };
     });
+
+    await expect(
+      Promise.all([
+        firstAdapterInstance.getWithCache(CacheKey.OpenidConfig, getter),
+        secondAdapterInstance.getWithCache(CacheKey.OpenidConfig, getter),
+      ])
+    ).resolves.toEqual([{ test: 'test' }, { test: 'test' }]);
+    expect(getter).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns one shared result when cache storage rejects a write', async () => {
+    const cache = new MockedStorage();
+    vi.spyOn(cache, 'setItem').mockRejectedValue(new Error('Cache unavailable'));
+    const adapters = { ...createAdapters(), cache };
+    const firstAdapterInstance = new ClientAdapterInstance(adapters);
+    const secondAdapterInstance = new ClientAdapterInstance(adapters);
+    const getter = vi.fn(async () => ({ test: 'test' }));
 
     await expect(
       Promise.all([

--- a/packages/client/src/adapter/index.ts
+++ b/packages/client/src/adapter/index.ts
@@ -35,6 +35,8 @@ export class ClientAdapterInstance {
    */
   requester!: Requester;
   storage!: Storage<StorageKey | PersistKey>;
+  cache?: Storage<CacheKey> | undefined;
+  /** @deprecated Use {@link cache} instead. */
   unstable_cache?: Storage<CacheKey> | undefined;
   navigate!: Navigate;
   generateState!: () => string | Promise<string>;
@@ -43,12 +45,15 @@ export class ClientAdapterInstance {
   /* END OF IMPLEMENTATION */
 
   constructor(adapter: ClientAdapter, requestOptions: CreateRequesterOptions = {}) {
+    const cache = adapter.cache ?? adapter.unstable_cache;
     const requester = adapter.fetch
       ? createRequester(adapter.fetch, requestOptions)
       : adapter.requester ?? createRequester(globalThis.fetch, requestOptions);
 
     // eslint-disable-next-line @silverhand/fp/no-mutating-assign
     Object.assign(this, adapter, {
+      cache,
+      unstable_cache: cache,
       requester,
     });
   }
@@ -70,7 +75,7 @@ export class ClientAdapterInstance {
    */
   async getCachedObject<T>(key: CacheKey): Promise<T | undefined> {
     const cached = await trySafe(async () => {
-      const data = await this.unstable_cache?.getItem(key);
+      const data = await this.cache?.getItem(key);
       // It's actually `unknown`
       // eslint-disable-next-line no-restricted-syntax
       return conditional(data && (JSON.parse(data) as unknown));
@@ -96,7 +101,7 @@ export class ClientAdapterInstance {
       return cached;
     }
 
-    const { unstable_cache: cache } = this;
+    const { cache } = this;
 
     if (!cache) {
       return getter();
@@ -109,35 +114,32 @@ export class ClientAdapterInstance {
       // Another client sharing the same cache storage is already populating this key. Wait for it
       // instead of issuing a duplicate discovery request.
       try {
-        await runningGetter;
+        // Cache keys identify one value shape, so all callers waiting on this key expect the same
+        // result type.
+        // eslint-disable-next-line no-restricted-syntax
+        return (await runningGetter) as T;
       } catch {
-        // The in-flight getter rejected before writing to cache. Fall through to the cache check
-        // and the current caller's getter below.
+        // The in-flight getter rejected before producing a value. Retry through the normal path.
       }
-
-      const cachedResult = await this.getCachedObject<T>(key);
-
-      if (cachedResult) {
-        return cachedResult;
-      }
-
-      // The in-flight getter may fail before writing to cache. Retry through the same population
-      // path so a successful recovery is stored for later callers.
       return this.getWithCache(key, getter);
     }
 
     const newRunningGetter = (async () => {
       const result = await getter();
-      await cache.setItem(key, JSON.stringify(result));
+      // Cache storage is an optimization. A storage failure must not discard a successful result.
+      await trySafe(async () => cache.setItem(key, JSON.stringify(result)));
       return result;
     })();
-    runningGetterMap.set(key, newRunningGetter);
+    const trackedRunningGetter = (async () => {
+      try {
+        return await newRunningGetter;
+      } finally {
+        runningGetterMap.delete(key);
+      }
+    })();
+    runningGetterMap.set(key, trackedRunningGetter);
 
-    try {
-      return await newRunningGetter;
-    } finally {
-      runningGetterMap.delete(key);
-    }
+    return trackedRunningGetter;
   }
 }
 

--- a/packages/client/src/adapter/types.ts
+++ b/packages/client/src/adapter/types.ts
@@ -92,7 +92,14 @@ export type ClientAdapter = ClientAdapterTransport & {
    *
    * @see {@link CacheKey}
    */
-  unstable_cache?: Storage<CacheKey>;
+  cache?: Storage<CacheKey> | undefined;
+  /**
+   * An optional storage for caching well-known data.
+   *
+   * @deprecated Use {@link ClientAdapter.cache | cache} instead.
+   * @see {@link CacheKey}
+   */
+  unstable_cache?: Storage<CacheKey> | undefined;
   navigate: Navigate;
   /**
    * The function that generates a random state string.

--- a/packages/client/src/mock.ts
+++ b/packages/client/src/mock.ts
@@ -142,7 +142,7 @@ export const createAdapters = (withCache = false) =>
   ({
     fetch: fetchFunction,
     storage: new MockedStorage(),
-    unstable_cache: conditional(withCache && new MockedStorage()),
+    cache: conditional(withCache && new MockedStorage()),
     navigate,
     generateCodeChallenge,
     generateCodeVerifier,

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -41,6 +41,13 @@ As the name suggests, Logto Node.js SDK is the foundation of all Logto SDKs that
 
 Usually, you are not expected to use it directly in your application, but instead choosing a framework specific SDK that built on top of it. We have already released a set of official SDKs to accelerate your integration. [Check this out](https://docs.logto.io/integrate-logto) and get started!
 
+### Discovery cache
+
+The Node and edge clients cache OIDC discovery metadata in an endpoint-scoped, process-local memory
+cache by default. Pass a custom `cache` storage adapter when the cache should be shared or managed by
+the application. The deprecated `unstable_cache` property remains supported, and `cache` takes
+precedence when both are provided.
+
 ## How to create your own SDK from scratch?
 
 If Logto does not support your traditional web framework and you want to create your own SDK from scratch, we recommend checking out the SDK specification first. You can also refer to our [Express SDK](https://github.com/logto-io/js/tree/master/packages/express) and [Next.js SDK](https://github.com/logto-io/js/tree/master/packages/next) to learn more about the implementation details.

--- a/packages/node/edge/index.test.ts
+++ b/packages/node/edge/index.test.ts
@@ -68,14 +68,45 @@ describe('LogtoClient (edge)', () => {
     expect(
       new LogtoClient({ endpoint: `${endpoint}/`, appId }, { navigate, storage })
     ).toBeDefined();
-    const cache = getLatestBaseClientAdapter().unstable_cache;
+    const cache = getLatestBaseClientAdapter().cache;
 
     expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
-    expect(getLatestBaseClientAdapter().unstable_cache).toBe(cache);
+    expect(getLatestBaseClientAdapter().cache).toBe(cache);
 
     expect(
       new LogtoClient({ endpoint: 'https://another.logto.dev', appId }, { navigate, storage })
     ).toBeDefined();
-    expect(getLatestBaseClientAdapter().unstable_cache).not.toBe(cache);
+    expect(getLatestBaseClientAdapter().cache).not.toBe(cache);
+  });
+
+  it('supports stable and deprecated custom caches with stable precedence', () => {
+    const cache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+    const unstableCache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+
+    expect(
+      new LogtoClient(
+        { endpoint, appId },
+        { navigate, storage, cache, unstable_cache: unstableCache }
+      )
+    ).toBeDefined();
+    expect(getLatestBaseClientAdapter().cache).toBe(cache);
+
+    expect(
+      new LogtoClient(
+        { endpoint, appId },
+        { navigate, storage, cache: undefined, unstable_cache: unstableCache }
+      )
+    ).toBeDefined();
+    expect(getLatestBaseClientAdapter().cache).toBe(unstableCache);
+  });
+
+  it('uses the default cache when cache properties are explicitly undefined', () => {
+    expect(
+      new LogtoClient(
+        { endpoint, appId },
+        { navigate, storage, cache: undefined, unstable_cache: undefined }
+      )
+    ).toBeDefined();
+    expect(getLatestBaseClientAdapter().cache).toBeDefined();
   });
 });

--- a/packages/node/edge/index.ts
+++ b/packages/node/edge/index.ts
@@ -6,14 +6,14 @@ import {
   createAuthenticatedFetch,
   resolveAdapterTransport,
 } from '../src/utils/adapter-transport.js';
-import { createMemoryCache } from '../src/utils/cache.js';
+import { resolveAdapterCache } from '../src/utils/cache.js';
 
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './generators.js';
 
 export { CacheKey, PersistKey, ReservedResource, decodeAccessToken } from '@logto/client';
 
 type EdgeClientAdapter = Pick<ClientAdapter, 'navigate' | 'storage'> &
-  Partial<Pick<ClientAdapter, 'fetch' | 'requester'>>;
+  Partial<Pick<ClientAdapter, 'cache' | 'unstable_cache' | 'fetch' | 'requester'>>;
 
 // Used for edge runtime, currently only NextJS.
 export default class LogtoClient extends BaseClient {
@@ -31,7 +31,7 @@ export default class LogtoClient extends BaseClient {
       generateCodeChallenge,
       generateCodeVerifier,
       generateState,
-      unstable_cache: createMemoryCache(config.endpoint),
+      cache: resolveAdapterCache(adapter, config.endpoint),
       ...transport,
     });
   }

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -117,18 +117,18 @@ describe('LogtoClient', () => {
       expect(
         new LogtoClient({ endpoint: `${endpoint}/`, appId }, { navigate, storage })
       ).toBeDefined();
-      const cache = getLatestBaseClientAdapter().unstable_cache;
+      const { cache } = getLatestBaseClientAdapter();
 
       expect(new LogtoClient({ endpoint, appId }, { navigate, storage })).toBeDefined();
-      expect(getLatestBaseClientAdapter().unstable_cache).toBe(cache);
+      expect(getLatestBaseClientAdapter().cache).toBe(cache);
 
       expect(
         new LogtoClient({ endpoint: 'https://another.logto.dev', appId }, { navigate, storage })
       ).toBeDefined();
-      expect(getLatestBaseClientAdapter().unstable_cache).not.toBe(cache);
+      expect(getLatestBaseClientAdapter().cache).not.toBe(cache);
     });
 
-    it('should allow overriding the default cache storage', () => {
+    it('should allow overriding the default cache storage through the deprecated property', () => {
       const unstableCache = {
         setItem: vi.fn(),
         getItem: vi.fn(),
@@ -138,7 +138,41 @@ describe('LogtoClient', () => {
       expect(
         new LogtoClient({ endpoint, appId }, { navigate, storage, unstable_cache: unstableCache })
       ).toBeDefined();
-      expect(getLatestBaseClientAdapter().unstable_cache).toBe(unstableCache);
+      expect(getLatestBaseClientAdapter().cache).toBe(unstableCache);
+    });
+
+    it('should allow overriding the default cache storage through the stable property', () => {
+      const cache = {
+        setItem: vi.fn(),
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+      };
+
+      expect(new LogtoClient({ endpoint, appId }, { navigate, storage, cache })).toBeDefined();
+      expect(getLatestBaseClientAdapter().cache).toBe(cache);
+    });
+
+    it('should prefer the stable cache property', () => {
+      const cache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+      const unstableCache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+
+      expect(
+        new LogtoClient(
+          { endpoint, appId },
+          { navigate, storage, cache, unstable_cache: unstableCache }
+        )
+      ).toBeDefined();
+      expect(getLatestBaseClientAdapter().cache).toBe(cache);
+    });
+
+    it('should use the default cache when cache properties are explicitly undefined', () => {
+      expect(
+        new LogtoClient(
+          { endpoint, appId },
+          { navigate, storage, cache: undefined, unstable_cache: undefined }
+        )
+      ).toBeDefined();
+      expect(getLatestBaseClientAdapter().cache).toBeDefined();
     });
   });
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,7 +4,7 @@ import { generateCodeChallenge, generateCodeVerifier, generateState } from '../e
 
 import BaseClient from './client.js';
 import { createAuthenticatedFetch, resolveAdapterTransport } from './utils/adapter-transport.js';
-import { createMemoryCache } from './utils/cache.js';
+import { resolveAdapterCache } from './utils/cache.js';
 
 export * from './exports.js';
 
@@ -28,8 +28,8 @@ export default class LogtoClient extends BaseClient {
         generateCodeChallenge,
         generateCodeVerifier,
         generateState,
-        unstable_cache: createMemoryCache(config.endpoint),
         ...adapter,
+        cache: resolveAdapterCache(adapter, config.endpoint),
         ...transport,
       },
       buildJwtVerifier

--- a/packages/node/src/utils/cache.test.ts
+++ b/packages/node/src/utils/cache.test.ts
@@ -1,6 +1,6 @@
 import { CacheKey } from '@logto/client';
 
-import { createMemoryCache } from './cache.js';
+import { createMemoryCache, resolveAdapterCache } from './cache.js';
 
 describe('createMemoryCache', () => {
   it('should reuse cache storage for the same normalized endpoint', async () => {
@@ -19,5 +19,23 @@ describe('createMemoryCache', () => {
 
     await cache.setItem(CacheKey.OpenidConfig, 'value');
     await expect(anotherEndpointCache.getItem(CacheKey.OpenidConfig)).resolves.toBeNull();
+  });
+
+  it('should resolve stable, deprecated, and default caches in order', () => {
+    const cache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+    const unstableCache = { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() };
+
+    expect(resolveAdapterCache({ cache, unstable_cache: unstableCache }, 'https://logto.dev')).toBe(
+      cache
+    );
+    expect(
+      resolveAdapterCache({ cache: undefined, unstable_cache: unstableCache }, 'https://logto.dev')
+    ).toBe(unstableCache);
+    expect(
+      resolveAdapterCache(
+        { cache: undefined, unstable_cache: undefined },
+        'https://default.logto.dev'
+      )
+    ).toBe(createMemoryCache('https://default.logto.dev'));
   });
 });

--- a/packages/node/src/utils/cache.ts
+++ b/packages/node/src/utils/cache.ts
@@ -1,10 +1,13 @@
-import type { CacheKey, Storage } from '@logto/client';
+import type { CacheKey, ClientAdapter, Storage } from '@logto/client';
 
 const cacheStorageMap = new Map<string, Storage<CacheKey>>();
 const cacheData = new Map<string, string>();
 
 const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, '');
 
+/**
+ * Creates an endpoint-scoped cache that is shared for the lifetime of the current process.
+ */
 export const createMemoryCache = (endpoint: string): Storage<CacheKey> => {
   const normalizedEndpoint = normalizeEndpoint(endpoint);
   const cacheStorage = cacheStorageMap.get(normalizedEndpoint);
@@ -27,3 +30,8 @@ export const createMemoryCache = (endpoint: string): Storage<CacheKey> => {
   cacheStorageMap.set(normalizedEndpoint, newCacheStorage);
   return newCacheStorage;
 };
+
+type CacheAdapter = Pick<ClientAdapter, 'cache' | 'unstable_cache'>;
+
+export const resolveAdapterCache = (adapter: CacheAdapter, endpoint: string): Storage<CacheKey> =>
+  adapter.cache ?? adapter.unstable_cache ?? createMemoryCache(endpoint);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -39,6 +39,20 @@ pnpm i && pnpm build
 cd packages/react-sample && pnpm start
 ```
 
+## Discovery cache
+
+Set `enableCache` on `LogtoProvider` to cache OIDC discovery metadata in session storage. Caching is
+disabled by default.
+
+```tsx
+<LogtoProvider config={config} enableCache>
+  <App />
+</LogtoProvider>
+```
+
+The deprecated `unstable_enableCache` property remains supported. `enableCache` takes precedence
+when both are provided.
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/packages/react/src/hooks/index.test.tsx
+++ b/packages/react/src/hooks/index.test.tsx
@@ -47,6 +47,57 @@ const createHookWrapper =
     <LogtoProvider config={{ endpoint, appId }}>{children}</LogtoProvider>
   );
 
+describe('LogtoProvider cache options', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('supports the stable cache option', async () => {
+    const { result } = renderHook(() => useLogto(), {
+      wrapper: ({ children }) => (
+        <LogtoProvider enableCache config={{ endpoint, appId }}>
+          {children}
+        </LogtoProvider>
+      ),
+    });
+
+    expect(LogtoClient).toHaveBeenLastCalledWith({ endpoint, appId }, true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('supports the deprecated cache option', async () => {
+    const { result } = renderHook(() => useLogto(), {
+      wrapper: ({ children }) => (
+        <LogtoProvider unstable_enableCache config={{ endpoint, appId }}>
+          {children}
+        </LogtoProvider>
+      ),
+    });
+
+    expect(LogtoClient).toHaveBeenLastCalledWith({ endpoint, appId }, true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('prefers the stable cache option', async () => {
+    const { result } = renderHook(() => useLogto(), {
+      wrapper: ({ children }) => (
+        <LogtoProvider unstable_enableCache config={{ endpoint, appId }} enableCache={false}>
+          {children}
+        </LogtoProvider>
+      ),
+    });
+
+    expect(LogtoClient).toHaveBeenLastCalledWith({ endpoint, appId }, false);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});
+
 const HasError = ({ children }: { children?: ReactNode }) => {
   const { error, setError } = useContext(LogtoContext);
   useEffect(() => {

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -10,6 +10,13 @@ export type LogtoProviderProps = {
    * @default false
    */
   // eslint-disable-next-line react/boolean-prop-naming
+  enableCache?: boolean;
+  /**
+   * Whether to enable cache for well-known data. Use sessionStorage by default.
+   *
+   * @deprecated Use {@link enableCache} instead.
+   */
+  // eslint-disable-next-line react/boolean-prop-naming
   unstable_enableCache?: boolean;
   LogtoClientClass?: typeof LogtoClient;
   children?: ReactNode;
@@ -19,12 +26,14 @@ export const LogtoProvider = ({
   config,
   LogtoClientClass = LogtoClient,
   children,
-  unstable_enableCache = false,
+  enableCache,
+  unstable_enableCache,
 }: LogtoProviderProps) => {
+  const resolvedEnableCache = enableCache ?? unstable_enableCache ?? false;
   const [loadingCount, setLoadingCount] = useState(1);
   const memorizedLogtoClient = useMemo(
-    () => ({ logtoClient: new LogtoClientClass(config, unstable_enableCache) }),
-    [LogtoClientClass, config, unstable_enableCache]
+    () => ({ logtoClient: new LogtoClientClass(config, resolvedEnableCache) }),
+    [LogtoClientClass, config, resolvedEnableCache]
   );
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [error, setError] = useState<Error>();

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -39,6 +39,19 @@ pnpm i && pnpm build
 cd packages/vue-sample && pnpm start
 ```
 
+## Discovery cache
+
+Add `enableCache: true` to the plugin configuration to cache OIDC discovery metadata in session
+storage. Caching is disabled by default.
+
+```ts
+app.use(createLogto, {
+  endpoint: 'https://your-tenant.logto.app',
+  appId: 'your-app-id',
+  enableCache: true,
+});
+```
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/packages/vue/src/index.test.ts
+++ b/packages/vue/src/index.test.ts
@@ -63,8 +63,14 @@ describe('createLogto.install', () => {
   it('should call LogtoClient constructor and provide Logto context data', async () => {
     createLogto.install(appMock, { appId, endpoint });
 
-    expect(LogtoClient).toHaveBeenCalledWith({ endpoint, appId });
+    expect(LogtoClient).toHaveBeenCalledWith({ endpoint, appId }, false);
     expect(appMock.provide).toBeCalled();
+  });
+
+  it('should enable cache through plugin configuration', () => {
+    createLogto.install(appMock, { appId, endpoint, enableCache: true });
+
+    expect(LogtoClient).toHaveBeenCalledWith({ endpoint, appId }, true);
   });
 });
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -42,8 +42,17 @@ type OptionalPromiseReturn<T> = {
     : T[K];
 };
 
+export type LogtoVueConfig = LogtoConfig & {
+  /**
+   * Whether to cache OIDC discovery metadata in session storage.
+   *
+   * @default false
+   */
+  enableCache?: boolean;
+};
+
 type LogtoVuePlugin = {
-  install: (app: App, config: LogtoConfig) => void;
+  install: (app: App, config: LogtoVueConfig) => void;
 };
 
 type Logto = {
@@ -87,8 +96,8 @@ type Logto = {
  * Use this in your Vue root component to register the plugin
  */
 export const createLogto: LogtoVuePlugin = {
-  install(app: App, config: LogtoConfig) {
-    const client = new LogtoClient(config);
+  install(app: App, { enableCache = false, ...config }: LogtoVueConfig) {
+    const client = new LogtoClient(config, enableCache);
     const context = createContext(client);
     const pluginMethods = createPluginMethods(context);
     const { isAuthenticated, isLoading, error } = context;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       '@silverhand/ts-config':
         specifier: ^6.0.0
         version: 6.0.0(typescript@5.3.3)
+      '@vitest/coverage-v8':
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.10.0)(happy-dom@20.8.9)(jiti@2.7.0)(less@4.2.2)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.39.0)(yaml@2.9.0))
       chrome-types:
         specifier: ^0.1.276
         version: 0.1.276

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.10.0)(happy-dom@20.8.9)(jiti@2.7.0)(less@4.2.2)(lightningcss@1.31.1)(sass@1.97.3)(terser@5.39.0)(yaml@2.9.0)
 
   packages/chrome-extension-sample:
     devDependencies:


### PR DESCRIPTION
Stabilizes cache configuration across the JavaScript SDKs while preserving compatibility aliases and runtime-specific defaults.

- adds stable `cache` and `enableCache` APIs with deterministic precedence
- supports custom Node and edge caches plus opt-in browser and mobile caching
- isolates browser caches by endpoint and application
- keeps rejected cache reads and writes from failing successful discovery
- adds Chrome session-storage caching and test coverage

Closes #1178
