### PR TITLE
fix(react-router): coordinate new sessions locally

### DIFF
--- a/.changeset/local-session-coordinator.md
+++ b/.changeset/local-session-coordinator.md
@@ -1,0 +1,5 @@
+---
+"@logto/react-router": patch
+---
+
+keep coordination request-local until a new persistent session reaches the browser

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -235,9 +235,16 @@ The default `ProcessLocalSessionCoordinator` serializes writes for the same stab
 single server process. This protects concurrent refresh-token rotation when `SessionStorage`
 returns reloadable server-side sessions.
 
-Cookie-only storage returns sessions without a stable ID, so it cannot coordinate refreshes across
-requests. It is suitable for simple deployments, but applications that need concurrent refresh
-coordination should use shared server-side session storage.
+Coordinator selection is based on the session loaded when a request begins. A session with a
+stable ID uses the configured coordinator. Without one, the request uses an internal request-local
+coordinator for its full lifetime. This includes cookie-only sessions and the first request of a
+new server-side session. Once the response cookie for a new server-side session reaches the
+browser, subsequent requests load its persistent ID and use the configured coordinator.
+
+Because cookie-only storage never returns a stable ID, it can serialize operations only within one
+request and cannot coordinate refreshes across concurrent requests. Passing a distributed
+coordinator does not change this. Applications that need cross-request coordination should use
+shared server-side session storage.
 
 For a multi-instance deployment, use both:
 

