### PR TITLE
feat(platform): expose token clearing APIs

### DIFF
--- a/.changeset/tame-dodos-clear.md
+++ b/.changeset/tame-dodos-clear.md
@@ -3,4 +3,7 @@
 "@logto/react-router": minor
 ---
 
-expose access-token and local-token clearing operations in React Router and Next.js request APIs
+expose token clearing APIs in Next.js and React Router
+
+Add `clearAccessToken` and `clearAllTokens` to Next.js server APIs and the React Router request
+context. Persist the resulting session changes through each framework's cookie response mechanism.

--- a/.changeset/tame-dodos-clear.md
+++ b/.changeset/tame-dodos-clear.md
@@ -1,0 +1,6 @@
+---
+"@logto/next": minor
+"@logto/react-router": minor
+---
+
+expose access-token and local-token clearing operations in React Router and Next.js request APIs

--- a/packages/next/edge/index.test.ts
+++ b/packages/next/edge/index.test.ts
@@ -6,6 +6,8 @@ import LogtoClient from './index.js';
 
 const signOut = vi.fn();
 const destroy = vi.fn();
+const clearAccessToken = vi.fn();
+const clearAllTokens = vi.fn();
 
 vi.mock('@logto/node', () => ({
   CookieStorage: vi.fn(
@@ -18,19 +20,33 @@ vi.mock('@logto/node', () => ({
         destroy();
         config.setCookie(config.cookieKey, 'encrypted-empty-session', { maxAge: 14 * 24 * 3600 });
       },
+      removeItem: async () => {
+        config.setCookie(config.cookieKey, 'encrypted-updated-session', {
+          maxAge: 14 * 24 * 3600,
+        });
+      },
     })
   ),
 }));
 
 type Adapter = {
   navigate: (url: string) => void;
+  storage: { removeItem: (key: string) => Promise<void> };
 };
 
 vi.mock('@logto/node/edge', () => ({
-  default: vi.fn((_: unknown, { navigate }: Adapter) => ({
+  default: vi.fn((_: unknown, { navigate, storage }: Adapter) => ({
     signOut: async () => {
       await signOut();
       navigate('https://logto.example.com/oidc/session/end');
+    },
+    clearAccessToken: async () => {
+      clearAccessToken();
+      await storage.removeItem('accessToken');
+    },
+    clearAllTokens: async () => {
+      clearAllTokens();
+      await storage.removeItem('accessToken');
     },
   })),
 }));
@@ -78,5 +94,29 @@ describe('Next (edge): sign-out', () => {
     expect(destroy).toHaveBeenCalledOnce();
     expect(consoleError).toHaveBeenCalledWith('Logto sign-out failed.', signOutError);
     consoleError.mockRestore();
+  });
+});
+
+describe('Next (edge): token clearing', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears cached access tokens and returns the updated session headers', async () => {
+    const client = new LogtoClient(config);
+    const headers = await client.clearAccessToken(
+      new Request('https://app.example.com/api/tokens')
+    );
+
+    expect(clearAccessToken).toHaveBeenCalledOnce();
+    expect(headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-updated-session');
+  });
+
+  it('clears all local tokens and returns the updated session headers', async () => {
+    const client = new LogtoClient(config);
+    const headers = await client.clearAllTokens(new Request('https://app.example.com/api/tokens'));
+
+    expect(clearAllTokens).toHaveBeenCalledOnce();
+    expect(headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-updated-session');
   });
 });

--- a/packages/next/edge/index.test.ts
+++ b/packages/next/edge/index.test.ts
@@ -102,19 +102,19 @@ describe('Next (edge): token clearing', () => {
     vi.clearAllMocks();
   });
 