--- a/packages/react-router/src/infrastructure/session/session-runtime.coordination.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.coordination.spec.ts
@@ -1,0 +1,170 @@
+import type { Session, SessionStorage } from 'react-router';
+import { createSession } from 'react-router';
+
+import type { SessionCoordinator } from './session-coordinator.js';
+import { SessionRuntime } from './session-runtime.js';
+
+type TestSessionData = {
+  refreshToken?: string;
+  idToken?: string;
+  theme?: string;
+};
+
+const delay = async (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+const getSessionId = (cookieHeader: string | undefined) =>
+  /logto-session=([^;]+)/.exec(cookieHeader ?? '')?.[1] ?? '';
+
+const createSessionStorage = (existingSessionId?: string) => {
+  const createdSessionId = existingSessionId ?? 'created-session-id';
+  const sessions = new Map<string, TestSessionData>();
+
+  if (existingSessionId) {
+    sessions.set(existingSessionId, { refreshToken: 'old' });
+  }
+
+  const getSession = vi.fn(async (cookieHeader: string | undefined) => {
+    const sessionId = getSessionId(cookieHeader);
+    const data = sessions.get(sessionId) ?? {};
+
+    return createSession(structuredClone(data), sessionId);
+  });
+  const commitSession = vi.fn(async (session: Session<TestSessionData>) => {
+    const sessionId = session.id || createdSessionId;
+
+    sessions.set(sessionId, structuredClone(session.data));
+
+    return `logto-session=${sessionId}; Path=/; HttpOnly`;
+  });
+  const destroySession = vi.fn(async (session: Session<TestSessionData>) => {
+    sessions.delete(session.id);
+
+    return 'logto-session=; Max-Age=0';
+  });
+  const sessionStorage: SessionStorage<TestSessionData> = {
+    getSession: async (cookieHeader) => getSession(cookieHeader ?? undefined),
+    commitSession,
+    destroySession,
+  };
+
+  return {
+    createdSessionId,
+    sessionStorage,
+    getData: () => structuredClone(sessions.get(createdSessionId) ?? {}),
+    commitSession,
+  };
+};
+
+const createObservedCoordinator = () => {
+  const runExclusive = vi.fn();
+  const sessionCoordinator: SessionCoordinator = {
+    runExclusive: async (sessionKey, operation) => {
+      runExclusive(sessionKey);
+      return operation();
+    },
+  };
+
+  return { sessionCoordinator, runExclusive };
+};
+
+describe('infrastructure:session:SessionRuntime coordination', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses the configured coordinator with the persistent session ID', async () => {
+    const store = createSessionStorage('session-id');
+    const { sessionCoordinator, runExclusive } = createObservedCoordinator();
+    const runtime = await SessionRuntime.create({
+      cookieHeader: 'logto-session=session-id',
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+
+    runtime.session.set('theme', 'dark');
+    await runtime.finalize();
+
+    expect(runExclusive).toHaveBeenCalledOnce();
+    expect(runExclusive).toHaveBeenCalledWith('session-id');
+  });
+
+  it('uses request-local coordination when the loaded session has no ID', async () => {
+    const store = createSessionStorage();
+    const { sessionCoordinator, runExclusive } = createObservedCoordinator();
+    const runtime = await SessionRuntime.create({
+      cookieHeader: undefined,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+
+    runtime.session.set('theme', 'dark');
+    await runtime.finalize();
+
+    expect(runExclusive).not.toHaveBeenCalled();
+    expect(store.getData()).toEqual({ theme: 'dark' });
+  });
+
+  it('serializes concurrent checkpoints for a session without an ID', async () => {
+    vi.useFakeTimers();
+
+    const store = createSessionStorage();
+    const { sessionCoordinator, runExclusive } = createObservedCoordinator();
+    const runtime = await SessionRuntime.create({
+      cookieHeader: undefined,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+    const observeOperation = vi.fn();
+    const first = runtime.checkpoint(async () => {
+      observeOperation('first:start');
+      await delay(10);
+      observeOperation('first:end');
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const second = runtime.checkpoint(async () => {
+      observeOperation('second');
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(observeOperation.mock.calls).toEqual([['first:start']]);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.all([first, second]);
+
+    expect(observeOperation.mock.calls).toEqual([['first:start'], ['first:end'], ['second']]);
+    expect(runExclusive).not.toHaveBeenCalled();
+  });
+
+  it('keeps request-local coordination after the first commit creates an ID', async () => {
+    const store = createSessionStorage();
+    const { sessionCoordinator, runExclusive } = createObservedCoordinator();
+    const runtime = await SessionRuntime.create({
+      cookieHeader: undefined,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator,
+    });
+
+    await runtime.checkpoint(async (session) => {
+      session.set('refreshToken', 'rotated');
+    });
+    await runtime.checkpoint(async (session) => {
+      session.set('idToken', 'id-token');
+    });
+    runtime.session.set('theme', 'dark');
+    await runtime.finalize();
+
+    expect(runtime.session.id).toBe(store.createdSessionId);
+    expect(runExclusive).not.toHaveBeenCalled();
+    expect(store.getData()).toEqual({
+      refreshToken: 'rotated',
+      idToken: 'id-token',
+      theme: 'dark',
+    });
+    expect(store.commitSession).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.spec.ts
@@ -1,10 +1,7 @@
 import type { Session, SessionStorage } from 'react-router';
 import { createSession } from 'react-router';
 
-import {
-  createProcessLocalSessionCoordinator,
-  type SessionCoordinator,
-} from './session-coordinator.js';
+import { createProcessLocalSessionCoordinator } from './session-coordinator.js';
 import { SessionRuntime } from './session-runtime.js';
 import type { TrackedSession } from './tracked-session.js';
 
@@ -101,48 +98,6 @@ describe('infrastructure:session:SessionRuntime', () => {
       theme: 'dark',
     });
     expect(store.commitSession).toHaveBeenCalledTimes(2);
-  });
-
-  it('uses the stable session ID as the coordination key', async () => {
-    const store = createTestSessionStorage({ refreshToken: 'old' });
-    const observeSessionKey = vi.fn();
-    const sessionCoordinator: SessionCoordinator = {
-      runExclusive: async (sessionKey, operation) => {
-        observeSessionKey(sessionKey);
-        return operation();
-      },
-    };
-    const runtime = await createRuntime(store.sessionStorage, sessionCoordinator);
-
-    runtime.session.set('theme', 'dark');
-    await runtime.finalize();
-
-    expect(observeSessionKey).toHaveBeenCalledOnce();
-    expect(observeSessionKey).toHaveBeenCalledWith('session-id');
-  });
-
-  it('does not share coordination keys for cookie-only sessions', async () => {
-    const observeSessionKey = vi.fn();
-    const sessionCoordinator: SessionCoordinator = {
-      runExclusive: async (sessionKey, operation) => {
-        observeSessionKey(sessionKey);
-        return operation();
-      },
-    };
-    const sessionStorage: SessionStorage<TestSessionData> = {
-      getSession: async () => createSession<TestSessionData>({}),
-      commitSession: async () => 'logto-session=value; Path=/',
-      destroySession: async () => 'logto-session=; Max-Age=0',
-    };
-    const firstRuntime = await createRuntime(sessionStorage, sessionCoordinator);
-    const secondRuntime = await createRuntime(sessionStorage, sessionCoordinator);
-
-    firstRuntime.session.set('theme', 'dark');
-    secondRuntime.session.set('theme', 'dark');
-    await Promise.all([firstRuntime.finalize(), secondRuntime.finalize()]);
-
-    expect(observeSessionKey).toHaveBeenCalledTimes(2);
-    expect(observeSessionKey.mock.calls[0]?.[0]).not.toBe(observeSessionKey.mock.calls[1]?.[0]);
   });
 
   it('reloads the session inside the coordinator before refreshing', async () => {

--- a/packages/react-router/src/infrastructure/session/session-runtime.ts
+++ b/packages/react-router/src/infrastructure/session/session-runtime.ts
@@ -1,7 +1,10 @@
 import type { Session, SessionData, SessionStorage } from 'react-router';
 import { createSession } from 'react-router';
 
-import type { SessionCoordinator } from './session-coordinator.js';
+import {
+  createProcessLocalSessionCoordinator,
+  type SessionCoordinator,
+} from './session-coordinator.js';
 import { TrackedSession } from './tracked-session.js';
 
 /**
@@ -40,17 +43,20 @@ export type SessionRuntimeOptions<
    * multi-instance coordination also requires shared server-side storage.
    */
   sessionStorage: SessionStorage<Data, FlashData>;
-  /** Serializes persistence operations that share a session identifier. */
+  /** Serializes persistence operations for sessions loaded with a persistent identifier. */
   sessionCoordinator: SessionCoordinator;
 }>;
 
-const createSessionKey = (session: Session) => {
+const createSessionCoordination = (session: Session, sessionCoordinator: SessionCoordinator) => {
   if (session.id) {
-    return session.id;
+    return { sessionCoordinator, sessionKey: session.id };
   }
 
-  // Cookie-backed sessions cannot reload state committed by another response.
-  return globalThis.crypto.randomUUID();
+  // Until the response establishes a persistent session, only this request can observe its state.
+  return {
+    sessionCoordinator: createProcessLocalSessionCoordinator(),
+    sessionKey: globalThis.crypto.randomUUID(),
+  };
 };
 
 const getRequestCookieHeader = (setCookieHeader: string) => {
@@ -81,11 +87,12 @@ export class SessionRuntime<
     FlashData extends SessionData = Data,
   >(options: SessionRuntimeOptions<Data, FlashData>) {
     const session = await options.sessionStorage.getSession(options.cookieHeader);
+    const coordination = createSessionCoordination(session, options.sessionCoordinator);
 
     return new SessionRuntime({
       ...options,
+      ...coordination,
       session,
-      sessionKey: createSessionKey(session),
     });
   }
 


### PR DESCRIPTION
Sessions loaded without a persistent ID now use an internal request-local coordinator for the request lifetime, avoiding unnecessary distributed locks while preserving checkpoint serialization. Sessions loaded with stable IDs continue to use the configured coordinator, and the README documents the cookie-only concurrency boundary.