-  it('clears cached access tokens and returns the updated session headers', async () => {
+  it('clears cached access tokens and updates the response headers', async () => {
     const client = new LogtoClient(config);
-    const headers = await client.clearAccessToken(
-      new Request('https://app.example.com/api/tokens')
-    );
+    const headers = new Headers();
+    await client.clearAccessToken(new Request('https://app.example.com/api/tokens'), headers);
 
     expect(clearAccessToken).toHaveBeenCalledOnce();
     expect(headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-updated-session');
   });
 
-  it('clears all local tokens and returns the updated session headers', async () => {
+  it('clears all local tokens and updates the response headers', async () => {
     const client = new LogtoClient(config);
-    const headers = await client.clearAllTokens(new Request('https://app.example.com/api/tokens'));
+    const headers = new Headers();
+    await client.clearAllTokens(new Request('https://app.example.com/api/tokens'), headers);
 
     expect(clearAllTokens).toHaveBeenCalledOnce();
     expect(headers.get('Set-Cookie')).toContain('logto_app-id=encrypted-updated-session');

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -123,6 +123,26 @@ export default class LogtoClient extends BaseClient {
   };
 
   /**
+   * Clear cached access tokens and return headers containing the updated session cookie. Attach
+   * the returned headers to the response so the cookie is persisted.
+   */
+  clearAccessToken = async (request: Request): Promise<Headers> => {
+    const { nodeClient, headers } = await this.createNodeClientFromEdgeRequest(request);
+    await nodeClient.clearAccessToken();
+    return headers;
+  };
+
+  /**
+   * Clear every locally stored token and return headers containing the updated session cookie.
+   * Attach the returned headers to the response so the cookie is persisted.
+   */
+  clearAllTokens = async (request: Request): Promise<Headers> => {
+    const { nodeClient, headers } = await this.createNodeClientFromEdgeRequest(request);
+    await nodeClient.clearAllTokens();
+    return headers;
+  };
+
+  /**
    * Create a Node client for the current edge request.
    *
    * The public return shape is intentionally kept as `{ nodeClient, headers }` (unchanged from

--- a/packages/next/edge/index.ts
+++ b/packages/next/edge/index.ts
@@ -122,24 +122,16 @@ export default class LogtoClient extends BaseClient {
     return context;
   };
 
-  /**
-   * Clear cached access tokens and return headers containing the updated session cookie. Attach
-   * the returned headers to the response so the cookie is persisted.
-   */
-  clearAccessToken = async (request: Request): Promise<Headers> => {
-    const { nodeClient, headers } = await this.createNodeClientFromEdgeRequest(request);
+  /** Clear cached access tokens and persist the updated session cookie to the response headers. */
+  clearAccessToken = async (request: Request, responseHeaders: Headers): Promise<void> => {
+    const { nodeClient } = await this.createRequestScopedClient(request, responseHeaders);
     await nodeClient.clearAccessToken();
-    return headers;
   };
 
-  /**
-   * Clear every locally stored token and return headers containing the updated session cookie.
-   * Attach the returned headers to the response so the cookie is persisted.
-   */
-  clearAllTokens = async (request: Request): Promise<Headers> => {
-    const { nodeClient, headers } = await this.createNodeClientFromEdgeRequest(request);
+  /** Clear every locally stored token and persist the updated session cookie to the response headers. */
+  clearAllTokens = async (request: Request, responseHeaders: Headers): Promise<void> => {
+    const { nodeClient } = await this.createRequestScopedClient(request, responseHeaders);
     await nodeClient.clearAllTokens();
-    return headers;
   };
 
   /**
@@ -160,9 +152,8 @@ export default class LogtoClient extends BaseClient {
    * Storage and the navigation URL are kept local to this call rather than on the (typically
    * singleton) client instance, so concurrent requests can never clobber each other's state.
    */
-  private async createRequestScopedClient(request: Request) {
+  private async createRequestScopedClient(request: Request, headers = new Headers()) {
     const cookies = new RequestCookies(request.headers);
-    const headers = new Headers();
     const responseCookies = new ResponseCookies(headers);
 
     const storage = new CookieStorage({

--- a/packages/next/server-actions/index.test.ts
+++ b/packages/next/server-actions/index.test.ts
@@ -3,6 +3,8 @@ import type { AccessTokenClaims, IdTokenClaims } from '@logto/node';
 import type { LogtoNextConfig } from '../src/types.js';
 
 import {
+  clearAccessToken,
+  clearAllTokens,
   getAccessTokenClaims,
   getAccessTokenClaimsRSC,
   getIdTokenClaims,
@@ -27,10 +29,14 @@ const getAccessTokenClaimsFromClient = vi.fn(
 const getOrganizationTokenClaimsFromClient = vi.fn(
   async (_organizationId: string) => organizationTokenClaims
 );
+const clearAccessTokenFromClient = vi.fn();
+const clearAllTokensFromClient = vi.fn();
 const createNodeClient = vi.fn(async () => ({
   getIdTokenClaims: getIdTokenClaimsFromClient,
   getAccessTokenClaims: getAccessTokenClaimsFromClient,
   getOrganizationTokenClaims: getOrganizationTokenClaimsFromClient,
+  clearAccessToken: clearAccessTokenFromClient,
+  clearAllTokens: clearAllTokensFromClient,
 }));
 
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
@@ -90,5 +96,15 @@ describe('Next (server actions): token claims', () => {
       'org-id'
     );
     expect(getOrganizationTokenClaimsFromClient).toHaveBeenCalledWith('org-id');
+  });
+
+  it('clears tokens with cookie persistence enabled', async () => {
+    await clearAccessToken(config);
+    await clearAllTokens(config);
+
+    expect(createNodeClient).toHaveBeenNthCalledWith(1);
+    expect(createNodeClient).toHaveBeenNthCalledWith(2);
+    expect(clearAccessTokenFromClient).toHaveBeenCalledOnce();
+    expect(clearAllTokensFromClient).toHaveBeenCalledOnce();
   });
 });

--- a/packages/next/server-actions/index.ts
+++ b/packages/next/server-actions/index.ts
@@ -191,6 +191,26 @@ export const getOrganizationTokenClaims = async (
 };
 
 /**
+ * Clear cached access tokens from the session. Use this in a Server Action or Route Handler where
+ * cookies are writable.
+ */
+export const clearAccessToken = async (config: LogtoNextConfig): Promise<void> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient();
+  await nodeClient.clearAccessToken();
+};
+
+/**
+ * Clear every locally stored token from the session. Use this in a Server Action or Route Handler
+ * where cookies are writable.
+ */
+export const clearAllTokens = async (config: LogtoNextConfig): Promise<void> => {
+  const client = new LogtoClient(config);
+  const nodeClient = await client.createNodeClient();
+  await nodeClient.clearAllTokens();
+};
+
+/**
  * Get access token for the specified resource or organization,
  * this function can be used in React Server Components (RSC)
  * Note: You can't write to the cookie in a React Server Component, so if the access token is refreshed, it won't be persisted in the session.

--- a/packages/next/src/index.token-clearing.test.ts
+++ b/packages/next/src/index.token-clearing.test.ts
@@ -1,0 +1,50 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+
+import LogtoClient from './index.js';
+import type { LogtoNextConfig } from './types.js';
+
+const clearAccessToken = vi.fn();
+const clearAllTokens = vi.fn();
+
+vi.mock('@logto/node', async (importOriginal) => ({
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  ...(await importOriginal<typeof import('@logto/node')>()),
+  __esModule: true,
+  default: vi.fn(() => ({ clearAccessToken, clearAllTokens })),
+}));
+
+const config: LogtoNextConfig = {
+  appId: 'app-id',
+  endpoint: 'https://logto.example.com',
+  baseUrl: 'https://app.example.com',
+  cookieSecret: 'complex_password_at_least_32_characters_long',
+  cookieSecure: false,
+};
+
+describe('Next: token clearing', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['clearAccessToken', clearAccessToken],
+    ['clearAllTokens', clearAllTokens],
+  ] as const)(
+    'calls NodeClient.%s through request-scoped storage',
+    async (method, clientMethod) => {
+      const client = new LogtoClient(config);
+
+      await testApiHandler({
+        pagesHandler: async (request, response) => {
+          await client[method](request, response);
+          response.end();
+        },
+        test: async ({ fetch }) => {
+          await fetch({ method: 'POST' });
+        },
+      });
+
+      expect(clientMethod).toHaveBeenCalledOnce();
+    }
+  );
+});

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -218,6 +218,16 @@ export default class LogtoClient extends LogtoNextBaseClient {
     return nodeClient.getOrganizationTokenClaims(organizationId);
   };
 
+  clearAccessToken = async (request: NextApiRequest, response: NextApiResponse): Promise<void> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    await nodeClient.clearAccessToken();
+  };
+
+  clearAllTokens = async (request: NextApiRequest, response: NextApiResponse): Promise<void> => {
+    const nodeClient = await this.createNodeClientFromNextApi(request, response);
+    await nodeClient.clearAllTokens();
+  };
+
   withLogtoApiRoute = (
     handler: NextApiHandler,
     config: GetContextParameters = {},

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -222,12 +222,19 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 };
 ```
 
-Use `getOrganizationToken(organizationId)` when you need an organization token. The request
-context also exposes `getIdTokenClaims()`, `getAccessTokenClaims(resource, organizationId)`, and
-`getOrganizationTokenClaims(organizationId)`. Pass both arguments when the token is scoped to an
-API resource within an organization. Access-token and organization-token claim lookups use the
-same coordinated session checkpoints as their token counterparts because they may refresh and
-rotate session credentials.
+The request context also provides:
+
+- `getOrganizationToken(organizationId)` for an organization token;
+- `getIdTokenClaims()` for ID token claims;
+- `getAccessTokenClaims(resource, organizationId)` for access token claims;
+- `getOrganizationTokenClaims(organizationId)` for organization token claims;
+- `clearAccessToken()` to remove cached access tokens; and
+- `clearAllTokens()` to remove every locally stored token.
+
+Pass both resource and organization arguments when the token is scoped to an API resource within
+an organization. Access-token and organization-token acquisition and claim lookups use coordinated
+session checkpoints because they may refresh and rotate session credentials. The clearing methods
+also persist their session changes before they return.
 
 ## Session coordination
 

--- a/packages/react-router/src/middleware/request-context.spec.ts
+++ b/packages/react-router/src/middleware/request-context.spec.ts
@@ -50,10 +50,15 @@ const idTokenClaims: IdTokenClaims = {
 };
 const accessTokenClaims: AccessTokenClaims = { sub: 'access-token-user-id' };
 const organizationTokenClaims: AccessTokenClaims = { sub: 'organization-token-user-id' };
+const noTokenClearing = async () => {
+  // Most tests in this suite do not exercise token clearing.
+};
 const defaultClaimsClientMethods = {
   getIdTokenClaims: async () => idTokenClaims,
   getAccessTokenClaims: async (_resource?: string, _organizationId?: string) => accessTokenClaims,
   getOrganizationTokenClaims: async (_organizationId: string) => organizationTokenClaims,
+  clearAccessToken: noTokenClearing,
+  clearAllTokens: noTokenClearing,
 };
 const authenticatedContext: LogtoContext = {
   isAuthenticated: true,

--- a/packages/react-router/src/middleware/request-context.token-clearing.spec.ts
+++ b/packages/react-router/src/middleware/request-context.token-clearing.spec.ts
@@ -1,0 +1,81 @@
+import type { AccessTokenClaims, IdTokenClaims, LogtoContext } from '@logto/node';
+import type { Session, SessionData, SessionStorage } from 'react-router';
+import { createSession } from 'react-router';
+
+import {
+  createProcessLocalSessionCoordinator,
+  SessionRuntime,
+} from '../infrastructure/session/index.js';
+
+import type { CreateLogtoRequestClient } from './request-context.js';
+import { createLogtoRequestContext } from './request-context.js';
+
+const sessionCookie = 'logto-session=session-id';
+
+const createTestSessionStorage = (initialData: SessionData) => {
+  const sessions = new Map<string, SessionData>([['session-id', structuredClone(initialData)]]);
+  const commitSession = vi.fn(async (session: Session) => {
+    sessions.set('session-id', structuredClone(session.data));
+    return `${sessionCookie}; Path=/; HttpOnly`;
+  });
+  const sessionStorage: SessionStorage = {
+    getSession: async () =>
+      createSession(structuredClone(sessions.get('session-id') ?? {}), 'session-id'),
+    commitSession,
+    destroySession: async () => `${sessionCookie}; Max-Age=0`,
+  };
+
+  return {
+    sessionStorage,
+    commitSession,
+    getData: () => structuredClone(sessions.get('session-id') ?? {}),
+  };
+};
+
+const idTokenClaims: IdTokenClaims = {
+  aud: 'app-id',
+  exp: 1_700_000_000,
+  iat: 1_600_000_000,
+  iss: 'https://logto.example.com/oidc',
+  sub: 'user-id',
+};
+
+const createClient: CreateLogtoRequestClient = (session) => ({
+  getContext: async () => ({ isAuthenticated: false }) satisfies LogtoContext,
+  getIdTokenClaims: async () => idTokenClaims,
+  getAccessToken: async () => 'access-token',
+  getAccessTokenClaims: async () => ({}) satisfies AccessTokenClaims,
+  getOrganizationToken: async () => 'organization-token',
+  getOrganizationTokenClaims: async () => ({}) satisfies AccessTokenClaims,
+  clearAccessToken: async () => {
+    session.unset('accessToken');
+  },
+  clearAllTokens: async () => {
+    session.unset('accessToken');
+    session.unset('idToken');
+    session.unset('refreshToken');
+  },
+});
+
+describe('middleware:createLogtoRequestContext token clearing', () => {
+  it('persists access-token and all-token clearing through session checkpoints', async () => {
+    const store = createTestSessionStorage({
+      accessToken: 'cached-access-token',
+      idToken: 'id-token',
+      refreshToken: 'refresh-token',
+    });
+    const runtime = await SessionRuntime.create({
+      cookieHeader: sessionCookie,
+      sessionStorage: store.sessionStorage,
+      sessionCoordinator: createProcessLocalSessionCoordinator(),
+    });
+    const context = createLogtoRequestContext(runtime, createClient);
+
+    await context.clearAccessToken();
+    expect(store.getData()).toEqual({ idToken: 'id-token', refreshToken: 'refresh-token' });
+
+    await context.clearAllTokens();
+    expect(store.getData()).toEqual({});
+    expect(store.commitSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-router/src/middleware/request-context.ts
+++ b/packages/react-router/src/middleware/request-context.ts
@@ -27,6 +27,8 @@ export type LogtoRequestContext = Readonly<{
   getAccessTokenClaims: (resource?: string, organizationId?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
   getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
+  clearAccessToken: () => Promise<void>;
+  clearAllTokens: () => Promise<void>;
 }>;
 
 type LogtoRequestClient = {
@@ -36,6 +38,8 @@ type LogtoRequestClient = {
   getAccessTokenClaims: (resource?: string, organizationId?: string) => Promise<AccessTokenClaims>;
   getOrganizationToken: (organizationId: string) => Promise<string>;
   getOrganizationTokenClaims: (organizationId: string) => Promise<AccessTokenClaims>;
+  clearAccessToken: () => Promise<void>;
+  clearAllTokens: () => Promise<void>;
 };
 
 export type CreateLogtoRequestClient = (session: Session) => LogtoRequestClient;
@@ -76,6 +80,12 @@ export const createLogtoRequestContext = (
       createClient(session).getOrganizationTokenClaims(organizationId)
     );
 
+  const clearAccessToken = async () =>
+    runtime.checkpoint(async (session) => createClient(session).clearAccessToken());
+
+  const clearAllTokens = async () =>
+    runtime.checkpoint(async (session) => createClient(session).clearAllTokens());
+
   return Object.freeze({
     session: runtime.session,
     getContext,
@@ -84,5 +94,7 @@ export const createLogtoRequestContext = (
     getAccessTokenClaims,
     getOrganizationToken,
     getOrganizationTokenClaims,
+    clearAccessToken,
+    clearAllTokens,
   });
 };


### PR DESCRIPTION
Expose explicit token-clearing operations through the platform SDK surfaces that wrap `@logto/node`, so applications do not need to reach into the underlying client.

- coordinated `clearAccessToken()` and `clearAllTokens()` on the React Router request context
- Pages Router and Server Actions helpers with writable cookie persistence
- Edge helpers that return updated response headers for cookie persistence
